### PR TITLE
Fix type of `mw.loader.addStyleTag`

### DIFF
--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -1,7 +1,7 @@
 declare global {
     namespace mw {
         namespace loader {
-            function addStyleTag(text: string, nextNode?: Node): HTMLElement;
+            function addStyleTag(text: string, nextNode?: Node): HTMLStyleElement;
 
             function getModuleNames(): string[];
 


### PR DESCRIPTION
`HTMLElement` does not have the sheet property of `HTMLStyleElement`.
https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html#mw-loader-method-newStyleTag