### PR TITLE
Add a type variable to Hook

### DIFF
--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -76,7 +76,7 @@ declare global {
          * @member mw
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook
          */
-        function hook(event: string): Hook;
+        function hook<T extends any[] = any[]>(event: string): Hook<T>;
     }
 }
 

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -41,14 +41,14 @@
  *
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook
  */
-interface Hook {
+interface Hook<T extends any[] = any[]> {
     /**
      * Register a hook handler
      *
      * @param {...Function} handler Function to bind.
      * @chainable
      */
-    add(...handler: Array<(...args: any[]) => any>): Hook;
+    add(...handler: ((...args: T) => any)[]): this;
 
     /**
      * Run a hook.
@@ -56,7 +56,7 @@ interface Hook {
      * @param {*} data
      * @chainable
      */
-    fire(data?: any): Hook;
+    fire(...data: T): this;
 
     /**
      * Unregister a hook handler
@@ -64,7 +64,7 @@ interface Hook {
      * @param {...Function} handler Function to unbind.
      * @chainable
      */
-    remove(handler: (...args: any[]) => any): Hook;
+    remove(handler: (...args: T) => any): this;
 }
 
 declare global {

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -48,7 +48,7 @@ interface Hook<T extends any[] = any[]> {
      * @param {...Function} handler Function to bind.
      * @chainable
      */
-    add(...handler: ((...args: T) => any)[]): this;
+    add(...handler: ((...data: T) => any)[]): this;
 
     /**
      * Run a hook.
@@ -64,7 +64,7 @@ interface Hook<T extends any[] = any[]> {
      * @param {...Function} handler Function to unbind.
      * @chainable
      */
-    remove(handler: (...args: T) => any): this;
+    remove(...handler: ((...data: T) => any)[]): this;
 }
 
 declare global {
@@ -76,7 +76,7 @@ declare global {
          * @member mw
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook
          */
-        function hook(event: string): Hook;
+        function hook<T extends any[] = any[]>(event: string): Hook<T>;
     }
 }
 

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -48,7 +48,7 @@ interface Hook<T extends any[] = any[]> {
      * @param {...Function} handler Function to bind.
      * @chainable
      */
-    add(...handler: ((...data: T) => any)[]): this;
+    add(...handler: Array<(...data: T) => any>): this;
 
     /**
      * Run a hook.
@@ -64,7 +64,7 @@ interface Hook<T extends any[] = any[]> {
      * @param {...Function} handler Function to unbind.
      * @chainable
      */
-    remove(...handler: ((...data: T) => any)[]): this;
+    remove(...handler: Array<(...data: T) => any>): this;
 }
 
 declare global {

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -76,7 +76,7 @@ declare global {
          * @member mw
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook
          */
-        function hook<T extends any[] = any[]>(event: string): Hook<T>;
+        function hook(event: string): Hook;
     }
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
         "no-padding": false,
         "no-unnecessary-qualifier": false,
         "unified-signatures": false,
-        "no-redundant-jsdoc": false
+        "no-redundant-jsdoc": false,
+        "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
Add a type variable to the `Hook` class, so that we can (optionally) specify the type of data shared when the hook is fired.
E.g.:
```js
/** @type {Hook<[string]>} */
var myHook = mw.hook('foo.bar');

myHook.add(function (myData) {
    myData.substring(1);   // ok
    myData.toPrecision(1); // not ok
});
```

## Standard hook typing
We may specify the type variable on hooks used by default on MediaWiki.
E.g. for `wikitext.content`:
```ts
    namespace mw {
        function hook(event: "wikitext.content"): Hook<[$content: JQuery]>;
        function hook(event: string): Hook;
    }
```
This is not backward-compatible, so this merge request does not propose to include any of these signatures.