### PR TITLE
Add MediaWiki core hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 [![NPM version](https://img.shields.io/npm/v/types-mediawiki.svg)](https://www.npmjs.com/package/types-mediawiki)
 ![Linter](https://github.com/wikimedia-gadgets/types-mediawiki/workflows/Lint/badge.svg)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 # types-mediawiki
 
 TypeScript definitions for MediaWiki JS interface.
 
-This package covers the functions and classes in the `mw` global object, as well a few jQuery plugins used in MediaWiki core. All commonly used parts of the interface are covered but as far as complete coverage is concerned, this is a work in progress.
+This package covers the functions and classes in the `mw` global object, as well some jQuery plugins used in MediaWiki core. All commonly used parts of the interface are covered.
+
+[`@types/jquery`](https://www.npmjs.com/package/@types/jquery) and [`@types/oojs-ui`](https://www.npmjs.com/package/@types/oojs-ui) from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) are included as dependencies, so you don't need to install them separately.
 
 [![Download stats](https://nodei.co/npm/types-mediawiki.png?downloads=true&downloadRank=true)](https://nodei.co/npm/types-mediawiki/)
 
@@ -25,7 +28,7 @@ Edit your project's `tsconfig.json` file so that it includes
 ]
 ```
 
-You should be all set! `mw` will be available in the global scope. There is no need to put any import statements in the TypeScript source files. This package includes [@types/jquery](https://www.npmjs.com/package/@types/jquery) as a dependency, so you don't need to install that separately.
+You should be all set! `mw` will be available in the global scope. There is no need to put any import statements in the TypeScript source files. 
 
 **If you find any errors or have suggestions for more specific typings, please open a PR or file an issue.**
 
@@ -56,11 +59,3 @@ import type { ApiEditPageParams, ApiParseParams } from "types-mediawiki/api_para
 
 Since it is just a type import, it doesn't generate any JavaScript. Hence, such imports can also be used in non-modular applications.
 
-## Types for OOjs & OOUI
-TypeScript definitions of OOjs and OOUI is available on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) and npm as [`@types/oojs`](https://www.npmjs.com/package/@types/oojs) and [`@types/oojs-ui`](https://www.npmjs.com/package/@types/oojs-ui) packages.
-
-## TODO
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-
--   Add doc comments for `mw.Title`, `mw.Uri`, `mw.storage`, `mw.language` and `mw.loader`.
--   Add types for more jQuery plugins.

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -1,168 +1,168 @@
+export interface User {
+    /**
+     * @property {Map}
+     * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
+     */
+    // TODO: add types for items in the options map
+    options: mw.Map;
+
+    /**
+     * @property {mw.Map}
+     * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
+     */
+    tokens: mw.Map<{
+        csrfToken: string;
+        patrolToken: string;
+        watchToken: string;
+    }>;
+
+    /**
+     * Generate a random user session ID.
+     *
+     * This information would potentially be stored in a cookie to identify a user during a
+     * session or series of sessions. Its uniqueness should not be depended on unless the
+     * browser supports the crypto API.
+     *
+     * Known problems with Math.random():
+     * Using the Math.random function we have seen sets
+     * with 1% of non uniques among 200,000 values with Safari providing most of these.
+     * Given the prevalence of Safari in mobile the percentage of duplicates in
+     * mobile usages of this code is probably higher.
+     *
+     * Rationale:
+     * We need about 80 bits to make sure that probability of collision
+     * on 155 billion  is <= 1%
+     *
+     * See https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
+     * n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))
+     *
+     * @return {string} 80 bit integer in hex format, padded
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-generateRandomSessionId
+     */
+    generateRandomSessionId(): string;
+
+    /**
+     * Get the current user's groups
+     *
+     * @param {Function} [callback]
+     * @return {JQuery.Promise}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
+     */
+    getGroups(callback?: (groups: string[]) => any): JQuery.Promise<string[]>;
+
+    /**
+     * Get the current user's database id
+     *
+     * Not to be confused with #id.
+     *
+     * @return {number} Current user's id, or 0 if user is anonymous
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getId
+     */
+    getId(): number;
+
+    /**
+     * Get the current user's name
+     *
+     * @return {string|null} User name string or null if user is anonymous
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getName
+     */
+    getName(): string | null;
+
+    /**
+     * A sticky generateRandomSessionId for the current JS execution context,
+     * cached within this class (also known as a page view token).
+     *
+     * @since 1.32
+     * @return {string} 80 bit integer in hex format, padded
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getPageviewToken
+     */
+    getPageviewToken(): string;
+
+    /**
+     * Get date user registered, if available
+     *
+     * @return {boolean|null|Date} False for anonymous users, null if data is
+     *  unavailable, or Date for when the user registered.
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRegistration
+     */
+    getRegistration(): boolean | null | Date;
+
+    /**
+     * Get the current user's rights
+     *
+     * @param {Function} [callback]
+     * @return {JQuery.Promise}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
+     */
+    getRights(callback?: (rights: string[]) => any): JQuery.Promise<string[]>;
+
+    /**
+     * Get the current user's name or the session ID
+     *
+     * Not to be confused with #getId.
+     *
+     * @return {string} User name or random session ID
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-id
+     */
+    id(): string;
+
+    /**
+     * Whether the current user is anonymous
+     *
+     * @return {boolean}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isAnon
+     */
+    isAnon(): boolean;
+
+    /**
+     * Is the user a normal non-temporary registered user?
+     *
+     * @return {boolean}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isNamed
+     */
+    isNamed(): boolean;
+
+    /**
+     * Is the user an autocreated temporary user?
+     *
+     * @return {boolean}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isTemp
+     */
+    isTemp(): boolean;
+
+    /**
+     * Retrieve a random ID, generating it if needed
+     *
+     * This ID is shared across windows, tabs, and page views. It is persisted
+     * for the duration of one browser session (until the browser app is closed),
+     * unless the user evokes a "restore previous session" feature that some browsers have.
+     *
+     * **Note:** Server-side code must never interpret or modify this value.
+     *
+     * @return {string} Random session ID
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-sessionId
+     */
+    sessionId(): string;
+
+    /**
+     * Get the current user's groups or rights
+     *
+     * @private
+     * @return {JQuery.Promise}
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
+     */
+    getUserInfo(): JQuery.Promise<{
+        groups: string[];
+        rights: string[];
+    }>;
+}
+
 declare global {
     namespace mw {
         /**
-         * @class mw.user
-         * @singleton
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user
          */
-        namespace user {
-            /**
-             * @property {Map}
-             * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
-             */
-            // TODO: add types for items in the options map
-            const options: Map;
-
-            /**
-             * @property {Map}
-             * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
-             */
-            const tokens: Map<{
-                csrfToken: string;
-                patrolToken: string;
-                watchToken: string;
-            }>;
-
-            /**
-             * Generate a random user session ID.
-             *
-             * This information would potentially be stored in a cookie to identify a user during a
-             * session or series of sessions. Its uniqueness should not be depended on unless the
-             * browser supports the crypto API.
-             *
-             * Known problems with Math.random():
-             * Using the Math.random function we have seen sets
-             * with 1% of non uniques among 200,000 values with Safari providing most of these.
-             * Given the prevalence of Safari in mobile the percentage of duplicates in
-             * mobile usages of this code is probably higher.
-             *
-             * Rationale:
-             * We need about 80 bits to make sure that probability of collision
-             * on 155 billion  is <= 1%
-             *
-             * See https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
-             * n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))
-             *
-             * @return {string} 80 bit integer in hex format, padded
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-generateRandomSessionId
-             */
-            function generateRandomSessionId(): string;
-
-            /**
-             * Get the current user's groups
-             *
-             * @param {Function} [callback]
-             * @return {JQuery.Promise}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
-             */
-            function getGroups(callback?: (groups: string[]) => any): JQuery.Promise<string[]>;
-
-            /**
-             * Get the current user's database id
-             *
-             * Not to be confused with #id.
-             *
-             * @return {number} Current user's id, or 0 if user is anonymous
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getId
-             */
-            function getId(): number;
-
-            /**
-             * Get the current user's name
-             *
-             * @return {string|null} User name string or null if user is anonymous
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getName
-             */
-            function getName(): string | null;
-
-            /**
-             * A sticky generateRandomSessionId for the current JS execution context,
-             * cached within this class (also known as a page view token).
-             *
-             * @since 1.32
-             * @return {string} 80 bit integer in hex format, padded
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getPageviewToken
-             */
-            function getPageviewToken(): string;
-
-            /**
-             * Get date user registered, if available
-             *
-             * @return {boolean|null|Date} False for anonymous users, null if data is
-             *  unavailable, or Date for when the user registered.
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRegistration
-             */
-            function getRegistration(): boolean | null | Date;
-
-            /**
-             * Get the current user's rights
-             *
-             * @param {Function} [callback]
-             * @return {JQuery.Promise}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
-             */
-            function getRights(callback?: (rights: string[]) => any): JQuery.Promise<string[]>;
-
-            /**
-             * Get the current user's name or the session ID
-             *
-             * Not to be confused with #getId.
-             *
-             * @return {string} User name or random session ID
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-id
-             */
-            function id(): string;
-
-            /**
-             * Whether the current user is anonymous
-             *
-             * @return {boolean}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isAnon
-             */
-            function isAnon(): boolean;
-
-            /**
-             * Is the user a normal non-temporary registered user?
-             *
-             * @return {boolean}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isNamed
-             */
-            function isNamed(): boolean;
-
-            /**
-             * Is the user an autocreated temporary user?
-             *
-             * @return {boolean}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isTemp
-             */
-            function isTemp(): boolean;
-
-            /**
-             * Retrieve a random ID, generating it if needed
-             *
-             * This ID is shared across windows, tabs, and page views. It is persisted
-             * for the duration of one browser session (until the browser app is closed),
-             * unless the user evokes a "restore previous session" feature that some browsers have.
-             *
-             * **Note:** Server-side code must never interpret or modify this value.
-             *
-             * @return {string} Random session ID
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-sessionId
-             */
-            function sessionId(): string;
-
-            /**
-             * Get the current user's groups or rights
-             *
-             * @private
-             * @return {JQuery.Promise}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
-             */
-            function getUserInfo(): JQuery.Promise<{
-                groups: string[];
-                rights: string[];
-            }>;
-        }
+        const user: User;
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "1.5.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
-                "@types/jquery": "^3.5.5"
+                "@types/jquery": "^3.5.5",
+                "@types/oojs-ui": "^0.46.0"
             },
             "devDependencies": {
                 "dtslint": "^4.0.6",
@@ -112,6 +113,20 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.9.tgz",
             "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q==",
             "dev": true
+        },
+        "node_modules/@types/oojs": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/oojs/-/oojs-7.0.6.tgz",
+            "integrity": "sha512-e6UBEoqJ3bLBvxtPnaFmqkK4HzPwrS3sqfB2dORUmAaShp/T7WhMoYjlwhe+7g748qv7eeX/q4WdOaeeVG2LtA=="
+        },
+        "node_modules/@types/oojs-ui": {
+            "version": "0.46.4",
+            "resolved": "https://registry.npmjs.org/@types/oojs-ui/-/oojs-ui-0.46.4.tgz",
+            "integrity": "sha512-tpQyPjxr6FhMRNaactbjNXkr4uCsKNQMOVNJiAO5AvzxoPddChNZp4gG37Pm80jAeDP11k9ww4durnEjzqqKsQ==",
+            "dependencies": {
+                "@types/jquery": "*",
+                "@types/oojs": "*"
+            }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -3443,6 +3458,20 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.9.tgz",
             "integrity": "sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q==",
             "dev": true
+        },
+        "@types/oojs": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/oojs/-/oojs-7.0.6.tgz",
+            "integrity": "sha512-e6UBEoqJ3bLBvxtPnaFmqkK4HzPwrS3sqfB2dORUmAaShp/T7WhMoYjlwhe+7g748qv7eeX/q4WdOaeeVG2LtA=="
+        },
+        "@types/oojs-ui": {
+            "version": "0.46.4",
+            "resolved": "https://registry.npmjs.org/@types/oojs-ui/-/oojs-ui-0.46.4.tgz",
+            "integrity": "sha512-tpQyPjxr6FhMRNaactbjNXkr4uCsKNQMOVNJiAO5AvzxoPddChNZp4gG37Pm80jAeDP11k9ww4durnEjzqqKsQ==",
+            "requires": {
+                "@types/jquery": "*",
+                "@types/oojs": "*"
+            }
         },
         "@types/parse-json": {
             "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "lint-staged": "^10.5.3",
                 "prettier": "^2.2.1",
                 "tslint-config-prettier": "^1.18.0",
-                "typescript": "^4.1.3"
+                "typescript": "^4.2.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -3078,9 +3078,9 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+            "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -5824,9 +5824,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+            "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
             "dev": true
         },
         "universalify": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     },
     "homepage": "https://github.com/wikimedia-gadgets/types-mediawiki#readme",
     "dependencies": {
-        "@types/jquery": "^3.5.5"
+        "@types/jquery": "^3.5.5",
+        "@types/oojs-ui": "^0.46.0"
     },
     "devDependencies": {
         "dtslint": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "lint-staged": "^10.5.3",
         "prettier": "^2.2.1",
         "tslint-config-prettier": "^1.18.0",
-        "typescript": "^4.1.3"
+        "typescript": "^4.2.2"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
Add definitions and basic documentation for the hooks used in MediaWiki core, as mentioned in https://github.com/wikimedia-gadgets/types-mediawiki/pull/26.

Hook names have been retrieved from a source code search, so there may be some missing, I do not know if there is a full list somewhere.

Notes (on things I'm not sure about):
* Both `apisandbox.formatRequest` and `wikipage.diff.diffTypeSwitch` hooks reference OOUI objects, so it is added as a dependency.
* User data from `mw.user` is used in the `postEdit` hook, so it has been moved into a separate `User` class.