### PR TITLE
Allow null for saveOption, saveOptions argument

### DIFF
--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -381,7 +381,7 @@ declare global {
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOption
              */
-            saveOption(name: string, value: string): JQuery.Promise<ApiResponse>;
+            saveOption(name: string, value: string | null): JQuery.Promise<ApiResponse>;
 
             /**
              * Asynchronously save the values of user options using the API.
@@ -398,7 +398,7 @@ declare global {
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOptions
              */
-            saveOptions(options: Record<string, string>): JQuery.Promise<ApiResponse>;
+            saveOptions(options: Record<string, string | null>): JQuery.Promise<ApiResponse>;
 
             /**
              * Convenience method for `action=watch`.

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -377,7 +377,7 @@ declare global {
              * Asynchronously save the value of a single user option using the API. See `saveOptions()`.
              *
              * @param {string} name
-             * @param {string?} value
+             * @param {string|null} value
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOption
              */


### PR DESCRIPTION
According to WMF's MediaWiki JS [doc](https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options) and [source code](https://doc.wikimedia.org/mediawiki-core/master/js/source/options.html#mw-Api-plugin-options-method-saveOption), `saveOption` and `saveOptions` method accept null.

Arguments of `saveOption` are defined in [source code](https://doc.wikimedia.org/mediawiki-core/master/js/source/options.html#mw-Api-plugin-options-method-saveOption) like:

```javascript
/**
 * Asynchronously save the value of a single user option using the API. See #saveOptions.
 *
 * @param {string} name
 * @param {string|null} value
 * @return {jQuery.Promise}
 */
saveOption: function ( name, value ) { ... }
```

And in [code documentation about `saveOptions`](https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOptions) , the following sentence is included:
> If a value of `null` is provided, the given option will be reset to the default value.
