### PR TITLE
Add `require` in mw.loader.using (MW +1.28)

### DIFF
--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -40,7 +40,7 @@ declare global {
 
             function using(
                 dependencies: string[] | string,
-                ready?: () => any,
+                ready?: (require: (module: string) => any) => any,
                 error?: () => any
             ): JQuery.Promise<any>;
         }


### PR DESCRIPTION
I have write access to the repo, but I'm deferring this to a PR to avoid staining the main branch in case this doesn't work.

Commit message:
```
Adds the `require` parameter used to access module exports when using `mw.loader.using`. Added in MediaWiki 1.28, see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-using for more information.
```