### PR TITLE
Move ForeignApi out of Api and document these

### DIFF
--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -550,6 +550,7 @@ declare global {
              * @param {number?} chunkSize Size (in bytes) per chunk (default: 5MB)
              * @param {number?} chunkRetries Amount of times to retry a failed chunk (default: 1)
              * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-chunkedUploadToStash
              */
             chunkedUploadToStash(
                 file: File,
@@ -558,6 +559,16 @@ declare global {
                 chunkRetries?: number
             ): JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>;
 
+            /**
+             * Upload a file to MediaWiki.
+             *
+             * The file will be uploaded using AJAX and FormData.
+             *
+             * @param {HTMLInputElement | File | Blob} file HTML `input type=file` element with a file already inside of it, or a File object.
+             * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
+             * @return {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-upload
+             */
             upload(
                 file: File | Blob | HTMLInputElement,
                 data: ApiUploadParams

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -17,7 +17,7 @@ type ApiResponse = Record<string, any>; // it will always be a JSON object, the 
  *
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-property-defaultOptions
  */
-interface ApiOptions {
+export interface ApiOptions {
     /**
      * Default query parameters for API requests
      */
@@ -31,10 +31,6 @@ interface ApiOptions {
      * Default is true if ajax.url is not set, false otherwise for compatibility.
      */
     useUS?: boolean;
-}
-
-interface ForeignApiOptions extends ApiOptions {
-    anonymous?: boolean;
 }
 
 declare global {
@@ -63,7 +59,7 @@ declare global {
              * } ).done( function ( data ) {
              *     console.log( data );
              * } );
-             *```
+             * ```
              * Since MW 1.26, boolean values for a parameter can be specified directly. If the value is false or undefined, the parameter will be omitted from the request, as required by the API.
              *
              * @param {ApiOptions} options
@@ -610,12 +606,6 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.login-method-login
              */
             login(username: string, password: string): JQuery.Promise<ApiResponse>;
-        }
-
-        class ForeignApi extends mw.Api {
-            constructor(url: string | mw.Uri, options?: ForeignApiOptions);
-
-            getOrigin(): string | void;
         }
     }
 }

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -521,7 +521,7 @@ declare global {
                 page: TitleLike,
                 user: string,
                 params?: ApiRollbackParams
-            ): JQuery.Promise<any>;
+            ): JQuery.Promise<ApiResponse>;
 
             /**
              * Upload a file in several chunks.

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -608,7 +608,7 @@ declare global {
             uploadToStash(
                 file: File | HTMLInputElement,
                 data?: ApiUploadParams
-            ): JQuery.Promise<ApiResponse>;
+            ): JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>;
 
             /**
              * @param {string} username

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -6,7 +6,8 @@ import {
     ApiUploadParams,
 } from "../api_params";
 
-type title = string | mw.Title;
+type TitleLike = string | mw.Title;
+type TitleLikeArray = string[] | mw.Title[]; // TitleLike[] would be a mixed array
 type ApiParams = Record<string, string | string[] | boolean | number | number[]>;
 type ApiResponse = Record<string, any>; // it will always be a JSON object, the rest is uncertain ...
 
@@ -39,21 +40,51 @@ interface ForeignApiOptions extends ApiOptions {
 declare global {
     namespace mw {
         /**
-         * Constructor to create an object to interact with the API of a particular
-         * MediaWiki server. mw.Api objects represent the API of a particular MediaWiki server.
-         *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api
          */
         class Api {
             /**
+             * Constructor to create an object to interact with the API of a particular MediaWiki server. mw.Api objects represent the API of a particular MediaWiki server.
+             * ```js
+             * var api = new mw.Api();
+             * api.get( {
+             *     action: 'query',
+             *     meta: 'userinfo'
+             * } ).done( function ( data ) {
+             *     console.log( data );
+             * } );
+             * ```
+             * Since MW 1.25, multiple values for a parameter can be specified using an array:
+             * ```js
+             * var api = new mw.Api();
+             * api.get( {
+             *     action: 'query',
+             *     meta: [ 'userinfo', 'siteinfo' ] // same effect as 'userinfo|siteinfo'
+             * } ).done( function ( data ) {
+             *     console.log( data );
+             * } );
+             *```
+             * Since MW 1.26, boolean values for a parameter can be specified directly. If the value is false or undefined, the parameter will be omitted from the request, as required by the API.
+             *
+             * @param {ApiOptions} options
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-constructor
              */
             constructor(options?: ApiOptions);
 
+            /**
+             * Abort all unfinished requests issued by this Api object.
+             *
+             * @returns {void}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-abort
+             */
             abort(): void;
 
             /**
-             * Perform API get request
+             * Perform API get request.
+             *
+             * @param {ApiParams} parameters
+             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-get
              */
             get(
@@ -61,39 +92,136 @@ declare global {
                 ajaxOptions?: JQuery.AjaxSettings
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Perform API post request.
+             *
+             * @param {ApiParams} parameters
+             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-post
+             */
             post(
                 parameters: ApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
             ): JQuery.Promise<ApiResponse>;
 
-            preprocessParameters(parameters: ApiParams, useUS: boolean): void;
+            /**
+             * Massage parameters from the nice format we accept into a format suitable for the API.
+             *
+             * @private
+             * @param {ApiParams} parameters (modified in-place)
+             * @param {boolean} useUS Whether to use U+001F when joining multi-valued parameters.
+             * @returns {void}
+             */
+            private preprocessParameters(parameters: ApiParams, useUS: boolean): void;
 
-            // index.js
+            /**
+             * Perform the API call.
+             *
+             * @param {ApiParams} parameters
+             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @returns {JQuery.Promise<ApiResponse>} API response data and the jqXHR object
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-ajax
+             */
             ajax(
                 parameters: ApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Post to API with specified type of token. If we have no token, get one and try to post.
+             * If we have a cached token try using that, and if it fails, blank out the
+             * cached token and start over. For example to change an user option you could do:
+             * ```js
+             * new mw.Api().postWithToken( 'csrf', {
+             *     action: 'options',
+             *     optionname: 'gender',
+             *     optionvalue: 'female'
+             * } );
+             * ```
+             *
+             * @param {string} tokenType The name of the token, like `options` or `edit`
+             * @param {ApiParams} params API parameters
+             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @since 1.22
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-postWithToken
+             */
             postWithToken(
                 tokenType: string,
                 params: ApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
             ): JQuery.Promise<ApiResponse>;
 
-            getToken(type: string, additionalParams?: ApiParams): JQuery.Promise<string>;
+            /**
+             * Get a token for a certain action from the API.
+             *
+             * @param {string} type Token type
+             * @param {(ApiParams | string)?} additionalParams Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
+             * @returns {JQuery.Promise<string>} Received token
+             * @since 1.22
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getToken
+             */
+            getToken(type: string, additionalParams?: ApiParams | string): JQuery.Promise<string>;
 
+            /**
+             * Indicate that the cached token for a certain action of the API is bad.
+             *
+             * Call this if you get a `badtoken` error when using the token returned by `getToken()`.
+             * You may also want to use `postWithToken()` instead, which invalidates bad cached tokens
+             * automatically.
+             *
+             * @param {string} type Token type
+             * @returns {void}
+             * @since 1.26
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-badToken
+             */
             badToken(type: string): void;
 
+            /**
+             * Given an API response indicating an error, get a jQuery object containing a human-readable
+             * error message that you can display somewhere on the page.
+             *
+             * For better quality of error messages, it's recommended to use the following options in your
+             * API queries:
+             *
+             * ```js
+             * errorformat: 'html',
+             * errorlang: mw.config.get( 'wgUserLanguage' ),
+             * errorsuselocal: true,
+             * ```
+             *
+             * Error messages, particularly for editing pages, may consist of multiple paragraphs of text.
+             * Your user interface should have enough space for that.
+             *
+             * Example usage:
+             *
+             * ```js
+             * var api = new mw.Api();
+             * // var title = 'Test valid title';
+             * var title = 'Test invalid title <>';
+             * api.postWithToken( 'watch', {
+             *     action: 'watch',
+             *     title: title
+             * } ).then( function ( data ) {
+             *     mw.notify( 'Success!' );
+             * }, function ( code, data ) {
+             *     mw.notify( api.getErrorMessage( data ), { type: 'error' } );
+             * } );
+             * ```
+             *
+             * @param {Object} data API response indicating an error
+             * @returns {JQuery} Error messages, each wrapped in a `<div>`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getErrorMessage
+             */
             getErrorMessage(data: ApiResponse): JQuery;
 
-            // edit.js
             /**
-             * Post to API with csrf token. If we have no token, get one and try to post. If
-             * we have a cached token try using that, and if it fails, blank out the cached
-             * token and start over.
+             * Post to API with csrf token. If we have no token, get one and try to post. If we have a cached token try using that, and if it fails, blank out the cached token and start over.
              *
-             * @param params API parameters
-             * @param ajaxOptions
+             * @param {APIParams} params API parameters
+             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-postWithEditToken
              */
             postWithEditToken(
@@ -101,35 +229,142 @@ declare global {
                 ajaxOptions?: JQuery.AjaxSettings
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * API helper to grab a csrf token.
+             *
+             * @returns {JQuery.Promise<string>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-getEditToken
+             */
             getEditToken(): JQuery.Promise<string>;
 
+            /**
+             * Create a new page.
+             *
+             * Example:
+             * ```js
+             * new mw.Api().create( 'Sandbox',
+             *     { summary: 'Load sand particles.' },
+             *     'Sand.'
+             * );
+             * ```
+             *
+             * @param {TitleLike} title Page title
+             * @param {ApiEditPageParams} params Edit API parameters
+             * @param {string} content Page content
+             * @returns {}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-create
+             */
             create(
-                title: title,
+                title: TitleLike,
                 params: ApiEditPageParams,
                 content: string
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Edit an existing page.
+             *
+             * To create a new page, use create() instead.
+             *
+             * Simple transformation:
+             * ```js
+             * new mw.Api()
+             *     .edit( 'Sandbox', function ( revision ) {
+             *         return revision.content.replace( 'foo', 'bar' );
+             *     } )
+             *     .then( function () {
+             *         console.log( 'Saved!' );
+             *     } );
+             * ```
+             * Set save parameters by returning an object instead of a string:
+             * ```js
+             * new mw.Api().edit(
+             *     'Sandbox',
+             *     function ( revision ) {
+             *         return {
+             *             text: revision.content.replace( 'foo', 'bar' ),
+             *             summary: 'Replace "foo" with "bar".',
+             *             assert: 'bot',
+             *             minor: true
+             *         };
+             *     }
+             * )
+             * .then( function () {
+             *     console.log( 'Saved!' );
+             * } );
+             * ```
+             * Transform asynchronously by returning a promise.
+             * ```js
+             * new mw.Api()
+             *     .edit( 'Sandbox', function ( revision ) {
+             *         return Spelling
+             *             .corrections( revision.content )
+             *             .then( function ( report ) {
+             *                 return {
+             *                     text: report.output,
+             *                     summary: report.changelog
+             *                 };
+             *             } );
+             *     } )
+             *     .then( function () {
+             *         console.log( 'Saved!' );
+             *     } );
+             * ```
+             *
+             * @param {TitleLike} title Page title
+             * @param {(data: { timestamp: string, content: string }) => string | ApiEditPageParams} transform Callback that prepares the edit
+             * @returns {JQuery.Promise<any>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-edit
+             */
             edit(
-                title: title,
+                title: TitleLike,
                 transform: (data: {
                     timestamp: string;
                     content: string;
                 }) => string | ApiEditPageParams
             ): JQuery.Promise<any>;
 
+            /**
+             * Post a new section to the page.
+             *
+             * @param {TitleLike} title Target page
+             * @param {string} header
+             * @param {string} message Wikitext message
+             * @param {ApiEditPageParams} additionalParams Additional API parameters
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-newSection
+             */
             newSection(
-                title: title,
+                title: TitleLike,
                 header: string,
                 message: string,
                 additionalParams?: ApiEditPageParams
             ): JQuery.Promise<ApiResponse>;
 
-            // user.js
+            /**
+             * Get the current user's groups and rights.
+             *
+             * @returns {JQuery.Promise<{ groups: string[], rights: string[] }>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.user-method-getUserInfo
+             */
             getUserInfo(): JQuery.Promise<{
                 groups: string[];
                 rights: string[];
             }>;
 
+            /**
+             * Extend an API parameter object with an assertion that the user won't change.
+             *
+             * This is useful for API calls which create new revisions or log entries. When the current page was loaded when the user was logged in, but at the time of the API call the user is not logged in anymore (e.g. due to session expiry), their IP is recorded in the page history or log, which can cause serious privacy issues. Extending the API parameters via this method ensures that that won't happen, by checking the user's identity that was embedded into the page when it was rendered against the active session on the server.
+             *
+             * Use it like this: `api.postWithToken( 'csrf', api.assertCurrentUser( { action: 'edit', ... } ) )`. When the assertion fails, the API request will fail, with one of the following error codes:
+             * * `apierror-assertanonfailed`: when the client-side logic thinks the user is anonymous but the server thinks it is logged in
+             * * `apierror-assertuserfailed`: when the client-side logic thinks the user is logged in but the server thinks it is anonymous
+             * * `apierror-assertnameduserfailed`: when both the client-side logic and the server thinks the user is logged in but they see it logged in under a different username.
+             *
+             * @param {ApiParams} query Query parameters. The object will not be changed
+             * @returns {JQuery.Promise<{ assert: "anon" | "user", assertUser: string }>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.user-method-assertCurrentUser
+             */
             assertCurrentUser(
                 query: ApiParams
             ): JQuery.Promise<{
@@ -137,70 +372,171 @@ declare global {
                 assertUser: string;
             }>;
 
-            // options.js
+            /**
+             * Asynchronously save the value of a single user option using the API. See `saveOptions()`.
+             *
+             * @param {string} name
+             * @param {string?} value
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOption
+             */
             saveOption(name: string, value: string): JQuery.Promise<ApiResponse>;
 
-            saveOptions(options: { [optionName: string]: string }): JQuery.Promise<ApiResponse>;
+            /**
+             * Asynchronously save the values of user options using the API.
+             *
+             * If a value of `null` is provided, the given option will be reset to the default value.
+             *
+             * Any warnings returned by the API, including warnings about invalid option names or values, are ignored. However, do not rely on this behavior.
+             *
+             * If necessary, the options will be saved using several sequential API requests. Only one promise is always returned that will be resolved when all requests complete.
+             *
+             * If a request from a previous `saveOptions()` call is still pending, this will wait for it to be completed, otherwise MediaWiki gets sad. No requests are sent for anonymous users, as they would fail anyway. See T214963.
+             *
+             * @param {Object} options
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOptions
+             */
+            saveOptions(options: Record<string, string>): JQuery.Promise<ApiResponse>;
 
-            // watch.js
-            watch(
-                pages: title | title[]
+            /**
+             * Convenience method for `action=watch`.
+             *
+             * @param {TitleLike | TitleLikeArray} pages
+             * @param {string?} expiry
+             * @returns {JQuery.Promise<{ watch: { title: string, watched: boolean } | Array<{ title: string, watched: boolean }> }>}
+             * @since 1.35: expiry parameter can be passed when watchlist expiry is enabled
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-watch
+             */
+            watch<P extends TitleLike | TitleLikeArray>(
+                pages: P,
+                expiry?: string
             ): JQuery.Promise<{
-                watch:
-                    | { title: string; watched: boolean }
-                    | Array<{ title: string; watched: boolean }>;
+                watch: P extends TitleLikeArray
+                    ? Array<{ title: string; watched: boolean }>
+                    : { title: string; watched: boolean };
             }>;
 
-            unwatch(
-                pages: title | title[]
+            /**
+             * Convenience method for `action=watch&unwatch=1`.
+             *
+             * @param {TitleLike | TitleLikeArray} pages
+             * @returns {JQuery.Promise<{ watch: { title: string, watched: boolean } | Array<{ title: string, watched: boolean }> }>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-unwatch
+             */
+            unwatch<P extends TitleLike | TitleLikeArray>(
+                pages: P
             ): JQuery.Promise<{
-                watch:
-                    | { title: string; watched: boolean }
-                    | Array<{ title: string; watched: boolean }>;
+                watch: P extends TitleLikeArray
+                    ? Array<{ title: string; watched: boolean }>
+                    : { title: string; watched: boolean };
             }>;
 
-            // parse.js
+            /**
+             * Convenience method for `action=parse`.
+             *
+             * @param {string | mw.Title} content Content to parse, either as a wikitext string or a mw.Title
+             * @param {ApiParseParams} additionalParams
+             * @returns {JQuery.Promise<string>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.parse-method-parse
+             */
             parse(
                 content: string | mw.Title,
                 additionalParams?: ApiParseParams
-            ): JQuery.Promise<ApiResponse>;
+            ): JQuery.Promise<string>;
 
-            // messages.js
+            /**
+             * Get a set of messages.
+             *
+             * @param {string[]} messages Messages to retrieve
+             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-getMessages
+             */
             getMessages(
                 messages: string[],
                 options?: ApiQueryAllMessagesParams
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Load a set of messages and add them to `mw.messages`.
+             *
+             * @param {string[]} messages Messages to retrieve
+             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-loadMessages
+             */
             loadMessages(
                 messages: string[],
                 options?: ApiQueryAllMessagesParams
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Load a set of messages and add them to `mw.messages`. Only messages that are not already known are loaded. If all messages are known, the returned promise is resolved immediately.
+             *
+             * @param {string[]} messages Messages to retrieve
+             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-loadMessagesIfMissing
+             */
             loadMessagesIfMissing(
                 messages: string[],
                 options?: ApiQueryAllMessagesParams
             ): JQuery.Promise<ApiResponse>;
 
-            // category.js
-            isCategory(title: title): JQuery.Promise<boolean>;
+            /**
+             * Determine if a category exists.
+             *
+             * @param {TitleLike} title
+             * @returns {JQuery.Promise<boolean>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.category-method-isCategory
+             */
+            isCategory(title: TitleLike): JQuery.Promise<boolean>;
 
+            /**
+             * Get a list of categories that match a certain prefix.
+             *
+             * E.g. given "Foo", return "Food", "Foolish people", "Foosball tables"...
+             *
+             * @param {string} prefix Prefix to match.
+             * @returns {JQuery.Promise<string[]>} Matched categories
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.category-method-getCategoriesByPrefix
+             */
             getCategoriesByPrefix(prefix: string): JQuery.Promise<string[]>;
 
-            getCategories(title: title): JQuery.Promise<boolean | mw.Title[]>;
+            /**
+             * Get the categories that a particular page on the wiki belongs to.
+             *
+             * @param {TitleLike} title
+             * @returns {JQuery.Promise<false | mw.Title[]>} List of category titles or false if title was not found
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.category-method-getCategories
+             */
+            getCategories(title: TitleLike): JQuery.Promise<false | mw.Title[]>;
 
-            // rollback.js
             /**
              * Convenience method for `action=rollback`.
              *
-             * @param {string|mw.Title} page
+             * @param {TitleLike} page
              * @param {string} user
-             * @param {Object} [params] Additional parameters
-             *
+             * @param {ApiRollbackParams?} params Additional parameters
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.rollback-method-rollback
              */
-            rollback(page: title, user: string, params?: ApiRollbackParams): JQuery.Promise<any>;
+            rollback(
+                page: TitleLike,
+                user: string,
+                params?: ApiRollbackParams
+            ): JQuery.Promise<any>;
 
-            // upload.js
+            /**
+             * Upload a file in several chunks.
+             *
+             * @param {File} file
+             * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
+             * @param {number?} chunkSize Size (in bytes) per chunk (default: 5MB)
+             * @param {number?} chunkRetries Amount of times to retry a failed chunk (default: 1)
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-chunkedUpload
+             */
             chunkedUpload(
                 file: File,
                 data: ApiUploadParams,
@@ -208,26 +544,71 @@ declare global {
                 chunkRetries?: number
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Upload a file to the stash, in chunks.
+             *
+             * This function will return a promise that will resolve with a function to finish the stash upload.
+             *
+             * @param {File | HTMLInputElement} file
+             * @param {ApiUploadParams?} data
+             * @param {number?} chunkSize Size (in bytes) per chunk (default: 5MB)
+             * @param {number?} chunkRetries Amount of times to retry a failed chunk (default: 1)
+             * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
+             */
             chunkedUploadToStash(
                 file: File,
                 data?: ApiUploadParams,
                 chunkSize?: number,
                 chunkRetries?: number
-            ): JQuery.Promise<ApiResponse>;
+            ): JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>;
 
             upload(
                 file: File | Blob | HTMLInputElement,
                 data: ApiUploadParams
             ): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Finish an upload in the stash.
+             *
+             * @param {string} filekey
+             * @param {ApiUploadParams} data
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-uploadFromStash
+             */
             uploadFromStash(filekey: string, data: ApiUploadParams): JQuery.Promise<ApiResponse>;
 
+            /**
+             * Upload a file to the stash.
+             *
+             * This function will return a promise that will resolve with a function to finish the stash upload. You can call that function with an argument containing more, or conflicting, data to pass to the server. For example:
+             * ```js
+             * // upload a file to the stash with a placeholder filename
+             * api.uploadToStash( file, { filename: 'testing.png' } ).done( function ( finish ) {
+             *     // finish is now the function we can use to finalize the upload
+             *     // pass it a new filename from user input to override the initial value
+             *     finish( { filename: getFilenameFromUser() } ).done( function ( data ) {
+             *         // the upload is complete, data holds the API response
+             *     } );
+             * } );
+             * ```
+             *
+             * @param {File | HTMLInputElement} file
+             * @param {ApiUploadParams?} data
+             * @return {JQuery.Promise}
+             * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-uploadToStash
+             */
             uploadToStash(
                 file: File | HTMLInputElement,
                 data?: ApiUploadParams
             ): JQuery.Promise<ApiResponse>;
 
-            // login.js
+            /**
+             * @param {string} username
+             * @param {string} password
+             * @returns {JQuery.Promise<ApiResponse>}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.login-method-login
+             */
             login(username: string, password: string): JQuery.Promise<ApiResponse>;
         }
 

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -1,14 +1,45 @@
 import { ApiOptions } from "./Api";
 
 interface ForeignApiOptions extends ApiOptions {
+    /**
+     * Whether to perform all requests anonymously. Use this option if the target wiki may otherwise not accept cross-origin requests, or if you don't need to perform write actions or read restricted information and want to avoid the overhead.
+     */
     anonymous?: boolean;
 }
 
 declare global {
     namespace mw {
+        /**
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi
+         */
         class ForeignApi extends mw.Api {
             /**
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi
+             * Create an object like `mw.Api`, but automatically handling everything required to communicate with another MediaWiki wiki via cross-origin requests (CORS).
+             *
+             * The foreign wiki must be configured to accept requests from the current wiki. See <https://www.mediawiki.org/wiki/Manual:$wgCrossSiteAJAXdomains> for details.
+             * ```js
+             * var api = new mw.ForeignApi( 'https://commons.wikimedia.org/w/api.php' );
+             * api.get( {
+             *     action: 'query',
+             *     meta: 'userinfo'
+             * } ).done( function ( data ) {
+             *     console.log( data );
+             * } );
+             * ```
+             *
+             * To ensure that the user at the foreign wiki is logged in, pass the `assert: 'user'` parameter to `get()`/`post()` (since MW 1.23): if they are not, the API request will fail. (Note that this doesn't guarantee that it's the same user.)
+             *
+             * Authentication-related MediaWiki extensions may extend this class to ensure that the user authenticated on the current wiki will be automatically authenticated on the foreign one. These extension modules should be registered using the ResourceLoaderForeignApiModules hook. See CentralAuth for a practical example. The general pattern to extend and override the name is:
+             * ```js
+             * function MyForeignApi() {};
+             * OO.inheritClass( MyForeignApi, mw.ForeignApi );
+             * mw.ForeignApi = MyForeignApi;
+             * ```
+             *
+             * @param {string | mw.Uri} url URL pointing to another wiki's `api.php` endpoint.
+             * @param {ForeignApiOptions?} options
+             * @since 1.26
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
             constructor(url: string | mw.Uri, options?: ForeignApiOptions);
 

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -1,0 +1,26 @@
+import { ApiOptions } from "./Api";
+
+interface ForeignApiOptions extends ApiOptions {
+    anonymous?: boolean;
+}
+
+declare global {
+    namespace mw {
+        class ForeignApi extends mw.Api {
+            /**
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi
+             */
+            constructor(url: string | mw.Uri, options?: ForeignApiOptions);
+
+            /**
+             * Return the origin to use for API requests, in the required format (protocol, host and port, if any).
+             *
+             * @protected
+             * @return {string | undefined}
+             */
+            protected getOrigin(): string | undefined;
+        }
+    }
+}
+
+export {};

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -1,4 +1,5 @@
 import "./Api";
+import "./ForeignApi";
 import "./hook";
 import "./html";
 import "./language";

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -5,7 +5,12 @@ declare global {
          */
         namespace user {
             const options: mw.Map;
-            const tokens: mw.Map;
+
+            const tokens: mw.Map<{
+                csrfToken: string;
+                patrolToken: string;
+                watchToken: string;
+            }>;
 
             function generateRandomSessionId(): string;
 


### PR DESCRIPTION
well, this resolves #5 in a way (i thought there would be more multiple-class/namespace files, but nevermind).* this PR also types the `mw.user.tokens` Map, which is a very tiny thing related to the mw APIs.

\* i now realized that there's also files with method–namespace mixing. was going to add them now but i'm already working on another PR, so that would make the merge conflict very confusing. so i'm gonna do this later (this also depends on how we decide to split the methods).