### PR TITLE
Specify key/values with mw.Map

### DIFF
--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -22,12 +22,9 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
              */
             get(): V;
-            get<S extends Array<keyof V>, F>(
-                selection: S,
-                fallback?: F
-            ): Pick<V, S extends Array<infer SS> ? SS : never | F>;
             get<S extends Array<keyof V>>(
-                selection: S
+                selection: S,
+                fallback?: any
             ): Pick<V, S extends Array<infer SS> ? SS : never>;
             get<S extends keyof V>(selection: S): V[S];
             get<S extends keyof V, F>(selection: S, fallback?: F): V[S] | F;

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -26,6 +26,10 @@ declare global {
                 selection: S,
                 fallback?: F
             ): Pick<V, S extends Array<infer SS> ? SS : never | F>;
+            get<S extends Array<keyof V>>(
+                selection: S
+            ): Pick<V, S extends Array<infer SS> ? SS : never>;
+            get<S extends keyof V>(selection: S): V[S];
             get<S extends keyof V, F>(selection: S, fallback?: F): V[S] | F;
 
             /**

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -26,8 +26,7 @@ declare global {
                 selection: S,
                 fallback?: any
             ): Pick<V, S extends Array<infer SS> ? SS : never>;
-            get<S extends keyof V>(selection: S): V[S];
-            get<S extends keyof V, F>(selection: S, fallback?: F): V[S] | F;
+            get<S extends keyof V>(selection: S, fallback?: V[S]): V[S];
 
             /**
              * Set the value of one or more keys.

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -1,0 +1,53 @@
+declare global {
+    namespace mw {
+        /**
+         * Create an object that can be read from or written to via methods that allow interaction both
+         * with single and multiple properties at once.
+         *
+         * **NOTE**: This is a private utility class for internal use by the framework.
+         * Don't rely on its existence.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map
+         */
+        class Map<V extends Record<string, any> = any> {
+            private values: V;
+
+            /**
+             * Get the value of one or more keys.
+             *
+             * If called with no arguments, all values are returned.
+             * @param selection Key or array of keys to retrieve values for.
+             * @param fallback Value for keys that don't exist.
+             * @returns If selection was a string, returns the value. If selection was an array, returns
+             * an object of key/values. If no selection is passed, a new object with all key/values is returned.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
+             */
+            get(): V;
+            get<S extends Array<keyof V>, F>(
+                selection: S,
+                fallback?: F
+            ): Pick<V, S extends Array<infer SS> ? SS : never | F>;
+            get<S extends keyof V, F>(selection: S, fallback?: F): V[S] | F;
+
+            /**
+             * Set the value of one or more keys.
+             *
+             * @param selection Key to set value for, or object mapping keys to values
+             * @param value Value to set (optional, only in use when key is a string)
+             * @returns True on success, false on failure
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-set
+             */
+            set<S extends keyof V>(selection: S, value: V[S]): boolean;
+            set(selection: Partial<V>): boolean;
+
+            /**
+             * Check if a given key exists in the map.
+             * @param selection Key to check
+             * @returns True if the key exists
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
+             */
+            exists(selection: keyof V): boolean;
+        }
+    }
+}
+
+export {};

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -82,6 +82,7 @@ declare global {
             wgDiffOldId: number;
             wgDiffNewId: number;
             wgWikibaseItemId: string;
+            [key: string]: any; // more config keys can be added by plugins
         }>;
 
         namespace html {

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -29,7 +29,60 @@ declare global {
          * global `window` object.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-config
          */
-        const config: mw.Map;
+        const config: mw.Map<{
+            debug: boolean;
+            skin: string;
+            stylepath: string;
+            wgArticlePath: string;
+            wgCaseSensitiveNamespaces: string[];
+            wgContentLanguage: string;
+            wgContentNamespaces: number[];
+            wgDBname: string;
+            wgEnableAPI: boolean;
+            wgEnableWriteAPI: boolean;
+            wgExtensionAssetsPath: string;
+            wgFormattedNamespaces: Record<string, string>;
+            wgNamespaceIds: Record<string, string>;
+            wgScript: string;
+            wgScriptPath: string;
+            wgServer: string;
+            wgSiteName: string;
+            wgVariantArticlePath: string | false;
+            wgVersion: string;
+            wgAction: string;
+            wgArticleId: number;
+            wgCanonicalNamespace: string;
+            wgCanonicalSpecialPageName: string | false;
+            wgCategories: string[];
+            wgCurRevisionId: number;
+            wgIsArticle: boolean;
+            wgIsProbablyEditable: boolean;
+            wgNamespaceNumber: number;
+            wgPageContentLanguage: string;
+            wgPageContentModel: string;
+            wgPageName: string;
+            wgRedirectedFrom: string;
+            wgRelevantPageName: string;
+            wgRelevantUserName: string;
+            wgRelevantPageIsProbablyEditable: boolean;
+            wgRestrictionEdit: string[];
+            wgRestrictionMove: string[];
+            wgRevisionId: number;
+            wgSearchType: string;
+            wgTitle: string;
+            wgUserEditCount: number;
+            wgUserGroups: string[];
+            wgUserId: number;
+            wgUserLanguage: string;
+            wgUserName: string;
+            wgUserRegistration: number;
+            wgIsMainPage: boolean;
+            wgUserVariant: string;
+            wgPostEdit: string;
+            wgDiffOldId: number;
+            wgDiffNewId: number;
+            wgWikibaseItemId: string;
+        }>;
 
         namespace html {
             function escape(s: string): string;

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -82,7 +82,7 @@ declare global {
             wgDiffOldId: number;
             wgDiffNewId: number;
             wgWikibaseItemId: string;
-            [key: string]: any; // more config keys can be added by plugins
+            [key: string]: unknown; // more config keys can be added by extensions
         }>;
 
         namespace html {

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -3,6 +3,7 @@ import "./language";
 import "./util";
 import "./user";
 import "./loader";
+import "./Map";
 import "./Title";
 import "./Uri";
 import "./hook";
@@ -48,47 +49,6 @@ declare global {
             function error(...msg: any[]): void;
 
             function warn(...msg: string[]): void;
-        }
-
-        /**
-         * Create an object that can be read from or written to via methods that allow interaction both
-         * with single and multiple properties at once.
-         *
-         * **NOTE**: This is a private utility class for internal use by the framework.
-         * Don't rely on its existence.
-         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map
-         */
-        class Map {
-            /**
-             * Get the value of one or more keys.
-             *
-             * If called with no arguments, all values are returned.
-             * @param selection Key or array of keys to retrieve values for.
-             * @param fallback Value for keys that don't exist.
-             * @returns If selection was a string, returns the value, If selection was an array, returns
-             * an object of key/values. If no selection is passed, a new object with all key/values is returned.
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
-             */
-            get(selection: string | string[], fallback?: any): any;
-
-            /**
-             * Get the value of one or more keys.
-             *
-             * If called with no arguments, all values are returned.
-             * @param selection Key to set value for, or object mapping keys to values
-             * @param value Value to set (optional, only in use when key is a string)
-             * @returns True on success, false on failure
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-set
-             */
-            set(selection: string | Record<string, any>, value?: any): boolean;
-
-            /**
-             * Check if a given key exists in the map.
-             * @param selection Key to check
-             * @returns True if the key exists
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
-             */
-            exists(selection: string): boolean;
         }
 
         // types for mw.widgets are out of scope!

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -21,7 +21,7 @@ declare global {
              * @param key
              * @param parameters
              */
-            constructor(map: mw.Map, key: string, parameters?: string[]);
+            constructor(map: mw.Map<Record<string, string>>, key: string, parameters?: string[]);
 
             /**
              * Change the format to 'escaped' and convert message to string

--- a/scripts/config-types-scraper.js
+++ b/scripts/config-types-scraper.js
@@ -1,0 +1,33 @@
+// Go to <https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#mw.config>
+// paste this into the browser console, and copy the log output
+
+function processType(type) {
+    type = type.toLowerCase();
+    type = type.replace(/or (unset|not defined)/, "");
+    type = type.replace("integer", "number");
+    type = type.replace(/ or /g, " | ");
+    if (type.startsWith("array of")) {
+        const element = type.replace(/array of (.*)s(\s|$)/, "$1");
+        type = `${element}[]`;
+    }
+    if (type === "array") type = "string[]";
+    if (type === "object") type = "Record<string, string>";
+
+    return type.trim();
+}
+
+const types = {};
+const tables = document.querySelectorAll(".wikitable");
+for (const table of tables) {
+    const rows = table.querySelectorAll("tr:not([colspan])");
+    for (const row of rows) {
+        const cells = row.querySelectorAll("td");
+        if (!cells.length) continue;
+        const name = cells[0].innerText.trim();
+        const type = processType(cells[1].innerText);
+        types[name] = type;
+    }
+}
+
+const entries = Object.entries(types).map(([k, v]) => `${" ".repeat(12)}${k}: ${v};`);
+console.log(`{\n${entries.join("\n")}${" ".repeat(8)}\n}`);


### PR DESCRIPTION
this PR adds [generics](https://www.typescriptlang.org/docs/handbook/generics.html) to `Map`, its methods, and one of its dependencies (`mw.config`). also, i moved it into a separate file because, imo, it doesn't really belong in the main `mw` namespace (and neither do `html` or `log`, which i will move in a separate PR).

i added this because the current model isn't really type-safe, which means you can do something like `mw.config.get("aaa")` without getting compilation errors (and `get()` will always return `any`, which is yucky). also, it defaults to `any` so existing code won't break

i got the types for the config from [here](https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#mw.config), and also included the script i used to scrape them, but i couldn't really find a list for `user.options` and `user.tokens`, so that can wait for now!