### PR TITLE
Add more jQuery plugins

### DIFF
--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -71,7 +71,7 @@ interface Client {
      *  Defaults to the global `navigator` object.
      * @return {Object} The client object
      */
-    profile(nav?: { userAgent: string; platform: string }): ClientProfile;
+    profile(nav?: Navigator): ClientProfile;
 
     /**
      * Checks the current browser against a support map object.
@@ -113,6 +113,11 @@ interface Client {
      * @return {boolean} The current browser is in the support map
      */
     test(map: any, profile?: ClientProfile, exactMatchOnly?: boolean): boolean;
+}
+
+export interface Navigator {
+    userAgent: string;
+    platform: string;
 }
 
 interface ClientProfile {

--- a/jquery/confirmable.d.ts
+++ b/jquery/confirmable.d.ts
@@ -1,0 +1,100 @@
+declare global {
+    interface JQuery {
+        confirmable: Confirmable;
+    }
+}
+
+interface Confirmable {
+    /**
+     * Enable inline confirmation for given clickable element (like `<a />` or `<button />`).
+     *
+     * An additional inline confirmation step being shown before the default action is carried out on
+     * click.
+     *
+     * Calling `.confirmable( { handler: function () { … } } )` will fire the handler only after the
+     * confirmation step.
+     *
+     * The element will have the `jquery-confirmable-element` class added to it when it's clicked for
+     * the first time, which has `white-space: nowrap;` and `display: inline-block;` defined in CSS.
+     * If the computed values for the element are different when you make it confirmable, you might
+     * encounter unexpected behavior.
+     *
+     * @param {Options} [options]
+     */
+    (options?: Partial<Options>): this;
+
+    /**
+     * Default options. Overridable primarily for internationalisation handling.
+     */
+    defaultOptions: Options;
+
+    handler(event: JQuery.Event, options: Options): void;
+}
+
+interface Options {
+    /**
+     * Optional selector used for jQuery event delegation.
+     */
+    delegate: string | null;
+
+    /**
+     * Events to hook to.
+     */
+    events: string;
+
+    /**
+     * Text to use for interface elements.
+     */
+    i18n: I18N;
+
+    /**
+     * Callback to fire when preparing confirmable buttons. It is fired separately for the 'Yes' and 'No' button.
+     * Receives the button jQuery object as the first parameter and 'yes' or 'no' as the second.
+     */
+    buttonCallback($button: JQuery): JQuery;
+
+    /**
+     * Callback to fire when the action is confirmed (user clicks the 'Yes' button).
+     */
+    handler: ((event: JQuery.Event) => void) | null;
+
+    /**
+     * Callback to fire when preparing confirmable interface.
+     * Receives the interface jQuery object as the only parameter.
+     */
+    wrapperCallback($interface: JQuery): JQuery;
+}
+
+interface I18N {
+    /**
+     * Text to use for the confirmation question.
+     */
+    confirm: string;
+
+    /**
+     * Text to use for the 'No' button.
+     */
+    no: string;
+
+    /**
+     * Title text to use for the 'No' button.
+     */
+    noTitle: string | undefined;
+
+    /**
+     * Word separator to place between the three text messages.
+     */
+    space: string;
+
+    /**
+     * Text to use for the 'Yes' button.
+     */
+    yes: string;
+
+    /**
+     * Title text to use for the 'Yes' button.
+     */
+    yesTitle: string | undefined;
+}
+
+export {};

--- a/jquery/confirmable.d.ts
+++ b/jquery/confirmable.d.ts
@@ -65,6 +65,7 @@ interface Options {
     wrapperCallback($interface: JQuery): JQuery;
 }
 
+// tslint:disable-next-line:interface-name
 interface I18N {
     /**
      * Text to use for the confirmation question.

--- a/jquery/footHovzer.d.ts
+++ b/jquery/footHovzer.d.ts
@@ -11,6 +11,7 @@ declare global {
          * hovzer.update();
          * ```
          *
+         * @private
          * @returns {FootHovzer}
          */
         getFootHovzer(): FootHovzer;

--- a/jquery/footHovzer.d.ts
+++ b/jquery/footHovzer.d.ts
@@ -1,0 +1,32 @@
+declare global {
+    interface JQueryStatic {
+        /**
+         * Utility to stack stuff in an overlay fixed on the bottom of the page.
+         *
+         * Usage:
+         *
+         * ```js
+         * var hovzer = $.getFootHovzer();
+         * hovzer.$.append( $myCollection );
+         * hovzer.update();
+         * ```
+         *
+         * @returns {FootHovzer}
+         */
+        getFootHovzer(): FootHovzer;
+    }
+}
+
+interface FootHovzer {
+    /**
+     * The stack container.
+     */
+    $: JQuery;
+
+    /**
+     * Update dimensions of stack to account for changes in the subtree.
+     */
+    update(): void;
+}
+
+export {};

--- a/jquery/highlightText.d.ts
+++ b/jquery/highlightText.d.ts
@@ -1,0 +1,42 @@
+declare global {
+    interface JQueryStatic {
+        highlightText: HighlightText;
+    }
+
+    interface JQuery {
+        /**
+         * Highlight certain text in current nodes (by wrapping it in `<span class="highlight">...</span>`).
+         *
+         * @param {string} matchString String to match
+         * @param {Options} [options]
+         * @returns {JQuery}
+         */
+        highlightText(matchString: string, options?: Options): this;
+    }
+}
+
+type Method = "prefixHighlight" | "prefixPlusComboHighlight" | "splitAndHighlight";
+
+interface HighlightText {
+    innerHighlight(node: Node, pat: string | RegExp): void;
+
+    prefixHighlight(node: Node, prefix: string): void;
+
+    prefixPlusComboHighlight(node: Node, prefix: string): void;
+
+    splitAndHighlight<T extends Node>(node: T, text: string): T;
+}
+
+interface Options {
+    /**
+     * Method of matching to use, one of:
+     *
+     * - 'splitAndHighlight': Split `matchString` on spaces, then match each word separately.
+     * - 'prefixHighlight': Match `matchString` at the beginning of text only.
+     * - 'prefixPlusComboHighlight': Match `matchString` plus any combining characters at
+     *   the beginning of text only.
+     */
+    method?: Method;
+}
+
+export {};

--- a/jquery/htmlform.d.ts
+++ b/jquery/htmlform.d.ts
@@ -1,0 +1,21 @@
+declare global {
+    interface JQuery {
+        /**
+         * jQuery plugin to fade or snap to visible state.
+         *
+         * @param {boolean} [instantToggle=false]
+         * @returns {JQuery}
+         */
+        goIn(instantToggle?: boolean): this;
+
+        /**
+         * jQuery plugin to fade or snap to hiding state.
+         *
+         * @param {boolean} [instantToggle=false]
+         * @returns {JQuery}
+         */
+        goOut(instantToggle?: boolean): this;
+    }
+}
+
+export {};

--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -4,6 +4,7 @@ import "./client";
 import "./collapsibleTabs";
 import "./colorUtil";
 import "./confirmable";
+import "./footHovzer";
 import "./highlightText";
 import "./lengthLimit";
 import "./makeCollapsible";

--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -6,6 +6,7 @@ import "./colorUtil";
 import "./confirmable";
 import "./footHovzer";
 import "./highlightText";
+import "./htmlform";
 import "./lengthLimit";
 import "./makeCollapsible";
 import "./spinner";

--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -1,6 +1,13 @@
 import "jquery";
 
-import "./textSelection";
-import "./collapsibleTabs";
 import "./client";
+import "./collapsibleTabs";
 import "./colorUtil";
+import "./confirmable";
+import "./highlightText";
+import "./lengthLimit";
+import "./makeCollapsible";
+import "./spinner";
+import "./tablesorter";
+import "./textSelection";
+import "./updateTooltipAccessKeys";

--- a/jquery/lengthLimit.d.ts
+++ b/jquery/lengthLimit.d.ts
@@ -1,0 +1,78 @@
+declare global {
+    interface JQueryStatic {
+        /**
+         * Utility function to trim down a string, based on byteLimit
+         * and given a safe start position. It supports insertion anywhere
+         * in the string, so "foo" to "fobaro" if limit is 4 will result in
+         * "fobo", not "foba". Basically emulating the native maxlength by
+         * reconstructing where the insertion occurred.
+         *
+         * @deprecated Use `require( 'mediawiki.String' ).trimByteLength` instead.
+         * @param {string} safeVal Known value that was previously returned by this
+         * function, if none, pass empty string.
+         * @param {string} newVal New value that may have to be trimmed down.
+         * @param {number} byteLimit Number of bytes the value may be in size.
+         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
+         * @returns {TrimResult}
+         */
+        trimByteLength(
+            safeVal: string,
+            newVal: string,
+            byteLimit: number,
+            filterFunction?: FilterFunction
+        ): TrimResult;
+    }
+
+    interface JQuery {
+        /**
+         * Enforces a byte limit on an input field, assuming UTF-8 encoding, for situations
+         * when, for example, a database field has a byte limit rather than a character limit.
+         * Plugin rationale: Browser has native maxlength for number of characters (technically,
+         * UTF-16 code units), this plugin exists to limit number of bytes instead.
+         *
+         * Can be called with a custom limit (to use that limit instead of the maxlength attribute
+         * value), a filter function (in case the limit should apply to something other than the
+         * exact input value), or both. Order of parameters is important!
+         *
+         * @param {number} [limit] Limit to enforce, fallsback to maxLength-attribute,
+         *  called with fetched value as argument.
+         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
+         * @returns {JQuery}
+         */
+        byteLimit(limit: number, filterFunction?: FilterFunction): this;
+        byteLimit(filterFunction?: FilterFunction): this;
+
+        /**
+         * Enforces a codepoint (character) limit on an input field.
+         *
+         * For unfortunate historical reasons, browsers' native maxlength counts [the number of UTF-16
+         * code units rather than Unicode codepoints] [1], which means that codepoints outside the Basic
+         * Multilingual Plane (e.g. many emojis) count as 2 characters each. This plugin exists to
+         * correct this.
+         *
+         * [1]: https://www.w3.org/TR/html5/sec-forms.html#limiting-user-input-length-the-maxlength-attribute
+         *
+         * Can be called with a custom limit (to use that limit instead of the maxlength attribute
+         * value), a filter function (in case the limit should apply to something other than the
+         * exact input value), or both. Order of parameters is important!
+         *
+         * @param {number} [limit] Limit to enforce, fallsback to maxLength-attribute,
+         *  called with fetched value as argument.
+         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
+         * @returns {JQuery}
+         */
+        codePointLimit(limit: number, filterFunction?: FilterFunction): this;
+        codePointLimit(filterFunction?: FilterFunction): this;
+    }
+}
+
+interface FilterFunction {
+    (str: string): string;
+}
+
+interface TrimResult {
+    newVal: string;
+    trimmed: boolean;
+}
+
+export {};

--- a/jquery/makeCollapsible.d.ts
+++ b/jquery/makeCollapsible.d.ts
@@ -10,7 +10,7 @@ declare global {
          * - The inner content is wrapped in a "div.mw-collapsible-content" (except for tables and lists).
          *
          * @param {Options} [options]
-         * @return {JQuery}
+         * @returns {JQuery}
          */
         makeCollapsible(options?: Options): this;
     }

--- a/jquery/makeCollapsible.d.ts
+++ b/jquery/makeCollapsible.d.ts
@@ -1,0 +1,53 @@
+declare global {
+    interface JQuery {
+        /**
+         * Enable collapsible-functionality on all elements in the collection.
+         *
+         * - Will prevent binding twice to the same element.
+         * - Initial state is expanded by default, this can be overridden by adding class
+         *   "mw-collapsed" to the "mw-collapsible" element.
+         * - Elements made collapsible have jQuery data "mw-made-collapsible" set to true.
+         * - The inner content is wrapped in a "div.mw-collapsible-content" (except for tables and lists).
+         *
+         * @param {Options} [options]
+         * @return {JQuery}
+         */
+        makeCollapsible(options?: Options): this;
+    }
+}
+
+interface Options {
+    /**
+     * Elements to be used as togglers for this collapsible element. By default, if the collapsible
+     * element has an id attribute like 'mw-customcollapsible-XXX', elements with a **class**
+     * of 'mw-customtoggle-XXX' are made togglers for it.
+     */
+    $customTogglers?: JQuery;
+
+    /**
+     * Whether to collapse immediately. By default collapse only if the element has the 'mw-collapsed' class.
+     */
+    collapsed?: boolean;
+
+    /**
+     * Text used for the toggler, when clicking it would collapse the element.
+     * Default: the 'data-collapsetext' attribute of the collapsible element or the content of 'collapsible-collapse' message.
+     */
+    collapseText?: string;
+
+    /**
+     * Text used for the toggler, when clicking it would expand the element.
+     * Default: the 'data-expandtext' attribute of the collapsible element or the content of 'collapsible-expand' message.
+     */
+    expandText?: string;
+
+    /**
+     * Whether to use a "plain mode" when making the element collapsible - that is, hide entire tables
+     * and lists (instead of hiding only all rows but first of tables, and hiding each list item
+     * separately for lists) and don't wrap other elements in div.mw-collapsible-content.
+     * May only be used with custom togglers.
+     */
+    plainMode?: boolean;
+}
+
+export {};

--- a/jquery/spinner.d.ts
+++ b/jquery/spinner.d.ts
@@ -1,0 +1,85 @@
+declare global {
+    interface JQueryStatic {
+        /**
+         * Create a spinner element
+         *
+         * The argument is an object with options used to construct the spinner (see below).
+         *
+         * It is a good practice to keep a reference to the created spinner to be able to remove it
+         * later. Alternatively, one can use the 'id' option and #removeSpinner (but make sure to choose
+         * an id that's unlikely to cause conflicts, e.g. with extensions, gadgets or user scripts).
+         *
+         * CSS classes used:
+         *
+         * - .mw-spinner for every spinner
+         * - .mw-spinner-small / .mw-spinner-large for size
+         * - .mw-spinner-block / .mw-spinner-inline for display types
+         *
+         * @example
+         * ```js
+         * // Create a large spinner reserving all available horizontal space.
+         * var $spinner = $.createSpinner( { size: 'large', type: 'block' } );
+         * // Insert above page content.
+         * $( '#mw-content-text' ).prepend( $spinner );
+         *
+         * // Place a small inline spinner next to the "Save" button
+         * var $spinner = $.createSpinner( { size: 'small', type: 'inline' } );
+         * // Alternatively, just `$.createSpinner();` as these are the default options.
+         * $( '#wpSave' ).after( $spinner );
+         *
+         * // The following two are equivalent:
+         * $.createSpinner( 'magic' );
+         * $.createSpinner( { id: 'magic' } );
+         * ```
+         *
+         * @param {string|Options} [opts] Options. If a string is given, it will be treated as the value
+         *   of the `id` option.
+         * @returns {JQuery}
+         */
+        createSpinner(opts?: string | Options): JQuery;
+
+        /**
+         * Remove a spinner element.
+         *
+         * @param {string} id Id of the spinner, as passed to {@link createSpinner}
+         * @returns {JQuery} The (now detached) spinner element
+         */
+        removeSpinner(id: string): JQuery;
+    }
+
+    interface JQuery {
+        /**
+         * Inject a spinner after each element in the collection
+         *
+         * Inserts spinner as siblings (not children) of the target elements.
+         * Collection contents remain unchanged.
+         *
+         * @param {string|Object} [opts] Options. If a string is given, it will be treated as the value
+         *   of the `id` option.
+         * @returns {JQuery}
+         */
+        injectSpinner(opts?: string | Options): this;
+    }
+}
+
+type Size = "large" | "small";
+type Type = "block" | "inline";
+
+interface Options {
+    /**
+     * If given, spinner will be given an id of "mw-spinner-{id}".
+     */
+    id?: string | undefined;
+
+    /**
+     * 'small' or 'large' for a 20-pixel or 32-pixel spinner.
+     */
+    size?: Size;
+
+    /**
+     * 'inline' or 'block'. Inline creates an inline-block with width and height equal to spinner size. Block is a block-level element with width 100%, height equal to spinner size.
+     */
+    type?: Type;
+}
+
+export {};

--- a/jquery/suggestions.d.ts
+++ b/jquery/suggestions.d.ts
@@ -1,0 +1,168 @@
+declare global {
+    interface JQuery {
+        /**
+         * This plugin provides a generic way to add suggestions to a text box.
+         *
+         * Set options:
+         *
+         * ```js
+         * $( '#textbox' ).suggestions( { option1: value1, option2: value2 } );
+         * $( '#textbox' ).suggestions( option, value );
+         * ```
+         *
+         * Initialize:
+         *
+         * ```js
+         * $( '#textbox' ).suggestions();
+         * ```
+         *
+         * @param {string} property Name of property
+         * @param {any} value Value to set property with
+         * @returns {JQuery}
+         */
+        suggestions<K extends keyof Options<T>, T = any>(property: K, value: Options<T>[K]): this;
+        suggestions<T = any>(options?: Partial<Options<T>>): this;
+    }
+}
+
+type Device = "keyboard" | "mouse";
+type Direction = "auto" | "end" | "left" | "right" | "start";
+
+interface Context<T = any> {
+    config: Options<T>;
+    data: unknown;
+}
+
+interface Options<T = any> {
+    /**
+     * Whether to cache results from a fetch. Defaults to false.
+     */
+    cache: boolean;
+
+    /**
+     * Number of milliseconds to cache results from a fetch. Must be higher than 1. Defaults to 1 minute.
+     */
+    cacheMaxAge: number;
+
+    /**
+     * Callback function to call when any pending asynchronous suggestions fetches. Called in context of the text box.
+     */
+    cancel(this: JQuery): void;
+
+    /**
+     * Number of milliseconds to wait for the user to stop typing. Must be between 0 and 1200. Defaults to 120.
+     */
+    delay: number;
+
+    /**
+     * Which direction to offset the suggestion box from.
+     * Values 'start' and 'end' translate to left and right respectively depending on the directionality
+     * of the current document, according to `$( document.documentElement ).css( 'direction' )`.
+     * Valid values: "left", "right", "start", "end", and "auto". Defaults to auto.
+     */
+    expandFrom: Direction;
+
+    /**
+     * Callback that should fetch suggestions and set the suggestions property. Called in context of the text box.
+     *
+     * @param {string} query
+     * @param {function(string[],any):void} response Callback to receive the suggestions with
+     * @param {number} maxRows
+     */
+    fetch(
+        this: JQuery,
+        query: string,
+        response: (suggestions: string[], metadata: T) => void,
+        maxRows: number
+    ): void;
+
+    /**
+     * Whether to highlight matched portions of the input or not. Defaults to false.
+     */
+    highlightInput: boolean;
+
+    /**
+     * Maximum suggestions box width relative to the textbox width.
+     * If set to e.g. 2, the suggestions box will never be grown beyond 2 times the width of the textbox.
+     * Must be higher than 1. Defaults to 3.
+     */
+    maxExpandFactor: number;
+
+    /**
+     * Maximum number of suggestions to display at one time. Must be between 1 and 100.
+     */
+    maxRows: number;
+
+    /**
+     * Sets `expandFrom=left`, for backwards compatibility.
+     */
+    positionFromLeft: boolean;
+
+    /**
+     * Set of callbacks for rendering and selecting.
+     */
+    result: Partial<ResultOptions<T>>;
+
+    /**
+     * Set of callbacks for rendering and selecting.
+     */
+    special: Partial<SpecialOptions<T>>;
+
+    /**
+     * Whether to submit the form containing the textbox when a suggestion is clicked. Defaults to false.
+     */
+    submitOnClick: boolean;
+
+    /**
+     * Array of suggestions to display.
+     */
+    suggestions: string[];
+
+    /**
+     * Set of callbacks for listening to a change in the text input.
+     */
+    update: Partial<UpdateOptions<T>>;
+
+    /**
+     * The element to place the suggestions below and match width of. Defaults to the element itself.
+     */
+    $region: JQuery;
+}
+
+interface ResultOptions<T = any> {
+    /**
+     * Called in context of the suggestions-result element.
+     */
+    render(this: JQuery, suggestion: string, context: Context<T>): void;
+
+    /**
+     * Called in context of the suggestions-result-current element.
+     */
+    select(this: JQuery, $textbox: JQuery, device: Device): any;
+}
+
+interface SpecialOptions<T = any> {
+    /**
+     * Called in context of the suggestions-special element.
+     */
+    render(this: JQuery, query: string, context: Context<T>): void;
+
+    /**
+     * Called in context of the suggestions-result-current element.
+     */
+    select(this: JQuery, $textbox: JQuery, device: Device): boolean;
+}
+
+interface UpdateOptions<T = any> {
+    /**
+     * Called after results are updated either from the cache or the API as a result of the user input.
+     */
+    after(this: JQuery, metadata: T): void;
+
+    /**
+     * Called right after the user changes the textbox text.
+     */
+    before(this: JQuery): void;
+}
+
+export {};

--- a/jquery/tablesorter.d.ts
+++ b/jquery/tablesorter.d.ts
@@ -19,13 +19,33 @@ declare global {
     }
 }
 
+export interface ParserTypeMap {
+    numeric: number;
+    text: string;
+}
+
+export interface ParserMap {
+    currency: "numeric";
+    date: "numeric";
+    IPAddress: "numeric";
+    number: "numeric";
+    text: "text";
+    time: "numeric";
+    usLongDate: "numeric";
+}
+
 type MultiSortKey = "altKey" | "ctrlKey" | "metaKey" | "shiftKey";
 
-interface Parser {
-    id: string;
-    type: string;
+type ParserFromType<K extends keyof ParserTypeMap> = ParserBase<ParserTypeMap[K], K>;
+type ParserFromKey<K extends keyof ParserMap> = ParserFromType<ParserMap[K]>;
 
-    format(s: string): any;
+type Parser = { [P in keyof ParserTypeMap]: ParserFromType<P> }[keyof ParserTypeMap];
+
+interface ParserBase<T, K extends string = string> {
+    id: string;
+    type: K;
+
+    format(s: string): T;
 
     is(s: string, table: HTMLTableElement): boolean;
 }
@@ -47,6 +67,7 @@ interface TableSorter {
 
     formatInt(s: string): number;
 
+    getParser<K extends keyof ParserMap>(id: K): ParserFromKey<K>;
     getParser(id: string): Parser;
 
     getParsers(): Parser[];

--- a/jquery/tablesorter.d.ts
+++ b/jquery/tablesorter.d.ts
@@ -1,0 +1,115 @@
+declare global {
+    interface JQueryStatic {
+        tablesorter: TableSorter;
+    }
+
+    interface JQuery {
+        /**
+         * Create a sortable table with multi-column sorting capabilities
+         *
+         * ```js
+         * // Create a simple tablesorter interface
+         * $( 'table' ).tablesorter();
+         *
+         * // Create a tablesorter interface, initially sorting on the first and second column
+         * $( 'table' ).tablesorter( { sortList: [ { 0: 'desc' }, { 1: 'asc' } ] } );
+         * ```
+         */
+        tablesorter(this: JQuery<HTMLTableElement>, settings?: Partial<Options>): this;
+    }
+}
+
+type MultiSortKey = "altKey" | "ctrlKey" | "metaKey" | "shiftKey";
+
+interface Parser {
+    id: string;
+    type: string;
+
+    format(s: string): any;
+
+    is(s: string, table: HTMLTableElement): boolean;
+}
+
+interface TableSorter {
+    dateRegex: [];
+    defaultOptions: Options;
+    monthNames: {};
+
+    addParser(parser: Parser): void;
+
+    clearTableBody(table: HTMLTableElement): void;
+
+    construct<T extends JQuery<HTMLTableElement>>($tables: T, settings?: Partial<Options>): T;
+
+    formatDigit(s: string): number;
+
+    formatFloat(s: string): number;
+
+    formatInt(s: string): number;
+
+    getParser(id: string): Parser;
+
+    getParsers(): Parser[];
+}
+
+interface Options {
+    /**
+     * Boolean flag indicating iftablesorter should cancel
+     * selection of the table headers text.
+     * Defaults to true.
+     */
+    cancelSelection: boolean;
+
+    columns: number;
+
+    columnToHeader: number[];
+    /**
+     * A string of the class name to be appended to
+     * sortable tr elements in the thead on a ascending sort.
+     * Defaults to 'headerSortUp'.
+     */
+    cssAsc: string;
+
+    cssChildRow: string;
+
+    /**
+     * A string of the class name to be appended to
+     * sortable tr elements in the thead on a descending sort.
+     * Defaults to 'headerSortDown'.
+     */
+    cssDesc: string;
+
+    /**
+     * A string of the class name to be appended to sortable
+     * tr elements in the thead of the table.
+     * Defaults to 'headerSort'.
+     */
+    cssHeader: string;
+
+    cssInitial: string;
+
+    headerList: HTMLTableCellElement[];
+
+    headerToColumns: number[][];
+
+    parsers: Parser[];
+
+    /**
+     * An array containing objects specifying sorting. By passing more
+     * than one object, multi-sorting will be applied. Object structure:
+     * ```
+     * { <Integer column index>: <String 'asc' or 'desc'> }
+     * ```
+     */
+    sortList: Array<[number, number]>;
+
+    /**
+     * A string of the multi-column sort key.
+     * Defaults to 'shiftKey'.
+     */
+    sortMultiSortKey: MultiSortKey;
+
+    unsortableClass: string;
+}
+
+export {};

--- a/jquery/tablesorter.d.ts
+++ b/jquery/tablesorter.d.ts
@@ -36,12 +36,12 @@ export interface ParserMap {
 
 type MultiSortKey = "altKey" | "ctrlKey" | "metaKey" | "shiftKey";
 
-type ParserFromType<K extends keyof ParserTypeMap> = ParserBase<ParserTypeMap[K], K>;
-type ParserFromKey<K extends keyof ParserMap> = ParserFromType<ParserMap[K]>;
+type ParserFromType<K extends keyof ParserTypeMap> = Parser<ParserTypeMap[K], K>;
+type ParserFromKey<K extends keyof ParserMap> = ParserMap[K] extends keyof ParserTypeMap
+    ? ParserFromType<ParserMap[K]>
+    : Parser;
 
-type Parser = { [P in keyof ParserTypeMap]: ParserFromType<P> }[keyof ParserTypeMap];
-
-interface ParserBase<T, K extends string = string> {
+interface Parser<T = unknown, K extends string = string> {
     id: string;
     type: K;
 
@@ -55,7 +55,7 @@ interface TableSorter {
     defaultOptions: Options;
     monthNames: {};
 
-    addParser(parser: Parser): void;
+    addParser<T = unknown>(parser: Parser<T>): void;
 
     clearTableBody(table: HTMLTableElement): void;
 
@@ -68,7 +68,7 @@ interface TableSorter {
     formatInt(s: string): number;
 
     getParser<K extends keyof ParserMap>(id: K): ParserFromKey<K>;
-    getParser(id: string): Parser;
+    getParser<T = unknown>(id: string): Parser<T>;
 
     getParsers(): Parser[];
 }

--- a/jquery/updateTooltipAccessKeys.d.ts
+++ b/jquery/updateTooltipAccessKeys.d.ts
@@ -1,4 +1,4 @@
-import { Navigator } from "./client";
+import { ClientNavigator } from "./client";
 
 declare global {
     interface JQuery {
@@ -6,7 +6,7 @@ declare global {
     }
 }
 
-type Modifier = "alt" | "alt-shift" | "ctrl" | "ctrl-option";
+type KeyModifier = "alt" | "alt-shift" | "ctrl" | "ctrl-option";
 
 interface TooltipAccessKeys<This = JQuery> {
     /**
@@ -29,10 +29,10 @@ interface TooltipAccessKeys<This = JQuery> {
     getAccessKeyLabel(element: HTMLElement): string;
 
     /**
-     * @param {Navigator} [nav] An object with a 'userAgent' and 'platform' property.
+     * @param {ClientNavigator} [nav] An object with a 'userAgent' and 'platform' property.
      * @returns {string}
      */
-    getAccessKeyPrefix(nav?: Navigator): `${Modifier}-`;
+    getAccessKeyPrefix(nav?: ClientNavigator): `${KeyModifier}-`;
 
     /**
      * Switch test mode on and off.

--- a/jquery/updateTooltipAccessKeys.d.ts
+++ b/jquery/updateTooltipAccessKeys.d.ts
@@ -1,0 +1,45 @@
+import { Navigator } from "./client";
+
+declare global {
+    interface JQuery {
+        updateTooltipAccessKeys: TooltipAccessKeys<this>;
+    }
+}
+
+type Modifier = "alt" | "alt-shift" | "ctrl" | "ctrl-option";
+
+interface TooltipAccessKeys<This = JQuery> {
+    /**
+     * Update the titles for all elements in a jQuery selection.
+     *
+     * @returns {JQuery}
+     */
+    (): This;
+
+    /**
+     * Get the access key label for an element.
+     *
+     * Will use native accessKeyLabel if available (currently only in Firefox 8+),
+     * falls back to #getAccessKeyModifiers.
+     *
+     * @param {HTMLElement} element Element to get the label for
+     * @returns {string} Access key label
+     */
+    // result may be HTMLElement.accessKeyLabel, the format of which depend very much on the browser.
+    getAccessKeyLabel(element: HTMLElement): string;
+
+    /**
+     * @param {Navigator} [nav] An object with a 'userAgent' and 'platform' property.
+     * @returns {string}
+     */
+    getAccessKeyPrefix(nav?: Navigator): `${Modifier}-`;
+
+    /**
+     * Switch test mode on and off.
+     *
+     * @param {boolean} mode New mode
+     */
+    setTestMode(mode: boolean): void;
+}
+
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@types/oojs-ui": "^0.46.0"
             },
             "devDependencies": {
-                "dtslint": "^4.0.6",
+                "dtslint": "^4.1.1",
                 "husky": "^4.3.7",
                 "lint-staged": "^10.5.3",
                 "prettier": "^2.2.1",
@@ -895,9 +895,9 @@
             }
         },
         "node_modules/dtslint": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.8.tgz",
-            "integrity": "sha512-ypMFCfHwWmbELC1xXS3dJ+tPt/iAc6emWpIdavtV7ubsmzc9wVd2joa7RS/3yQ9g9EPBwylIWMSMf/bItS1Dbw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.1.1.tgz",
+            "integrity": "sha512-8SD3My7Cf1OnldIBFIwOPCaIg9PqgRumX0Xf/bbcOop5VG66iwok787DiuoJVhlvInoP5uFr8cBKGFNtwi25Ww==",
             "dev": true,
             "dependencies": {
                 "@definitelytyped/header-parser": "latest",
@@ -4109,9 +4109,9 @@
             }
         },
         "dtslint": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.8.tgz",
-            "integrity": "sha512-ypMFCfHwWmbELC1xXS3dJ+tPt/iAc6emWpIdavtV7ubsmzc9wVd2joa7RS/3yQ9g9EPBwylIWMSMf/bItS1Dbw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.1.1.tgz",
+            "integrity": "sha512-8SD3My7Cf1OnldIBFIwOPCaIg9PqgRumX0Xf/bbcOop5VG66iwok787DiuoJVhlvInoP5uFr8cBKGFNtwi25Ww==",
             "dev": true,
             "requires": {
                 "@definitelytyped/header-parser": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "types-mediawiki",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "types-mediawiki",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@types/jquery": "^3.5.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@types/oojs-ui": "^0.46.0"
     },
     "devDependencies": {
-        "dtslint": "^4.0.6",
+        "dtslint": "^4.1.1",
         "husky": "^4.3.7",
         "lint-staged": "^10.5.3",
         "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "types-mediawiki",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "TypeScript definitions for MediaWiki JS interface",
     "types": "index.d.ts",
     "scripts": {


### PR DESCRIPTION
Add types and doc for other jQuery plugins, based on MediaWiki [1.41](https://doc.wikimedia.org/mediawiki-core/REL1_41/js/#!/api/jQuery), namely:

- `jquery.confirmable`
- `jquery.highlightText`
- `jquery.lengthLimit`
- `jquery.makeCollapsible`
- `jquery.spinner`
- `jquery.suggestions`
- `jquery.tablesorter`
- `footHovzer` plugin from `mediawiki.debug`
- `goIn` and `goOut` plugins from `mediawiki.htmlform`
- `updateTooltipAccessKeys` plugin from `mediawiki.util`

## About `jquery.tablesorter` parsers

Auto-completion for default parsers and parser types is handled via the exported `ParserMap` and `ParserTypeMap` interfaces.
These can be extended to register custom parsers and parser types, for example we can declare:
```ts
import "types-mediawiki/jquery/tablesorter";

declare module "types-mediawiki/jquery/tablesorter" {
    interface ParserTypeMap {
        myParserType: { result: string; };
    }

    interface ParserMap {
        myParser: "myParserType";
    }
}
```
then we get auto-completion and type-checking for using `myParser`:
![image](https://github.com/wikimedia-gadgets/types-mediawiki/assets/28448871/e04d4947-7bfe-4861-9442-1237e82d57d7)
and for declaring non-registered parsers that use `myParserType`:
![image](https://github.com/wikimedia-gadgets/types-mediawiki/assets/28448871/dd83e003-edab-4f44-ac8a-d2544a21861f)