### PR TITLE
Update config.d.ts by adding wgServerName

### DIFF
--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -27,6 +27,7 @@ declare global {
             wgScript: string;
             wgScriptPath: string;
             wgServer: string;
+            wgServerName: string;
             wgSiteName: string;
             wgVariantArticlePath: string | false;
             wgVersion: string;


### PR DESCRIPTION
This is a new config variable added in MediaWiki 1.24, and reference can be found from the [MW history document](https://gerrit.wikimedia.org/g/mediawiki/core/+/master/HISTORY#9907).