### PR TITLE
Update types and add doc comments

### DIFF
--- a/mw/RegExp.d.ts
+++ b/mw/RegExp.d.ts
@@ -1,0 +1,26 @@
+declare global {
+    namespace mw {
+        /**
+         * @class mw.RegExp
+         * @see https://doc.wikimedia.org/mediawiki-core/REL1_29/js/source/mediawiki.RegExp.html
+         */
+        namespace RegExp {
+            /**
+             * Escape string for safe inclusion in regular expression
+             *
+             * The following characters are escaped:
+             *
+             *     \ { } ( ) | . ? * + - ^ $ [ ]
+             *
+             * @deprecated
+             * @since 1.26; deprecated since 1.34
+             * @param {string} str String to escape
+             * @return {string} Escaped string
+             * @see https://doc.wikimedia.org/mediawiki-core/REL1_29/js/source/mediawiki.RegExp.html#mw-RegExp-static-method-escape
+             */
+            function escape(str: string): string;
+        }
+    }
+}
+
+export {};

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -3,92 +3,416 @@ type title = string | mw.Title;
 declare global {
     namespace mw {
         /**
-         * Parse titles into an object structure. Note that when using the constructor directly,
-         * passing invalid titles will result in an exception. Use newFromText to use the logic
-         * directly and get null for invalid titles which is easier to work with.
+         * Parse titles into an object structure. Note that when using the constructor
+         * directly, passing invalid titles will result in an exception. Use #newFromText to use the
+         * logic directly and get null for invalid titles which is easier to work with.
          *
-         * Note that in the constructor and newFromText method, namespace is the default namespace
-         * only, and can be overridden by a namespace prefix in title. If you do not want this
-         * behavior, use makeTitle.
+         * Note that in the constructor and #newFromText method, `namespace` is the **default** namespace
+         * only, and can be overridden by a namespace prefix in `title`. If you do not want this behavior,
+         * use #makeTitle. Compare:
          *
+         *     new mw.Title( 'Foo', NS_TEMPLATE ).getPrefixedText();                  // => 'Template:Foo'
+         *     mw.Title.newFromText( 'Foo', NS_TEMPLATE ).getPrefixedText();          // => 'Template:Foo'
+         *     mw.Title.makeTitle( NS_TEMPLATE, 'Foo' ).getPrefixedText();            // => 'Template:Foo'
+         *
+         *     new mw.Title( 'Category:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Category:Foo'
+         *     mw.Title.newFromText( 'Category:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Category:Foo'
+         *     mw.Title.makeTitle( NS_TEMPLATE, 'Category:Foo' ).getPrefixedText();   // => 'Template:Category:Foo'
+         *
+         *     new mw.Title( 'Template:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Template:Foo'
+         *     mw.Title.newFromText( 'Template:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Template:Foo'
+         *     mw.Title.makeTitle( NS_TEMPLATE, 'Template:Foo' ).getPrefixedText();   // => 'Template:Template:Foo'
+         *
+         * @class mw.Title
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title
          */
         class Title {
             /**
-             * @param title Title of the page. If no second argument given, this will be searched for a namespace
-             * @param namespace If given, will used as default namespace for the given title. Defaults to `NS_MAIN`.
-             * @throws Error When the title is invalid.
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-constructor
+             * Store page existence
+             *
+             * @static
+             * @property {Object} exist
+             * @property {Object} exist.pages Keyed by title. Boolean true value indicates page does exist.
+             *
+             * @property {Function} exist.set The setter function.
+             *
+             *  Example to declare existing titles:
+             *
+             *     Title.exist.set( ['User:John_Doe', ...] );
+             *
+             *  Example to declare titles nonexistent:
+             *
+             *     Title.exist.set( ['File:Foo_bar.jpg', ...], false );
+             *
+             * @property {string|Array} exist.set.titles Title(s) in strict prefixedDb title form
+             * @property {boolean} [exist.set.state=true] State of the given titles
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-property-exist
              */
-            constructor(title: string, namespace?: number);
-
-            title: string;
-            namespace: number;
-
-            static newFromText(title: string, namespace?: number): mw.Title | null;
-
-            static makeTitle(title: string, namespace?: number): mw.Title | null;
-
-            static newFromUserInput(title: string, namespace?: number, options?: any): mw.Title;
-
-            static newFromFileName(uncleanName: string): mw.Title;
-
-            static newFromImg(img: HTMLElement | JQuery): mw.Title;
-
-            static isTalkNamespace(namespaceId: number): boolean;
-
-            static wantSignatureNamespace(namespaceId: number): boolean;
-
-            static exists(title: title): boolean | null;
-
             static exist: {
                 pages: { [title: string]: boolean };
                 set: (titles: string | string[], state?: boolean) => boolean;
             };
 
-            static normalizeExtension(extension: string): string;
+            /**
+             * @method constructor
+             * @param {string} title Title of the page. If no second argument given,
+             *  this will be searched for a namespace
+             * @param {number} [namespace=NS_MAIN] If given, will used as default namespace for the given title
+             * @throws {Error} When the title is invalid
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-constructor
+             */
+            constructor(title: string, namespace?: number);
 
-            static phpCharToUpper(chr: string): string;
-
-            getNamespaceId(): number;
-
-            getNamespacePrefix(): string;
-
-            getName(): string;
-
-            getNameText(): string;
-
-            getExtension(): string | null;
-
-            getDotExtension(): string;
-
-            getMain(): string;
-
-            getMainText(): string;
-
-            getPrefixedDb(): string;
-
-            getPrefixedText(): string;
-
-            getRelativeText(namespace: number): string;
-
-            getFragment(): string | null;
-
-            getUrl(params: any): string;
-
-            isTalkPage(): boolean;
-
-            getTalkPage(): Title | null;
-
-            getSubjectPage(): Title | null;
-
+            /**
+             * Check the title can have an associated talk page
+             *
+             * @return {boolean} The title can have an associated talk page
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-canHaveTalkPage
+             */
             canHaveTalkPage(): boolean;
 
+            /**
+             * Whether this title exists on the wiki.
+             *
+             * @return {boolean|null} Boolean if the information is available, otherwise null
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-exists
+             */
             exists(): boolean | null;
 
+            /**
+             * Get the extension of the page name (if any)
+             *
+             * @return {string|null} Name extension or null if there is none
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getExtension
+             */
+            getExtension(): string | null;
+
+            /**
+             * Get the page name as if it is a file name, without extension or namespace prefix,
+             * in the human-readable form with spaces instead of underscores. For example, the title
+             * "File:Example_image.svg" will be returned as "Example image".
+             *
+             * Note that this method will work for non-file titles but probably give nonsensical results.
+             * A title like "User:Dr._J._Fail" will be returned as "Dr. J"! Use #getMainText instead.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameTextWithoutExtension
+             */
+            getFileNameTextWithoutExtension(): string;
+
+            /**
+             * Get the page name as if it is a file name, without extension or namespace prefix,
+             * in the canonical form with underscores instead of spaces. For example, the title
+             * "File:Example_image.svg" will be returned as "Example_image".
+             *
+             * Note that this method will work for non-file titles but probably give nonsensical results.
+             * A title like "User:Dr._J._Fail" will be returned as "Dr._J"! Use #getMain instead.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameWithoutExtension
+             */
+            getFileNameWithoutExtension(): string;
+
+            /**
+             * Get the fragment (if any).
+             *
+             * Note that this method (by design) does not include the hash character and
+             * the value is not url encoded.
+             *
+             * @return {string|null}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFragment
+             */
+            getFragment(): string | null;
+
+            /**
+             * Get the main page name
+             *
+             * Example: "Example_image.svg" for "File:Example_image.svg".
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getMain
+             */
+            getMain(): string;
+
+            /**
+             * Get the main page name (transformed by #text)
+             *
+             * Example: "Example image.svg" for "File:Example_image.svg".
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getMainText
+             */
+            getMainText(): string;
+
+            /**
+             * Get the namespace number
+             *
+             * Example: 6 for "File:Example_image.svg".
+             *
+             * @return {number}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNamespaceId
+             */
+            getNamespaceId(): number;
+
+            /**
+             * Get the namespace prefix (in the content language)
+             *
+             * Example: "File:" for "File:Example_image.svg".
+             * In #NS_MAIN this is '', otherwise namespace name plus ':'
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNamespacePrefix
+             */
+            getNamespacePrefix(): string;
+
+            /**
+             * Get the full page name
+             *
+             * Example: "File:Example_image.svg".
+             * Most useful for API calls, anything that must identify the "title".
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getPrefixedDb
+             */
+            getPrefixedDb(): string;
+
+            /**
+             * Get the full page name (transformed by #text)
+             *
+             * Example: "File:Example image.svg" for "File:Example_image.svg".
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getPrefixedText
+             */
+            getPrefixedText(): string;
+
+            /**
+             * Get the page name relative to a namespace
+             *
+             * Example:
+             *
+             * - "Foo:Bar" relative to the Foo namespace becomes "Bar".
+             * - "Bar" relative to any non-main namespace becomes ":Bar".
+             * - "Foo:Bar" relative to any namespace other than Foo stays "Foo:Bar".
+             *
+             * @param {number} namespace The namespace to be relative to
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getRelativeText
+             */
+            getRelativeText(namespace: number): string;
+
+            /**
+             * Get the title for the subject page of a talk page
+             *
+             * @return {mw.Title|null} The title for the subject page of a talk page, null if not available
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getSubjectPage
+             */
+            getSubjectPage(): Title | null;
+
+            /**
+             * Get the title for the associated talk page
+             *
+             * @return {mw.Title|null} The title for the associated talk page, null if not available
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getTalkPage
+             */
+            getTalkPage(): Title | null;
+
+            /**
+             * Get the URL to this title
+             *
+             * @param {Object} [params] A mapping of query parameter names to values,
+             *     e.g. `{ action: 'edit' }`.
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getUrl
+             */
+            getUrl(params?: any): string;
+
+            /**
+             * Check if a given namespace is a talk namespace
+             *
+             * See NamespaceInfo::isTalk in PHP
+             *
+             * @param {number} namespaceId Namespace ID
+             * @return {boolean} Namespace is a talk namespace
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkNamespace
+             */
+            isTalkNamespace(namespaceId: number): boolean;
+
+            /**
+             * Check if the title is in a talk namespace
+             *
+             * @return {boolean} The title is in a talk namespace
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkPage
+             */
+            isTalkPage(): boolean;
+
+            /**
+             * Normalize a file extension to the common form, making it lowercase and checking some synonyms,
+             * and ensure it's clean. Extensions with non-alphanumeric characters will be discarded.
+             * Keep in sync with File::normalizeExtension() in PHP.
+             *
+             * @param {string} extension File extension (without the leading dot)
+             * @return {string} File extension in canonical form
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-normalizeExtension
+             */
+            normalizeExtension(extension: string): string;
+
+            /**
+             * PHP's strtoupper differs from String.toUpperCase in a number of cases (T147646).
+             *
+             * @param {string} chr Unicode character
+             * @return {string} Unicode character, in upper case, according to the same rules as in PHP
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-phpCharToUpper
+             */
+            phpCharToUpper(chr: string): string;
+
+            /**
+             * Alias of mw.Title#getPrefixedDb
+             *
+             * TODO: Use @-alias when we switch to JSDoc
+             *
+             * @method
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-toString
+             */
             toString(): string;
 
+            /**
+             * Alias of mw.Title#getPrefixedText
+             *
+             * TODO: Use @-alias when we switch to JSDoc
+             *
+             * @method
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-toText
+             */
             toText(): string;
+
+            /**
+             * Check if signature buttons should be shown in a given namespace
+             *
+             * See NamespaceInfo::wantSignatures in PHP
+             *
+             * @param {number} namespaceId Namespace ID
+             * @return {boolean} Namespace is a signature namespace
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-wantSignaturesNamespace
+             */
+            wantSignatureNamespace(namespaceId: number): boolean;
+
+            /**
+             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
+             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
+             * "Dr. J"! Use #getMain or #getMainText for the actual page name.
+             *
+             * @deprecated since 1.40, use #getFileNameWithoutExtension instead
+             * @return {string} File name without file extension, in the canonical form with underscores
+             *  instead of spaces. For example, the title "File:Example_image.svg" will be returned as
+             *  "Example_image".
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getName
+             */
+            getName(): string;
+
+            /**
+             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
+             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
+             * "Dr. J"! Use #getMainText for the actual page name.
+             *
+             * @deprecated since 1.40, use #getFileNameTextWithoutExtension instead
+             * @return {string} File name without file extension, formatted with spaces instead of
+             *  underscores. For example, the title "File:Example_image.svg" will be returned as
+             *  "Example image".
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNameText
+             */
+            getNameText(): string;
+
+            /**
+             * Whether this title exists on the wiki.
+             *
+             * @static
+             * @param {string|mw.Title} title prefixed db-key name (string) or instance of Title
+             * @return {boolean|null} Boolean if the information is available, otherwise null
+             * @throws {Error} If title is not a string or mw.Title
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-exists
+             */
+            static exists(title: title): boolean | null;
+
+            /**
+             * Constructor for Title objects with predefined namespace.
+             *
+             * Unlike #newFromText or #constructor, this function doesn't allow the given `namespace` to be
+             * overridden by a namespace prefix in `title`. See #constructor for details about this behavior.
+             *
+             * The single exception to this is when `namespace` is 0, indicating the main namespace. The
+             * function behaves like #newFromText in that case.
+             *
+             * @static
+             * @param {number} namespace Namespace to use for the title
+             * @param {string} title
+             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-makeTitle
+             */
+            static makeTitle(namespace: number, title: string): Title | null;
+
+            /**
+             * Sanitizes a file name as supplied by the user, originating in the user's file system
+             * so it is most likely a valid MediaWiki title and file name after processing.
+             * Returns null on fatal errors.
+             *
+             * @static
+             * @param {string} uncleanName The unclean file name including file extension but
+             *   without namespace
+             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromFileName
+             */
+            static newFromFileName(uncleanName: string): Title;
+
+            /**
+             * Get the file title from an image element
+             *
+             *     var title = mw.Title.newFromImg( imageNode );
+             *
+             * @static
+             * @param {HTMLElement|JQuery} img The image to use as a base
+             * @return {Title|null} The file title or null if unsuccessful
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromImg
+             */
+            static newFromImg(img: HTMLElement | JQuery): Title;
+
+            /**
+             * Constructor for Title objects with a null return instead of an exception for invalid titles.
+             *
+             * Note that `namespace` is the **default** namespace only, and can be overridden by a namespace
+             * prefix in `title`. If you do not want this behavior, use #makeTitle. See #constructor for
+             * details.
+             *
+             * @static
+             * @param {string} title
+             * @param {number} [namespace=NS_MAIN] Default namespace
+             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromText
+             */
+            static newFromText(title: string, namespace?: number): Title | null;
+
+            /**
+             * Constructor for Title objects from user input altering that input to
+             * produce a title that MediaWiki will accept as legal
+             *
+             * @static
+             * @param {string} title
+             * @param {number} [defaultNamespace=NS_MAIN]
+             *  If given, will used as default namespace for the given title.
+             * @param {Object} [options] additional options
+             * @param {boolean} [options.forUploading=true]
+             *  Makes sure that a file is uploadable under the title returned.
+             *  There are pages in the file namespace under which file upload is impossible.
+             *  Automatically assumed if the title is created in the Media namespace.
+             * @return {Title|null} A valid Title object or null if the input cannot be turned into a valid title
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromUserInput
+             */
+            static newFromUserInput(
+                title: string,
+                defaultNamespace?: number,
+                options?: { forUploading: boolean }
+            ): Title;
         }
     }
 }

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -1,54 +1,259 @@
+type Options =
+    | {
+          strictMode?: boolean;
+          overrideKeys?: boolean;
+          arrayParams?: boolean;
+      }
+    | boolean;
+
 declare global {
     namespace mw {
+        /**
+         * A factory method to create an mw.Uri class with a default location to resolve relative URLs
+         * against (including protocol-relative URLs).
+         *
+         * @method
+         * @param {string|Function} documentLocation A full url, or function returning one.
+         *  If passed a function, the return value may change over time and this will be honoured. (T74334)
+         * @member mw
+         * @return {Function} An mw.Uri class constructor
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-UriRelative
+         */
+        function UriRelative(documentLocation: string | ((...args: any[]) => string)): Uri;
+
         class Uri {
+            /**
+             * @property {string|undefined} fragment For example `top`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-fragment
+             */
             fragment: string | undefined;
+            /**
+             * @property {string} host For example `www.example.com` (always present)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-host
+             */
             host: string;
+            /**
+             * @property {string|undefined} password For example `pwd`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-password
+             */
             password: string | undefined;
+            /**
+             * @property {string} path For example `/dir/dir.2/index.htm` (always present)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-path
+             */
             path: string;
+            /**
+             * @property {string|undefined} port For example `81`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-port
+             */
             port: string | undefined;
+            /**
+             * @property {string} protocol For example `http` (always present)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-protocol
+             */
             protocol: string;
+            /**
+             * @property {Object} query For example `{ a: '0', b: '', c: 'value' }` (always present)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-query
+             */
             query: any;
+            /**
+             * @property {string|undefined} user For example `usr`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-user
+             */
             user: string | undefined;
 
+            /**
+             * Regular expressions to parse many common URIs.
+             *
+             * These are gnarly expressions. For improved readability, they have been moved to a separate
+             * file where they make use of named capture groups. That syntax isn't valid in JavaScript ES5,
+             * so the server-side strips these before delivering to the client.
+             *
+             * @private
+             * @static
+             * @property {Object} parser
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-parser
+             */
+            static parser: {
+                strict: RegExp;
+                loose: RegExp;
+            };
+
+            /**
+             * The order here matches the order of captured matches in the `parser` property regexes.
+             *
+             * @private
+             * @static
+             * @property {string[]} properties
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-properties
+             */
+            static properties: [
+                "protocol",
+                "user",
+                "password",
+                "host",
+                "port",
+                "path",
+                "query",
+                "fragment"
+            ];
+
+            /**
+             * Construct a new URI object. Throws error if arguments are illegal/impossible, or
+             * otherwise don't parse.
+             *
+             * @class mw.Uri
+             * @constructor
+             * @param {Object|string} [uri] URI string, or an Object with appropriate properties (especially
+             *  another URI object to clone). Object must have non-blank `protocol`, `host`, and `path`
+             *  properties. If omitted (or set to `undefined`, `null` or empty string), then an object
+             *  will be created for the default `uri` of this constructor (`location.href` for mw.Uri,
+             *  other values for other instances -- see mw.UriRelative for details).
+             * @param {Object|boolean} [options] Object with options, or (backwards compatibility) a boolean
+             *  for strictMode
+             * @param {boolean} [options.strictMode=false] Trigger strict mode parsing of the url.
+             * @param {boolean} [options.overrideKeys=false] Whether to let duplicate query parameters
+             *  override each other (`true`) or automagically convert them to an array (`false`).
+             * @param {boolean} [options.arrayParams=false] Whether to parse array query parameters (e.g.
+             *  `&foo[0]=a&foo[1]=b` or `&foo[]=a&foo[]=b`) or leave them alone. Currently this does not
+             *  handle associative or multi-dimensional arrays, but that may be improved in the future.
+             *  Implies `overrideKeys: true` (query parameters without `[...]` are not parsed as arrays).
+             * @throws {Error} when the query string or fragment contains an unknown % sequence
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-constructor
+             */
             constructor(
                 uri?:
                     | string
-                    | mw.Uri
-                    | {
-                          fragment?: string;
+                    | Uri
+                    | Partial<{
+                          fragment: string;
                           host: string;
-                          password?: string;
+                          password: string;
                           path: string;
-                          port?: string;
+                          port: string;
                           protocol: string;
-                          query?: any;
-                          user?: string;
-                      },
-                options?: {
-                    strictMode?: boolean;
-                    overrideKeys?: boolean;
-                    arrayParams?: boolean;
-                }
+                          query: any;
+                          user: string;
+                      }>,
+                options?: Options
             );
 
-            clone(): mw.Uri;
+            /**
+             * Clone this URI
+             *
+             * @return {Uri} New URI object with same properties
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-clone
+             */
+            clone(): Uri;
 
-            extend(parameters: any): mw.Uri;
+            /**
+             * Extend the query section of the URI with new parameters.
+             *
+             * @param {Object} parameters Query parameters to add to ours (or to override ours with) as an
+             *  object
+             * @return {Uri} This URI object
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-extend
+             */
+            extend(parameters: Record<string, any>): Uri;
 
+            /**
+             * Get the userInfo, host and port section of the URI.
+             *
+             * In most real-world URLs this is simply the hostname, but the definition of 'authority' section is more general.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getAuthority
+             */
             getAuthority(): string;
 
+            /**
+             * Get host and port section of a URI.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getHostPort
+             */
             getHostPort(): string;
 
+            /**
+             * Get the query arguments of the URL, encoded into a string.
+             *
+             * Does not preserve the original order of arguments passed in the URI. Does handle escaping.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getQueryString
+             */
             getQueryString(): string;
 
+            /**
+             * Get everything after the authority section of the URI.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getRelativePath
+             */
             getRelativePath(): string;
 
+            /**
+             * Get user and password section of a URI.
+             *
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getUserInfo
+             */
             getUserInfo(): string;
 
+            /**
+             * Get the entire URI string.
+             *
+             * Note that the output may not be precisely the same as the constructor input,
+             * due to order of query arguments.
+             * Note also that the fragment is not always roundtripped as-is; some characters will
+             * become encoded, including the slash character, which can cause problems with e.g.
+             * mediawiki.router. It is recommended to use the native URL class (via
+             * web2017-polyfills, which loads a polyfill if needed) in contexts where the fragment
+             * is important.
+             *
+             * @return {string} The URI string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-toString
+             */
             toString(): string;
 
+            /**
+             * Parse a string and set our properties accordingly.
+             *
+             * @private
+             * @param {string} str URI, see constructor.
+             * @param {Object} options See constructor.
+             * @throws {Error} when the query string or fragment contains an unknown % sequence
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-parse
+             */
+            parse(str: string, options: Options): void;
+
+            /**
+             * Decode a url encoded value.
+             *
+             * Reversed #encode. Standard decodeURIComponent, with addition of replacing
+             * `+` with a space.
+             *
+             * @static
+             * @param {string} s String to decode
+             * @return {string} Decoded string
+             * @throws {Error} when the string contains an unknown % sequence
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-method-decode
+             */
             static decode(s: string): string;
 
+            /**
+             * Encode a value for inclusion in a url.
+             *
+             * Standard encodeURIComponent, with extra stuff to make all browsers work similarly and more
+             * compliant with RFC 3986. Similar to rawurlencode from PHP and our JS library
+             * mw.util.rawurlencode, except this also replaces spaces with `+`.
+             *
+             * @static
+             * @param {string} s String to encode
+             * @return {string} Encoded string for URI
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-method-encode
+             */
             static encode(s: string): string;
         }
     }

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -4,25 +4,54 @@ interface Experiment {
      */
     name: string;
     /**
-     * Whether the experiment is enabled
+     * Whether the experiment is enabled. If the experiment is disabled, then the user is always assigned to the control bucket
      */
     enabled: boolean;
     /**
-     * An object consisting of the experiment's buckets ("control" and at least one bucket) and their probabilities (a number < 1, eg 0.25)
+     * A map of bucket name to probability that the user will be assigned to that bucket
      */
     buckets: Record<string, number>;
 }
 
 declare global {
     namespace mw {
+        /**
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.experiments
+         */
         namespace experiment {
             /**
-             * Get a bucket for a user for the given experiment
-             * @param {string} token A unique identifier for the user
-             * @param {Experiment} experiment The expermient to get a bucket from
-             * @returns {string} The name of the chosen bucket (for example, if the buckets were "control", "a" and "b", it could return "b")
+             * Gets the bucket for the experiment given the token.
+             *
+             * The name of the experiment and the token are hashed. The hash is converted
+             * to a number which is then used to get a bucket.
+             *
+             * @example
+             * // The experiment has three buckets: control, A, and B. The user has a 50% chance of
+             * // being assigned to the control bucket, and a 25% chance of being assigned to either
+             * // the A or B bucket. If the experiment were disabled, then the user would always be
+             * // assigned to the control bucket.
+             * {
+             *   name: 'My first experiment',
+             *   enabled: true,
+             *   buckets: {
+             *     control: 0.5
+             *     A: 0.25,
+             *     B: 0.25
+             *   }
+             * }
+             *
+             * @param {Object} experiment
+             * @param {string} experiment.name The name of the experiment
+             * @param {boolean} experiment.enabled Whether or not the experiment is
+             *  enabled. If the experiment is disabled, then the user is always assigned
+             *  to the control bucket
+             * @param {Object} experiment.buckets A map of bucket name to probability
+             *  that the user will be assigned to that bucket
+             * @param {string} token A token that uniquely identifies the user for the
+             *  duration of the experiment
+             * @return {string|undefined} The bucket
              */
-            function getBucket(experiment: Experiment, token: string): string;
+            function getBucket(experiment: Experiment, token: string): string | undefined;
         }
     }
 }

--- a/mw/global.d.ts
+++ b/mw/global.d.ts
@@ -1,0 +1,64 @@
+declare global {
+    /**
+     * Global variables and functions.
+     *
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global
+     */
+
+    /**
+     * Schedule a function to run once the page is ready (DOM loaded).
+     *
+     * @since 1.5.8
+     * @member global
+     * @param {Function} fn
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-addOnloadHook
+     */
+    function addOnloadHook(fn: (...args: any[]) => any): void;
+
+    /**
+     * Import a local JS content page, for use by user scripts and site-wide scripts.
+     *
+     * Note that if the same title is imported multiple times, it will only
+     * be loaded and executed once.
+     *
+     * @since 1.12.2
+     * @member global
+     * @param {string} title
+     * @return {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importScript
+     */
+    function importScript(title: string): HTMLScriptElement | null;
+
+    /**
+     * @since 1.12.2
+     * @method importScriptURI
+     * @member global
+     * @param {string} url
+     * @return {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importScriptURI
+     */
+    function importScriptURI(url: string): HTMLScriptElement | null;
+
+    /**
+     * Import a local CSS content page, for use by user scripts and site-wide scripts.
+     *
+     * @since 1.12.2
+     * @member global
+     * @param {string} title
+     * @return {HTMLLinkElement} Link tag
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheet
+     */
+    function importStylesheet(title: string): HTMLLinkElement | null;
+
+    /**
+     * @since 1.12.2
+     * @member global
+     * @param {string} url
+     * @param {string} media
+     * @return {HTMLLinkElement} Link tag
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheetURI
+     */
+    function importStylesheetURI(url: string, media: string): HTMLLinkElement | null;
+}
+
+export {};

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -1,29 +1,49 @@
 declare global {
     namespace mw {
+        /**
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html
+         */
         namespace html {
             /**
-             * Escape a string for HTML.
-             * Converts special characters to HTML entities.
-             * @param {string} s The string to escape
-             * @returns {string} HTML
-             */
-            function escape(s: string): string;
-
-            /**
              * Create an HTML element string, with safe escaping.
-             * @param {string} name The tag name
-             * @param {{ [key: string]: string }} attrs An object with members mapping element names to values
-             * @param {string | html.Raw} contents The contents of the element
-             * @returns {string} HTML
+             *
+             * @param {string} name The tag name.
+             * @param {Object} [attrs] An object with members mapping element names to values
+             * @param {string|Raw|null} [contents=null] The contents of the element.
+             *
+             *  - string: Text to be escaped.
+             *  - null: The element is treated as void with short closing form, e.g. `<br/>`.
+             *  - this.Raw: The raw value is directly included.
+             * @return {string} HTML
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html-method-element
              */
             function element(
                 name: string,
                 attrs?: Record<string, string>,
-                contents?: string | mw.html.Raw
+                contents?: string | Raw | null
             ): string;
 
             /**
+             * Escape a string for HTML.
+             *
+             * Converts special characters to HTML entities.
+             *
+             *     mw.html.escape( '< > \' & "' );
+             *     // Returns &lt; &gt; &#039; &amp; &quot;
+             *
+             * @param {string} s The string to escape
+             * @return {string} HTML
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html-method-escape
+             */
+            function escape(s: string): string;
+
+            /**
              * Wrapper object for raw HTML passed to mw.html.element().
+             *
+             * @class mw.html.Raw
+             * @constructor
+             * @param {string} value
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html.Raw-method-constructor
              */
             class Raw<V extends string = string> {
                 constructor(value: V);

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -12,6 +12,7 @@ import "./log";
 import "./Map";
 import "./message";
 import "./notification";
+import "./RegExp";
 import "./Rest";
 import "./storage";
 import "./template";

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -3,6 +3,7 @@ import "./config";
 import "./cookie";
 import "./ForeignApi";
 import "./ForeignRest";
+import "./global";
 import "./hook";
 import "./html";
 import "./language";

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -1,35 +1,274 @@
 declare global {
     namespace mw {
+        /**
+         * Base language object with methods related to language support, attempting to mirror some of the
+         * functionality of the Language class in MediaWiki:
+         *
+         *   - storing and retrieving language data
+         *   - transforming message syntax (`{{PLURAL:}}`, `{{GRAMMAR:}}`, `{{GENDER:}}`)
+         *   - formatting numbers
+         *
+         * @class
+         * @singleton
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language
+         */
         namespace language {
+            /**
+             * Language-related data (keyed by language, contains instances of mw.Map).
+             *
+             * Exported dynamically by the ResourceLoader\LanguageDataModule class in PHP.
+             *
+             * To set data:
+             *
+             *     // Override, extend or create the language data object of 'nl'
+             *     mw.language.setData( 'nl', 'myKey', 'My value' );
+             *
+             *     // Set multiple key/values pairs at once
+             *     mw.language.setData( 'nl', { foo: 'X', bar: 'Y' } );
+             *
+             * To get GrammarForms data for language 'nl':
+             *
+             *     var grammarForms = mw.language.getData( 'nl', 'grammarForms' );
+             *
+             * Possible data keys:
+             *
+             *  - `digitTransformTable`
+             *  - `separatorTransformTable`
+             *  - `minimumGroupingDigits`
+             *  - `grammarForms`
+             *  - `pluralRules`
+             *  - `digitGroupingPattern`
+             *  - `fallbackLanguages`
+             *  - `bcp47Map`
+             *  - `languageNames`
+             *
+             * @property {Object}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-data
+             */
+            const data: Record<string, any>;
+
+            /**
+             * Information about month names in current UI language.
+             *
+             * Object keys:
+             *
+             * - `names`: array of month names (in nominative case in languages which have the distinction),
+             *   zero-indexed
+             * - `genitive`: array of month names in genitive case, zero-indexed
+             * - `abbrev`: array of three-letter-long abbreviated month names, zero-indexed
+             * - `keys`: object with three keys like the above, containing zero-indexed arrays of message keys
+             *   for appropriate messages which can be passed to mw.msg.
+             *
+             * @property {Object}
+             * @member mw.language
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
+             */
+            const months: Record<string, any>;
+
+            /**
+             * Formats language tags according the BCP 47 standard.
+             * See LanguageCode::bcp47 for the PHP implementation.
+             *
+             * @param {string} languageTag Well-formed language tag
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-bcp47
+             */
             function bcp47(languageTag: string): string;
 
+            /**
+             * Grammatical transformations, needed for inflected languages.
+             * Invoked by putting `{{grammar:case|word}}` in a message.
+             *
+             * The rules can be defined in $wgGrammarForms global or computed
+             * dynamically by overriding this method per language.
+             *
+             * @param {string} word
+             * @param {string} form
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertGrammar
+             */
             function convertGrammar(word: string, form: string): string;
 
+            /**
+             * Converts a number using #getDigitTransformTable.
+             *
+             * @param {number} num Value to be converted
+             * @param {boolean} [integer=false] Whether to convert the return value to an integer
+             * @return {number|string} Formatted number
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertNumber
+             */
             function convertNumber(num: number, integer?: boolean): number | string;
 
+            /**
+             * Plural form transformations, needed for some languages.
+             *
+             * @param {number} count Non-localized quantifier
+             * @param {Array} forms List of plural forms
+             * @param {Object} [explicitPluralForms] List of explicit plural forms
+             * @return {string} Correct form for quantifier in this language
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertPlural
+             */
             function convertPlural(
                 count: number,
                 forms: string[],
-                explicitPluralForms?: any
+                explicitPluralForms?: Record<string, any>
             ): string;
 
-            function flipTransform(...Transformation: any[]): any;
+            /**
+             * Helper function to flip transformation tables.
+             *
+             * @param {...Object} Transformation tables
+             * @return {Object}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
+             */
+            function flipTransform(
+                ...Transformation: Array<Record<string, any>>
+            ): Record<string, any>;
 
+            /**
+             * Provides an alternative text depending on specified gender.
+             *
+             * Usage in message text: `{{gender:[gender|user object]|masculine|feminine|neutral}}`.
+             * If second or third parameter are not specified, masculine is used.
+             *
+             * These details may be overridden per language.
+             *
+             * @param {string} gender 'male', 'female', or anything else for neutral.
+             * @param {Array} forms List of gender forms
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-gender
+             */
             function gender(gender: string, forms: string[]): string;
 
+            /**
+             * Convenience method for retrieving language data.
+             *
+             * Structured by language code and data key, covering for the potential inexistence of a
+             * data object for this language.
+             *
+             * @param {string} langCode
+             * @param {string} dataKey
+             * @return {any} Value stored in the mw.Map (or `undefined` if there is no map for the
+             *  specified langCode)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getData
+             */
             function getData(langCode: string, dataKey: string): any;
 
+            /**
+             * Get the digit transform table for current UI language.
+             *
+             * @return {Object|Array}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getDigitTransformTable
+             */
             function getDigitTransformTable(): any;
 
+            /**
+             * Get the language fallback chain for current UI language, including the language itself.
+             *
+             * @return {string[]} List of language keys, e.g. `['pfl', de', 'en']`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getFallbackLanguageChain
+             */
             function getFallbackLanguageChain(): string[];
 
+            /**
+             * Get the language fallback chain for current UI language (not including the language itself).
+             *
+             * @return {string[]} List of language keys, e.g. `['de', 'en']`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getFallbackLanguages
+             */
             function getFallbackLanguages(): string[];
 
+            /**
+             * Get the separator transform table for current UI language.
+             *
+             * @return {Object|Array}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getSeparatorTransformTable
+             */
             function getSeparatorTransformTable(): any;
 
+            /**
+             * Turn a list of string into a simple list using commas and 'and'.
+             *
+             * See Language::listToText in languages/Language.php
+             *
+             * @param {string[]} list
+             * @return {string}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-listToText
+             */
             function listToText(list: string[]): string;
 
-            function setData(langCode: string, dataKey: string, value?: any): void;
+            /**
+             * Convenience method for setting language data.
+             *
+             * Creates the data mw.Map if there isn't one for the specified language already.
+             *
+             * @param {string} langCode
+             * @param {string|Object} dataKey Key or object of key/values
+             * @param {any} [value] Value for dataKey, omit if dataKey is an object
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
+             */
+            function setData(langCode: string, dataKey: any, value?: any): void;
+
+            /**
+             * Apply numeric pattern to absolute value using options. Gives no
+             * consideration to local customs.
+             *
+             * Adapted from dojo/number library with thanks
+             * <http://dojotoolkit.org/reference-guide/1.8/dojo/number.html>
+             *
+             * @private
+             * @param {number} value the number to be formatted, ignores sign
+             * @param {string} pattern the number portion of a pattern (e.g. `#,##0.00`)
+             * @param {Object} [options] If provided, all option keys must be present:
+             * @param {string} options.decimal The decimal separator. Defaults to: `'.'`.
+             * @param {string} options.group The group separator. Defaults to: `','`.
+             * @param {number|null} options.minimumGroupingDigits
+             * @return {string}
+             */
+            function commafyNumber(
+                value: number,
+                pattern: string,
+                options?: { decimal: string; group: string; minimumGroupingDigits: number | null }
+            ): string;
+
+            /**
+             * Pad a string to guarantee that it is at least `size` length by
+             * filling with the character `ch` at either the start or end of the
+             * string. Pads at the start, by default.
+             *
+             * Example: Fill the string to length 10 with '+' characters on the right.
+             *
+             *     pad( 'blah', 10, '+', true ); // => 'blah++++++'
+             *
+             * @private
+             * @param {string} text The string to pad
+             * @param {number} size The length to pad to
+             * @param {string} [ch='0'] Character to pad with
+             * @param {boolean} [end=false] Adds padding at the end if true, otherwise pads at start
+             * @return {string}
+             */
+            function pad(text: string, size: number, ch?: string, end?: boolean): string;
+
+            /**
+             * Pads an array to a specific length by copying the last one element.
+             *
+             * @private
+             * @param {Array} forms Number of forms given to convertPlural
+             * @param {number} count Number of forms required
+             * @return {Array} Padded array of forms
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-preConvertPlural
+             */
+            function preConvertPlural(forms: string[], count: number): string[];
+
+            /**
+             * Replicate a string 'n' times.
+             *
+             * @private
+             * @param {string} str The string to replicate
+             * @param {number} num Number of times to replicate the string
+             * @return {string}
+             */
+            function replicate(str: string, num: number): string;
         }
     }
 }

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -1,10 +1,192 @@
 declare global {
     namespace mw {
+        /**
+         * Client for ResourceLoader server end point.
+         *
+         * This client is in charge of maintaining the module registry and state
+         * machine, initiating network (batch) requests for loading modules, as
+         * well as dependency resolution and execution of source code.
+         *
+         * For more information, refer to
+         * <https://www.mediawiki.org/wiki/ResourceLoader/Features>
+         *
+         * @class mw.loader
+         * @singleton
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader
+         */
         namespace loader {
-            function addStyleTag(text: string, nextNode?: Node): HTMLStyleElement;
+            /**
+             * Create a new style element and add it to the DOM.
+             *
+             * @param {string} text CSS text
+             * @param {Node|null} [nextNode] The element where the style tag
+             *  should be inserted before
+             * @return {HTMLStyleElement} Reference to the created style element
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-addStyleTag
+             */
+            function addStyleTag(text: string, nextNode?: Node | null): HTMLStyleElement;
 
+            /**
+             * Get the names of all registered ResourceLoader modules.
+             *
+             * @member mw.loader
+             * @return {string[]}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getModuleNames
+             */
             function getModuleNames(): string[];
 
+            /**
+             * Load a script by URL.
+             *
+             * Example:
+             *
+             *     mw.loader.getScript(
+             *         'https://example.org/x-1.0.0.js'
+             *     )
+             *         .then( function () {
+             *             // Script succeeded. You can use X now.
+             *         }, function ( e ) {
+             *             // Script failed. X is not avaiable
+             *             mw.log.error( e.message ); // => "Failed to load script"
+             *         } );
+             *     } );
+             *
+             * @member mw.loader
+             * @param {string} url Script URL
+             * @return {JQuery.Promise} Resolved when the script is loaded
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getScript
+             */
+            function getScript(url: string): JQuery.Promise<any>;
+
+            /**
+             * Get the state of a module.
+             *
+             * @param {string} module Name of module
+             * @return {string|null} The state, or null if the module (or its state) is not
+             *  in the registry.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getState
+             */
+            function getState(module: string): string | null;
+
+            /**
+             * Load an external script or one or more modules.
+             *
+             * This method takes a list of unrelated modules. Use cases:
+             *
+             * - A web page will be composed of many different widgets. These widgets independently
+             *   queue their ResourceLoader modules (`OutputPage::addModules()`). If any of them
+             *   have problems, or are no longer known (e.g. cached HTML), the other modules
+             *   should still be loaded.
+             * - This method is used for preloading, which must not throw. Later code that
+             *   calls #using() will handle the error.
+             *
+             * @param {string|Array} modules Either the name of a module, array of modules,
+             *  or a URL of an external script or style
+             * @param {string} [type='text/javascript'] MIME type to use if calling with a URL of an
+             *  external script or style; acceptable values are "text/css" and
+             *  "text/javascript"; if no type is provided, text/javascript is assumed.
+             * @throws {Error} If type is invalid
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-load
+             */
+            function load(modules: string | string[], type?: string): void;
+
+            /**
+             * Register a module, letting the system know about it and its properties.
+             *
+             * The startup module calls this method.
+             *
+             * When using multiple module registration by passing an array, dependencies that
+             * are specified as references to modules within the array will be resolved before
+             * the modules are registered.
+             *
+             * @param {string|Array} modules Module name or array of arrays, each containing
+             *  a list of arguments compatible with this method
+             * @param {string|number} [version] Module version hash (falls backs to empty string)
+             *  Can also be a number (timestamp) for compatibility with MediaWiki 1.25 and earlier.
+             * @param {string[]} [dependencies] Array of module names on which this module depends.
+             * @param {string} [group=null] Group which the module is in
+             * @param {string} [source='local'] Name of the source
+             * @param {string} [skip=null] Script body of the skip function
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-register
+             */
+            function register(
+                modules: string | string[],
+                version?: string | number,
+                dependencies?: string[],
+                group?: string | null,
+                source?: string,
+                skip?: string | null
+            ): void;
+
+            /**
+             * Change the state of one or more modules.
+             *
+             * @param {Object} states Object of module name/state pairs
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-state
+             */
+            function state(states: Record<string, any>): void;
+
+            /**
+             * Execute a function after one or more modules are ready.
+             *
+             * Use this method if you need to dynamically control which modules are loaded
+             * and/or when they loaded (instead of declaring them as dependencies directly
+             * on your module.)
+             *
+             * This uses the same loader as for regular module dependencies. This means
+             * ResourceLoader will not re-download or re-execute a module for the second
+             * time if something else already needed it. And the same browser HTTP cache,
+             * and localStorage are checked before considering to fetch from the network.
+             * And any on-going requests from other dependencies or using() calls are also
+             * automatically re-used.
+             *
+             * Example of inline dependency on OOjs:
+             *
+             *     mw.loader.using( 'oojs', function () {
+             *         OO.compare( [ 1 ], [ 1 ] );
+             *     } );
+             *
+             * Example of inline dependency obtained via `require()`:
+             *
+             *     mw.loader.using( [ 'mediawiki.util' ], function ( require ) {
+             *         var util = require( 'mediawiki.util' );
+             *     } );
+             *
+             * Since MediaWiki 1.23 this returns a promise.
+             *
+             * Since MediaWiki 1.28 the promise is resolved with a `require` function.
+             *
+             * @member mw.loader
+             * @param {string|Array} dependencies Module name or array of modules names the
+             *  callback depends on to be ready before executing
+             * @param {Function} [ready] Callback to execute when all dependencies are ready
+             * @param {Function} [error] Callback to execute if one or more dependencies failed
+             * @return {JQuery.Promise} With a `require` function
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-using
+             */
+            function using(
+                dependencies: string | string[],
+                ready?: (...args: any[]) => any,
+                error?: (...args: any[]) => any
+            ): JQuery.Promise<any>;
+
+            /**
+             * Exposed for testing and debugging only.
+             *
+             * @private
+             * @property {number}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-property-maxQueryLength
+             */
+            const maxQueryLength: number;
+
+            /**
+             * The module registry is exposed as an aid for debugging and inspecting page
+             * state; it is not a public interface for modifying the registry.
+             *
+             * @private
+             * @property {Object}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-property-moduleRegistry
+             */
             const moduleRegistry: Record<
                 string,
                 {
@@ -14,35 +196,296 @@ declare global {
                         exports: any;
                     };
                     packageExports: any;
-                    skip: string | null;
+                    skip: "string" | null;
                     source: string;
-                    state: "registered" | "ready";
+                    state: "error" | "loaded" | "missing" | "registered" | "ready";
                     version: string;
                 }
             >;
 
-            function getScript(url: string): JQuery.Promise<any>;
+            /**
+             * Utility function for execute()
+             *
+             * @private
+             * @param {string} url URL
+             * @param {string} [media] Media attribute
+             * @param {Node|null} [nextNode]
+             * @return {HTMLLinkElement}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html#global-method-addLinkTag
+             */
+            function addLinkTag(
+                url: string,
+                media?: string,
+                nextNode?: Node | null
+            ): HTMLLinkElement;
 
-            function getState(module: string): string | null;
-
-            function load(modules: string | string[], type?: string): void;
-
-            function register(
-                modules: string | string[],
-                version?: string | number,
-                dependencies?: string[],
-                group?: string,
-                source?: string,
-                skip?: string
+            /**
+             * Load and execute a script.
+             *
+             * @private
+             * @param {string} src URL to script, will be used as the src attribute in the script tag
+             * @param {Function} [callback] Callback to run after request resolution
+             * @param {string[]} [modules] List of modules being requested, for state to be marked as error
+             * in case the script fails to load
+             * @return {HTMLScriptElement}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html#mw-loader-method-addScriptTag
+             */
+            function addScriptTag(
+                src: string,
+                callback?: (...args: any[]) => any,
+                modules?: string[]
+            ): HTMLScriptElement;
+            /**
+             * Add one or more modules to the module load queue.
+             *
+             * See also #work().
+             *
+             * @private
+             * @param {string[]} dependencies Array of module names in the registry
+             * @param {Function} [ready] Callback to execute when all dependencies are ready
+             * @param {Function} [error] Callback to execute when any dependency fails
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-enqueue
+             */
+            function enqueue(
+                dependencies: string[],
+                ready?: (...args: any[]) => any,
+                error?: (...args: any[]) => any
             ): void;
 
-            function state(states: any): void;
+            /**
+             * Implement a module given the components that make up the module.
+             *
+             * When #load() or #using() requests one or more modules, the server
+             * response contain calls to this function.
+             *
+             * @param {string} module Name of module and current module version. Formatted
+             *  as '`[name]@[version]`". This version should match the requested version
+             *  (from #batchRequest and #registry). This avoids race conditions (T117587).
+             *  For back-compat with MediaWiki 1.27 and earlier, the version may be omitted.
+             * @param {Function|Array|string|Object} [script] Module code. This can be a function,
+             *  a list of URLs to load via `<script src>`, a string for `domEval()`, or an
+             *  object like {"files": {"foo.js":function, "bar.js": function, ...}, "main": "foo.js"}.
+             *  If an object is provided, the main file will be executed immediately, and the other
+             *  files will only be executed if loaded via require(). If a function or string is
+             *  provided, it will be executed/evaluated immediately. If an array is provided, all
+             *  URLs in the array will be loaded immediately, and executed as soon as they arrive.
+             * @param {Object} [style] Should follow one of the following patterns:
+             *
+             *     { "css": [css, ..] }
+             *     { "url": { <media>: [url, ..] } }
+             *
+             * The reason css strings are not concatenated anymore is T33676. We now check
+             * whether it's safe to extend the stylesheet.
+             *
+             * @private
+             * @param {Object} [messages] List of key/value pairs to be added to mw#messages.
+             * @param {Object} [templates] List of key/value pairs to be added to mw#templates.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-implement
+             */
+            function implement(
+                module: string,
+                script?: any,
+                style?: Record<string, any>,
+                messages?: Record<string, string>,
+                templates?: Record<string, any>
+            ): void;
 
-            function using(
-                dependencies: string[] | string,
-                ready?: (require: (module: string) => any) => any,
-                error?: () => any
-            ): JQuery.Promise<any>;
+            /**
+             * Get the exported value of a module.
+             *
+             * This static method is publicly exposed for debugging purposes
+             * only and must not be used in production code. In production code,
+             * please use the dynamically provided `require()` function instead.
+             *
+             * In case of lazy-loaded modules via mw.loader#using(), the returned
+             * Promise provides the function, see #using() for examples.
+             *
+             * @since 1.27
+             * @private
+             * @param {string} moduleName Module name
+             * @return {any} Exported value
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-require
+             */
+            function require(moduleName: string): any;
+
+            /**
+             * Get names of module that a module depends on, in their proper dependency order.
+             *
+             * @private
+             * @param {string[]} modules Array of string module names
+             * @return {Array} List of dependencies, including 'module'.
+             * @throws {Error} If an unregistered module or a dependency loop is encountered
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-resolve
+             */
+            function resolve(modules: string[]): string[];
+
+            /**
+             * Start loading of all queued module dependencies.
+             *
+             * @private
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-work
+             */
+            function work(): void;
+
+            /**
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store
+             */
+            namespace store {
+                /**
+                 * The localStorage key for the entire module store. The key references
+                 * $wgDBname to prevent clashes between wikis which share a common host.
+                 *
+                 * @property {string}
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-property-key
+                 */
+                const key: string;
+
+                /**
+                 * A string containing various factors by which the module cache should vary.
+                 *
+                 * Defined by ResourceLoader\StartupModule::getStoreVary() in PHP.
+                 *
+                 * @property {string}
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-property-vary
+                 */
+                const vary: string;
+
+                /**
+                 * Queue the name of a module that the next update should consider storing.
+                 *
+                 * @since 1.32
+                 * @param {string} module Module name
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-add
+                 */
+                function add(module: string): void;
+
+                /**
+                 * Clear the entire module store right now.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-clear
+                 */
+                function clear(): void;
+
+                /**
+                 * Retrieve a module from the store and update cache hit stats.
+                 *
+                 * @param {string} module Module name
+                 * @return {string|boolean} Module implementation or false if unavailable
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-get
+                 */
+                function get(module: string): string | boolean;
+
+                /**
+                 * Initialize the store.
+                 *
+                 * Retrieves store from localStorage and (if successfully retrieved) decoding
+                 * the stored JSON value to a plain object.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-init
+                 */
+                function init(): void;
+
+                /**
+                 * Internal helper for init(). Separated for ease of testing.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-load
+                 */
+                function load(): void;
+
+                /**
+                 * Iterate through the module store, removing any item that does not correspond
+                 * (in name and version) to an item in the module registry.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-prune
+                 */
+                function prune(): void;
+
+                /**
+                 * Construct a JSON-serializable object representing the content of the store.
+                 *
+                 * @return {Object} Module store contents.
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-toJSON
+                 */
+                function toJSON(): { items: string; vary: string; asOf: number };
+
+                /**
+                 * Whether the store is in use on this page.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html
+                 */
+                const enabled: boolean | null;
+
+                /**
+                 * The contents of the store, mapping '[name]@[version]' keys
+                 * to module implementations.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html
+                 */
+                const items: any;
+
+                /**
+                 * Names of modules to be stored during the next update.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html
+                 */
+                const queue: string[];
+
+                /**
+                 * Cache hit stats
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html
+                 */
+                const stats: { hits: number; misses: number; expired: number; failed: number };
+
+                /**
+                 * Add the contents of the named module to the in-memory store.
+                 *
+                 * This method does not guarantee that the module will be stored.
+                 * Inspection of the module's meta data and size will ultimately decide that.
+                 *
+                 * This method is considered internal to mw.loader.store and must only
+                 * be called if the store is enabled.
+                 *
+                 * @private
+                 * @param {string} module Module name
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-set
+                 */
+                function set(module: string): void;
+
+                /**
+                 * Request a sync of the in-memory store back to persisted localStorage.
+                 *
+                 * This function debounces updates. The debouncing logic should account
+                 * for the following factors:
+                 *
+                 * - Writing to localStorage is an expensive operation that must not happen
+                 *   during the critical path of initialising and executing module code.
+                 *   Instead, it should happen at a later time after modules have been given
+                 *   time and priority to do their thing first.
+                 *
+                 * - This method is called from mw.loader.store.add(), which will be called
+                 *   hundreds of times on a typical page, including within the same call-stack
+                 *   and eventloop-tick. This is because responses from load.php happen in
+                 *   batches. As such, we want to allow all modules from the same load.php
+                 *   response to be written to disk with a single flush, not many.
+                 *
+                 * - Repeatedly deleting and creating timers is non-trivial.
+                 *
+                 * - localStorage is shared by all pages from the same origin, if multiple
+                 *   pages are loaded with different module sets, the possibility exists that
+                 *   modules saved by one page will be clobbered by another. The impact of
+                 *   this is minor, it merely causes a less efficient cache use, and the
+                 *   problem would be corrected by subsequent page views.
+                 *
+                 * This method is considered internal to mw.loader.store and must only
+                 * be called if the store is enabled.
+                 *
+                 * @private
+                 * @method
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-requestUpdate
+                 */
+                function requestUpdate(): void;
+            }
         }
     }
 }

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -1,15 +1,104 @@
+/**
+ * A wrapper for the HTML5 Storage interface (`localStorage` or `sessionStorage`)
+ * that is safe to call in all browsers.
+ *
+ * @class mw.SafeStorage
+ * @private
+ * @param {Object|undefined} store The Storage instance to wrap around
+ * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage
+ */
 interface SafeStorage {
+    /**
+     * Retrieve value from device storage.
+     *
+     * @param {string} key Key of item to retrieve
+     * @return {string|null|boolean} String value, null if no value exists, or false
+     *  if storage is not available.
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-get
+     */
     get(key: string): string | null | boolean;
 
+    /**
+     * Retrieve JSON object from device storage.
+     *
+     * @param {string} key Key of item to retrieve
+     * @return {Object|null|boolean} Object, null if no value exists or value
+     *  is not JSON-parseable, or false if storage is not available.
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getObject
+     */
     getObject(key: string): any;
 
+    /**
+     * Remove a value from device storage.
+     *
+     * @param {string} key Key of item to remove
+     * @return {boolean} Whether the key was removed
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-remove
+     */
     remove(key: string): boolean;
 
+    /**
+     * Set a value in device storage.
+     *
+     * @param {string} key Key name to store under
+     * @param {string} value Value to be stored
+     * @param {number} [expiry] Number of seconds after which this item can be deleted
+     * @return {boolean} The value was set
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-set
+     */
     set(key: string, value: string, expiry?: number): boolean;
 
+    /**
+     * Set the expiry time for an item in the store
+     *
+     * @param {string} key Key name
+     * @param {number} [expiry] Number of seconds after which this item can be deleted,
+     *  omit to clear the expiry (either making the item never expire, or to clean up
+     *  when deleting a key).
+     * @return {boolean} The expiry was set (or cleared) [since 1.41]
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-setExpires
+     */
     setExpires(key: string, expiry?: number): void;
 
+    /**
+     * Set an object value in device storage by JSON encoding
+     *
+     * @param {string} key Key name to store under
+     * @param {Object} value Object value to be stored
+     * @param {number} [expiry] Number of seconds after which this item can be deleted
+     * @return {boolean} The value was set
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-setObject
+     */
     setObject(key: string, value: any, expiry?: number): boolean;
+
+    /**
+     * Clear any expired items from the store
+     *
+     * @private
+     * @return {JQuery.Promise} Resolves when items have been expired
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-clearExpired
+     */
+    clearExpired(): JQuery.Promise<any>;
+
+    /**
+     * Get all keys with expiry values
+     *
+     * @private
+     * @return {JQuery.Promise} Promise resolving with all the keys which have
+     *  expiry values (unprefixed), or as many could be retrieved in the allocated time.
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getExpiryKeys
+     */
+    getExpiryKeys(): JQuery.Promise<any>;
+
+    /**
+     * Check if a given key has expired
+     *
+     * @private
+     * @param {string} key Key name
+     * @return {boolean} Whether key is expired
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-isExpired
+     */
+    isExpired(key: string): boolean;
 }
 
 interface MwStorage extends SafeStorage {
@@ -18,6 +107,47 @@ interface MwStorage extends SafeStorage {
 
 declare global {
     namespace mw {
+        /**
+         * A safe interface to HTML5 `localStorage`.
+         *
+         * This normalises differences across browsers and silences any and all
+         * exceptions that may occur.
+         *
+         * **Note**: Storage keys are not automatically prefixed in relation to
+         * MediaWiki and/or the current wiki. Always **prefix your keys** with "mw" to
+         * avoid conflicts with gadgets, JavaScript libraries, browser extensions,
+         * internal CDN or webserver cookies, and third-party applications that may
+         * be embedded on the page.
+         *
+         * **Warning**: This API has limited storage space and does not use an expiry
+         * by default. This means unused **keys are stored forever**, unless you
+         * opt-in to the `expiry` parameter or otherwise make sure that your code
+         * can rediscover and delete keys you created in the past.
+         *
+         * If you don't use the `expiry` parameter, avoid keys with variable
+         * components as this leads to untracked keys that your code has no way
+         * to know about and delete when the data is no longer needed. Instead,
+         * store dynamic values in an object under a single constant key that you
+         * manage or replace over time.
+         * See also <https://phabricator.wikimedia.org/T121646>.
+         *
+         * Example:
+         *
+         *     mw.storage.set( key, value, expiry );
+         *     mw.storage.set( key, value ); // stored indefinitely
+         *     mw.storage.get( key );
+         *
+         * Example:
+         *
+         *     var local = require( 'mediawiki.storage' ).local;
+         *     local.set( key, value, expiry );
+         *     local.get( key );
+         *
+         * @class
+         * @singleton
+         * @extends mw.SafeStorage
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.storage
+         */
         const storage: MwStorage;
     }
 }

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -1,47 +1,167 @@
 declare global {
     namespace mw {
         /**
+         * @class mw.user
+         * @singleton
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user
          */
         namespace user {
+            /**
+             * @property {Map}
+             * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
+             */
             // TODO: add types for items in the options map
-            const options: mw.Map;
+            const options: Map;
 
-            const tokens: mw.Map<{
+            /**
+             * @property {Map}
+             * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
+             */
+            const tokens: Map<{
                 csrfToken: string;
                 patrolToken: string;
                 watchToken: string;
             }>;
 
+            /**
+             * Generate a random user session ID.
+             *
+             * This information would potentially be stored in a cookie to identify a user during a
+             * session or series of sessions. Its uniqueness should not be depended on unless the
+             * browser supports the crypto API.
+             *
+             * Known problems with Math.random():
+             * Using the Math.random function we have seen sets
+             * with 1% of non uniques among 200,000 values with Safari providing most of these.
+             * Given the prevalence of Safari in mobile the percentage of duplicates in
+             * mobile usages of this code is probably higher.
+             *
+             * Rationale:
+             * We need about 80 bits to make sure that probability of collision
+             * on 155 billion  is <= 1%
+             *
+             * See https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
+             * n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))
+             *
+             * @return {string} 80 bit integer in hex format, padded
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-generateRandomSessionId
+             */
             function generateRandomSessionId(): string;
 
-            function getPageviewToken(): string;
+            /**
+             * Get the current user's groups
+             *
+             * @param {Function} [callback]
+             * @return {JQuery.Promise}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
+             */
+            function getGroups(callback?: (groups: string[]) => any): JQuery.Promise<string[]>;
 
+            /**
+             * Get the current user's database id
+             *
+             * Not to be confused with #id.
+             *
+             * @return {number} Current user's id, or 0 if user is anonymous
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getId
+             */
             function getId(): number;
 
             /**
              * Get the current user's name
              *
+             * @return {string|null} User name string or null if user is anonymous
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getName
              */
             function getName(): string | null;
 
+            /**
+             * A sticky generateRandomSessionId for the current JS execution context,
+             * cached within this class (also known as a page view token).
+             *
+             * @since 1.32
+             * @return {string} 80 bit integer in hex format, padded
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getPageviewToken
+             */
+            function getPageviewToken(): string;
+
+            /**
+             * Get date user registered, if available
+             *
+             * @return {boolean|null|Date} False for anonymous users, null if data is
+             *  unavailable, or Date for when the user registered.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRegistration
+             */
             function getRegistration(): boolean | null | Date;
 
-            function isAnon(): boolean;
+            /**
+             * Get the current user's rights
+             *
+             * @param {Function} [callback]
+             * @return {JQuery.Promise}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
+             */
+            function getRights(callback?: (rights: string[]) => any): JQuery.Promise<string[]>;
 
-            function sessionId(): string;
-
+            /**
+             * Get the current user's name or the session ID
+             *
+             * Not to be confused with #getId.
+             *
+             * @return {string} User name or random session ID
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-id
+             */
             function id(): string;
 
             /**
-             * Get the current user's groups
+             * Whether the current user is anonymous
              *
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isAnon
              */
-            function getGroups(callback?: (groups: string[]) => any): JQuery.Promise<string[]>;
+            function isAnon(): boolean;
 
-            function getRights(callback?: (rights: string[]) => any): JQuery.Promise<string[]>;
+            /**
+             * Is the user a normal non-temporary registered user?
+             *
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isNamed
+             */
+            function isNamed(): boolean;
+
+            /**
+             * Is the user an autocreated temporary user?
+             *
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isTemp
+             */
+            function isTemp(): boolean;
+
+            /**
+             * Retrieve a random ID, generating it if needed
+             *
+             * This ID is shared across windows, tabs, and page views. It is persisted
+             * for the duration of one browser session (until the browser app is closed),
+             * unless the user evokes a "restore previous session" feature that some browsers have.
+             *
+             * **Note:** Server-side code must never interpret or modify this value.
+             *
+             * @return {string} Random session ID
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-sessionId
+             */
+            function sessionId(): string;
+
+            /**
+             * Get the current user's groups or rights
+             *
+             * @private
+             * @return {JQuery.Promise}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
+             */
+            function getUserInfo(): JQuery.Promise<{
+                groups: string[];
+                rights: string[];
+            }>;
         }
     }
 }

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -1,57 +1,118 @@
 declare global {
     namespace mw {
         /**
-         * Utility library
+         * Utility library provided by the `mediawiki.util` module.
          *
+         * @class mw.util
+         * @singleton
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util
          */
         namespace util {
+            /**
+             * The content wrapper of the skin (e.g. `.mw-body`).
+             *
+             * Populated on document ready. To use this property,
+             * wait for `$.ready` and be sure to have a module dependency on
+             * `mediawiki.util` which will ensure
+             * your document ready handler fires after initialization.
+             *
+             * Because of the lazy-initialised nature of this property,
+             * you're discouraged from using it.
+             *
+             * If you need just the wikipage content (not any of the
+             * extra elements output by the skin), use `$( '#mw-content-text' )`
+             * instead. Or listen to mw.hook#wikipage_content which will
+             * allow your code to re-run when the page changes (e.g. live preview
+             * or re-render after ajax save).
+             *
+             * @property {JQuery}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-property-S-content
+             */
             const $content: JQuery;
 
-            function rawurlencode(str: string): string;
-
-            function escapeIdForAttribute(str: string): string;
-
-            function escapeIdForLink(str: string): string;
-
-            function debounce(
-                delay: number,
-                callback: (...args: any[]) => any
-            ): (...args: any[]) => void;
+            /**
+             * Append a new style block to the head and return the CSSStyleSheet object.
+             *
+             * To access the `<style>` element, reference `sheet.ownerNode`, or call
+             * the mw.loader#addStyleTag method directly.
+             *
+             * This function returns the CSSStyleSheet object for convience with features
+             * that are managed at that level, such as toggling of styles:
+             *
+             *     var sheet = util.addCSS( '.foobar { display: none; }' );
+             *     $( '#myButton' ).click( function () {
+             *         // Toggle the sheet on and off
+             *         sheet.disabled = !sheet.disabled;
+             *     } );
+             *
+             * See also [MDN: CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
+             *
+             * @param {string} text CSS to be appended
+             * @return {CSSStyleSheet} The sheet object
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addCSS
+             */
+            function addCSS(text: string): CSSStyleSheet;
 
             /**
-             * Encode page titles for use in a URL
+             * Add a link to a portlet menu on the page, such as:
              *
-             * We want / and : to be included as literal characters in our title URLs
-             * as they otherwise fatally break the title.
+             * - p-cactions (Content actions),
+             * - p-personal (Personal tools),
+             * - p-navigation (Navigation),
+             * - p-tb (Toolbox).
+             * - p-associated-pages (For namespaces and special page tabs on supported skins)
+             * - p-namespaces (For namespaces on legacy skins)
              *
-             * The others are decoded because we can, it's prettier and matches behaviour
-             * of `wfUrlencode` in PHP.
+             * Additional menus can be discovered through the following code:
+             * ```$('.mw-portlet').toArray().map((el) => el.id);```
              *
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-wikiUrlencode
+             * Menu availability varies by skin, wiki, and current page.
+             *
+             * The first three parameters are required, the others are optional and
+             * may be null. Though providing an id and tooltip is recommended.
+             *
+             * By default, the new link will be added to the end of the menu. To
+             * add the link before an existing item, pass the DOM node or a CSS selector
+             * for that item, e.g. `'#foobar'` or `document.getElementById( 'foobar' )`.
+             *
+             *     mw.util.addPortletLink(
+             *         'p-tb', 'https://www.mediawiki.org/',
+             *         'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
+             *     );
+             *
+             *     var node = mw.util.addPortletLink(
+             *         'p-tb',
+             *         new mw.Title( 'Special:Example' ).getUrl(),
+             *         'Example'
+             *     );
+             *     $( node ).on( 'click', function ( e ) {
+             *         console.log( 'Example' );
+             *         e.preventDefault();
+             *     } );
+             *
+             * Remember that to call this inside a user script, you may have to ensure the
+             * `mediawiki.util` is loaded first:
+             *
+             *     $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
+             *          mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
+             *     } );
+             *
+             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @param {string} href Link URL
+             * @param {string} text Link text
+             * @param {string} [id] ID of the list item, should be unique and preferably have
+             *  the appropriate prefix ('ca-', 'pt-', 'n-' or 't-')
+             * @param {string} [tooltip] Text to show when hovering over the link, without accesskey suffix
+             * @param {string} [accesskey] Access key to activate this link. One character only,
+             *  avoid conflicts with other links. Use `$( '[accesskey=x]' )` in the console to
+             *  see if 'x' is already used.
+             * @param {HTMLElement|JQuery|string} [nextnode] Element that the new item should be added before.
+             *  Must be another item in the same list, it will be ignored otherwise.
+             *  Can be specified as DOM reference, as jQuery object, or as CSS selector string.
+             * @fires util_addPortletLink
+             * @return {HTMLLIElement|null} The added list item, or null if no element was added.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addPortletLink
              */
-            function wikiUrlencode(str: string): string;
-
-            function getUrl(pageName: string, params?: { [param: string]: string }): string;
-
-            function wikiScript(str: string): string;
-
-            function addCSS(text: string): any;
-
-            /**
-             * Grab the URL parameter value for the given parameter.
-             * Returns null if not found.
-             *
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getParamValue
-             */
-            function getParamValue(param: string, url?: string): string;
-
-            function hidePortlet(portletId: string): void;
-
-            function isPortletVisible(portletId: string): boolean;
-
-            function showPortlet(portletId: string): void;
-
             function addPortletLink(
                 portletId: string,
                 href: string,
@@ -59,32 +120,362 @@ declare global {
                 id?: string,
                 tooltip?: string,
                 accesskey?: string,
-                nextnode?: string
-            ): HTMLLIElement;
-
-            function validateEmail(mailtxt: string): boolean;
-
-            function isIPv4Address(address: string, allowBlock?: boolean): boolean;
-
-            function isIPv6Address(address: string, allowBlock?: boolean): boolean;
+                nextnode?: HTMLElement | JQuery | string
+            ): HTMLLIElement | null;
 
             /**
-             * Check whether a string is an IP address
+             * Add content to the subtitle of the skin.
+             *
+             * @param {HTMLElement|string} nodeOrHTMLString
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addSubtitle
+             */
+            function addSubtitle(nodeOrHTMLString: HTMLElement | string): void;
+
+            /**
+             * Clears the entire subtitle if present in the page. Used for refreshing subtitle
+             * after edit with response from parse API.
+             *
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-clearSubtitle
+             */
+            function clearSubtitle(): void;
+
+            /**
+             * Return a function, that, as long as it continues to be invoked, will not
+             * be triggered. The function will be called after it stops being called for
+             * N milliseconds. If `immediate` is passed, trigger the function on the
+             * leading edge, instead of the trailing.
+             *
+             * Ported from Underscore.js 1.5.2, Copyright 2009-2013 Jeremy Ashkenas, DocumentCloud
+             * and Investigative Reporters & Editors, distributed under the MIT license, from
+             * <https://github.com/jashkenas/underscore/blob/1.5.2/underscore.js#L689>.
+             *
+             * @since 1.34
+             * @param {Function} func Function to debounce
+             * @param {number} [wait=0] Wait period in milliseconds
+             * @param {boolean} [immediate] Trigger on leading edge
+             * @return {Function} Debounced function
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-debounce
+             */
+            function debounce<T extends (...args: any[]) => any>(
+                func: T,
+                wait?: number,
+                immediate?: boolean
+            ): T;
+            function debounce<T extends (...args: any[]) => any>(
+                delay: number,
+                callback: (...args: any[]) => any
+            ): T;
+
+            /**
+             * Encode a string as CSS id, for use as HTML id attribute value.
+             *
+             * Analog to `Sanitizer::escapeIdForAttribute()` in PHP.
+             *
+             * @since 1.30
+             * @param {string} str String to encode
+             * @return {string} Encoded string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeIdForAttribute
+             */
+            function escapeIdForAttribute(str: string): string;
+
+            /**
+             * Encode a string as URL fragment, for use as HTML anchor link.
+             *
+             * Analog to `Sanitizer::escapeIdForLink()` in PHP.
+             *
+             * @since 1.30
+             * @param {string} str String to encode
+             * @return {string} Encoded string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeIdForLink
+             */
+            function escapeIdForLink(str: string): string;
+
+            /**
+             * Escape string for safe inclusion in regular expression
+             *
+             * The following characters are escaped:
+             *
+             *     \ { } ( ) | . ? * + - ^ $ [ ]
+             *
+             * @since 1.26; moved to mw.util in 1.34
+             * @param {string} str String to escape
+             * @return {string} Escaped string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeRegExp
+             */
+            function escapeRegExp(str: string): string;
+
+            /**
+             * Get the value for a given URL query parameter.
+             *
+             *     mw.util.getParamValue( 'foo', '/?foo=x' ); // "x"
+             *     mw.util.getParamValue( 'foo', '/?foo=' ); // ""
+             *     mw.util.getParamValue( 'foo', '/' ); // null
+             *
+             * @param {string} param The parameter name.
+             * @param {string} [url=location.href] URL to search through, defaulting to the current browsing location.
+             * @return {string|null} Parameter value, or null if parameter was not found.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getParamValue
+             */
+            function getParamValue(param: string, url?: string): string | null;
+
+            /**
+             * Get the target element from a link hash
+             *
+             * This is the same element as you would get from
+             * document.querySelectorAll(':target'), but can be used on
+             * an arbitrary hash fragment, or after pushState/replaceState
+             * has been used.
+             *
+             * Link fragments can be unencoded, fully encoded or partially
+             * encoded, as defined in the spec.
+             *
+             * We can't just use decodeURI as that assumes the fragment
+             * is fully encoded, and throws an error on a string like '%A',
+             * so we use the percent-decode.
+             *
+             * @param {string} [hash] Hash fragment, without the leading '#'.
+             *  Taken from location.hash if omitted.
+             * @return {HTMLElement|null} Element, if found
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getTargetFromFragment
+             */
+            function getTargetFromFragment(hash?: string): HTMLElement | null;
+
+            /**
+             * Get the URL to a given local wiki page name,
+             *
+             * @param {string|null} [pageName=wgPageName] Page name
+             * @param {Object} [params] A mapping of query parameter names to values,
+             *  e.g. `{ action: 'edit' }`
+             * @return {string} URL, relative to `wgServer`.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getUrl
+             */
+            function getUrl(pageName?: string | null, params?: { [param: string]: string }): string;
+
+            /**
+             * Hide a portlet.
+             *
+             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-hidePortlet
+             */
+            function hidePortlet(portletId: string): void;
+
+            /**
+             * Check whether a string is a valid IP address
              *
              * @since 1.25
+             * @param {string} address String to check
+             * @param {boolean} [allowBlock=false] If a block of IPs should be allowed
+             * @return {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPAddress
              */
             function isIPAddress(address: string, allowBlock?: boolean): boolean;
 
+            /**
+             * Whether a string is a valid IPv4 address or not.
+             *
+             * Based on \Wikimedia\IPUtils::isIPv4 in PHP.
+             *
+             *     // Valid
+             *     mw.util.isIPv4Address( '80.100.20.101' );
+             *     mw.util.isIPv4Address( '192.168.1.101' );
+             *
+             *     // Invalid
+             *     mw.util.isIPv4Address( '192.0.2.0/24' );
+             *     mw.util.isIPv4Address( 'hello' );
+             *
+             * @param {string} address
+             * @param {boolean} [allowBlock=false]
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPv4Address
+             */
+            function isIPv4Address(address: string, allowBlock?: boolean): boolean;
+
+            /**
+             * Whether a string is a valid IPv6 address or not.
+             *
+             * Based on \Wikimedia\IPUtils::isIPv6 in PHP.
+             *
+             *     // Valid
+             *     mw.util.isIPv6Address( '2001:db8:a:0:0:0:0:0' );
+             *     mw.util.isIPv6Address( '2001:db8:a::' );
+             *
+             *     // Invalid
+             *     mw.util.isIPv6Address( '2001:db8:a::/32' );
+             *     mw.util.isIPv6Address( 'hello' );
+             *
+             * @param {string} address
+             * @param {boolean} [allowBlock=false]
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPv6Address
+             */
+            function isIPv6Address(address: string, allowBlock?: boolean): boolean;
+
+            /**
+             * Is a portlet visible?
+             *
+             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isPortletVisible
+             */
+            function isPortletVisible(portletId: string): boolean;
+
+            /**
+             * This functionality has been adapted from MediaWiki\User\TempUser\Pattern::isMatch()
+             *
+             * Checks if the pattern matches the given username
+             *
+             * @param {string} username
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isTemporaryUser
+             */
+            function isTemporaryUser(username: string): boolean;
+
+            /**
+             * Parse the URL of an image uploaded to MediaWiki, or a thumbnail for such an image,
+             * and return the image name, thumbnail size and a template that can be used to resize
+             * the image.
+             *
+             * @param {string} url URL to parse (URL-encoded)
+             * @return {Object|null} URL data, or null if the URL is not a valid MediaWiki
+             *   image/thumbnail URL.
+             * @return {string} return.name File name (same format as Title.getMainText()).
+             * @return {number} [return.width] Thumbnail width, in pixels. Null when the file is not
+             *   a thumbnail.
+             * @return {function(number):string} [return.resizeUrl] A function that takes a width
+             *   parameter and returns a thumbnail URL (URL-encoded) with that width. The width
+             *   parameter must be smaller than the width of the original image (or equal to it; that
+             *   only works if MediaHandler::mustRender returns true for the file). Null when the
+             *   file in the original URL is not a thumbnail.
+             *   On wikis with $wgGenerateThumbnailOnParse set to true, this will fall back to using
+             *   Special:Redirect which is less efficient. Otherwise, it is a direct thumbnail URL.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-parseImageUrl
+             */
             function parseImageUrl(
                 url: string
             ): {
                 name: string;
-                width: number | null;
-                resizeUrl: (w: any) => string;
+                width?: number | null;
+                resizeUrl: (w: number) => string;
             } | null;
 
-            function escapeRegExp(str: string): string;
+            /**
+             * Percent-decode a string, as found in a URL hash fragment
+             *
+             * Implements the percent-decode method as defined in
+             * https://url.spec.whatwg.org/#percent-decode.
+             *
+             * URLSearchParams implements https://url.spec.whatwg.org/#concept-urlencoded-parser
+             * which performs a '+' to ' ' substitution before running percent-decode.
+             *
+             * To get the desired behaviour we percent-encode any '+' in the fragment
+             * to effectively expose the percent-decode implementation.
+             *
+             * @param {string} text Text to decode
+             * @return {string|null} Decoded text, null if decoding failed
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-percentDecodeFragment
+             */
+            function percentDecodeFragment(text: string): string | null;
+
+            /**
+             * This functionality has been adapted from \Wikimedia\IPUtils::prettifyIP()
+             *
+             * Prettify an IP for display to end users.
+             * This will make it more compact and lower-case.
+             *
+             * @param {string} ip IP address in quad or octet form (CIDR or not).
+             * @return {string|null}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-prettifyIP
+             */
+            function prettifyIP(ip: string): string | null;
+
+            /**
+             * Encode the string like PHP's rawurlencode
+             *
+             * @param {string} str String to be encoded.
+             * @return {string} Encoded string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-rawurlencode
+             */
+            function rawurlencode(str: string): string;
+
+            /**
+             * This functionality has been adapted from \Wikimedia\IPUtils::sanitizeIP()
+             *
+             * Convert an IP into a verbose, uppercase, normalized form.
+             * Both IPv4 and IPv6 addresses are trimmed. Additionally,
+             * IPv6 addresses in octet notation are expanded to 8 words;
+             * IPv4 addresses have leading zeros, in each octet, removed.
+             *
+             * @param {string} ip IP address in quad or octet form (CIDR or not).
+             * @return {string|null}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-sanitizeIP
+             */
+            function sanitizeIP(ip: string): string | null;
+
+            /**
+             * Reveal a portlet if it is hidden.
+             *
+             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-showPortlet
+             */
+            function showPortlet(portletId: string): void;
+
+            /**
+             * Return a function, that, when invoked, will only be triggered at most once
+             * during a given window of time. If called again during that window, it will
+             * wait until the window ends and then trigger itself again.
+             *
+             * As it's not knowable to the caller whether the function will actually run
+             * when the wrapper is called, return values from the function are entirely
+             * discarded.
+             *
+             * Ported from OOUI.
+             *
+             * @param {Function} func Function to throttle
+             * @param {number} wait Throttle window length, in milliseconds
+             * @return {Function} Throttled function
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-throttle
+             */
+            function throttle<T extends (...args: any[]) => any>(func: T, wait: number): T;
+
+            /**
+             * Validate a string as representing a valid e-mail address.
+             *
+             * This validation is based on the HTML5 specification.
+             *
+             *     mw.util.validateEmail( "me@example.org" ) === true;
+             *
+             * @param {string} email E-mail address
+             * @return {boolean|null} True if valid, false if invalid, null if `email` was empty.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-validateEmail
+             */
+            function validateEmail(email: string): boolean | null;
+
+            /**
+             * Get URL to a MediaWiki server entry point.
+             *
+             * Similar to `wfScript()` in PHP.
+             *
+             * @since 1.18
+             * @param {string} [str="index"] Name of entry point (e.g. 'index' or 'api')
+             * @return {string} URL to the script file (e.g. `/w/api.php`)
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-wikiScript
+             */
+            function wikiScript(str?: string): string;
+
+            /**
+             * Encode page titles in a way that matches `wfUrlencode` in PHP.
+             *
+             * This is important both for readability and consistency in the user experience,
+             * as well as for caching. If URLs are not formatted in the canonical way, they
+             * may be subject to drastically shorter cache durations and/or miss automatic
+             * purging after edits, thus leading to stale content being served from a
+             * non-canonical URL.
+             *
+             * @param {string} str String to be encoded.
+             * @return {string} Encoded string
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-wikiUrlencode
+             */
+            function wikiUrlencode(str: string): string;
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "types-mediawiki",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "types-mediawiki",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@types/jquery": "^3.5.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "types-mediawiki",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "TypeScript definitions for MediaWiki JS interface",
     "types": "index.d.ts",
     "scripts": {


### PR DESCRIPTION
Update types and doc comments. Adapted from fork https://github.com/AnYiEE/types-mediawiki-renovate. The fork included many functions which incorrectly appeared in JSDuck docs but weren't actually accessible - I've removed them.