### PR TITLE
Update to 1.41, fix types & cleanup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Edit your project's `tsconfig.json` file so that it includes
 ]
 ```
 
-You should be all set! `mw` will be available in the global scope. There is no need to put any import statements in the TypeScript source files. 
+You should be all set! `mw` will be available in the global scope. There is no need to put any import statements in the TypeScript source files.
 
 **If you find any errors or have suggestions for more specific typings, please open a PR or file an issue.**
 
@@ -58,4 +58,3 @@ import type { ApiEditPageParams, ApiParseParams } from "types-mediawiki/api_para
 ```
 
 Since it is just a type import, it doesn't generate any JavaScript. Hence, such imports can also be used in non-modular applications.
-

--- a/api_params/index.d.ts
+++ b/api_params/index.d.ts
@@ -8,6 +8,30 @@ type password = string;
 type upload = File; // XXX
 type OneOrMore<T> = T | T[];
 
+export type ApiAssert = "anon" | "bot" | "user";
+
+export type ApiTokenType =
+    | "createaccount"
+    | "csrf"
+    | "deleteglobalaccount"
+    | "login"
+    | "patrol"
+    | "rollback"
+    | "setglobalaccountstatus"
+    | "userrights"
+    | "watch";
+
+export type ApiLegacyTokenType =
+    | "block"
+    | "delete"
+    | "edit"
+    | "email"
+    | "import"
+    | "move"
+    | "options"
+    | "protect"
+    | "unblock";
+
 export interface ApiParams {
     action?: string;
     format?: "json" | "jsonfm" | "xml" | "xmlfm" | "php" | "none";

--- a/api_params/index.d.ts
+++ b/api_params/index.d.ts
@@ -1,3 +1,5 @@
+// tslint:disable:no-empty-interface
+
 type timestamp = string;
 type expiry = string;
 type namespace = number;
@@ -32,6 +34,8 @@ export interface ApiParams {
     formatversion?: "1" | "2" | "latest";
 }
 
+export {};
+
 // AUTOMATICALLY GENERATED FROM HERE:
 
 export interface AbuseFilterApiCheckMatchParams extends ApiParams {
@@ -61,7 +65,9 @@ export interface AbuseFilterApiAbuseLogPrivateDetailsParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiAntiSpoofParams extends ApiParams {
+export interface ApiAcquireTempUserNameParams extends ApiParams {}
+
+export interface AntiSpoofApiAntiSpoofParams extends ApiParams {
     username?: string;
 }
 
@@ -86,16 +92,16 @@ export interface ApiBlockParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiBounceHandlerParams extends ApiParams {
+export interface BounceHandlerApiBounceHandlerParams extends ApiParams {
     email?: string;
 }
 
-export interface ApiCategoryTreeParams extends ApiParams {
+export interface CategoryTreeApiCategoryTreeParams extends ApiParams {
     category?: string;
     options?: string;
 }
 
-export interface ApiCentralAuthTokenParams extends ApiParams {}
+export interface CentralAuthApiCentralAuthTokenParams extends ApiParams {}
 
 export interface ApiCentralNoticeCdnCacheUpdateBannerParams extends ApiParams {
     banner?: string;
@@ -113,8 +119,8 @@ export interface ApiCentralNoticeQueryCampaignParams extends ApiParams {
 }
 
 export interface ApiChangeAuthenticationDataParams extends ApiParams {
-    request?: string;
-    token?: string;
+    changeauthrequest?: string;
+    changeauthtoken?: string;
 }
 
 export interface ApiChangeContentModelParams extends ApiParams {
@@ -153,7 +159,9 @@ export interface ApiCheckTokenParams extends ApiParams {
     maxtokenage?: number;
 }
 
-export interface CirrusSearchApiConfigDumpParams extends ApiParams {}
+export interface CirrusSearchApiConfigDumpParams extends ApiParams {
+    prop?: OneOrMore<"globals" | "namespacemap" | "profiles" | "replicagroup" | "usertesting">;
+}
 
 export interface CirrusSearchApiMappingDumpParams extends ApiParams {}
 
@@ -166,13 +174,33 @@ export interface CirrusSearchApiSettingsDumpParams extends ApiParams {}
 export interface ApiClearHasMsgParams extends ApiParams {}
 
 export interface ApiClientLoginParams extends ApiParams {
-    requests?: string | string[];
-    messageformat?: "html" | "none" | "raw" | "wikitext";
-    mergerequestfields?: boolean;
-    preservestate?: boolean;
-    returnurl?: string;
-    continue?: boolean;
-    token?: string;
+    loginrequests?: string | string[];
+    loginmessageformat?: "html" | "none" | "raw" | "wikitext";
+    loginmergerequestfields?: boolean;
+    loginpreservestate?: boolean;
+    loginreturnurl?: string;
+    logincontinue?: boolean;
+    logintoken?: string;
+}
+
+export interface CollectionApiCollectionParams extends ApiParams {
+    submodule?:
+        | "addarticle"
+        | "addcategory"
+        | "addchapter"
+        | "clearcollection"
+        | "getbookcreatorboxcontent"
+        | "getcollection"
+        | "getpopupdata"
+        | "postcollection"
+        | "removearticle"
+        | "removeitem"
+        | "renamechapter"
+        | "setsorting"
+        | "settitles"
+        | "sortitems"
+        | "suggestarticleaction"
+        | "suggestundoarticleaction";
 }
 
 export interface ApiComparePagesParams extends ApiParams {
@@ -252,19 +280,20 @@ export interface ApiComparePagesParams extends ApiParams {
         | "user"
     >;
     slots?: OneOrMore<"main">;
+    difftype?: "inline" | "table" | "unified";
 }
 
 export interface ApiAMCreateAccountParams extends ApiParams {
-    requests?: string | string[];
-    messageformat?: "html" | "none" | "raw" | "wikitext";
-    mergerequestfields?: boolean;
-    preservestate?: boolean;
-    returnurl?: string;
-    continue?: boolean;
-    token?: string;
+    createrequests?: string | string[];
+    createmessageformat?: "html" | "none" | "raw" | "wikitext";
+    createmergerequestfields?: boolean;
+    createpreservestate?: boolean;
+    createreturnurl?: string;
+    createcontinue?: boolean;
+    createtoken?: string;
 }
 
-export interface ApiCreateLocalAccountParams extends ApiParams {
+export interface CentralAuthApiCreateLocalAccountParams extends ApiParams {
     username?: string;
     reason?: string;
     token?: string;
@@ -275,19 +304,14 @@ export interface ApiCSPReportParams extends ApiParams {
     source?: string;
 }
 
-export interface ApiContentTranslationConfigurationParams extends ApiParams {
-    from?: string;
-    to?: string;
-}
-
-export interface ApiContentTranslationDeleteParams extends ApiParams {
+export interface ContentTranslationActionApiContentTranslationDeleteParams extends ApiParams {
     from?: string;
     to?: string;
     sourcetitle?: string;
     token?: string;
 }
 
-export interface ApiContentTranslationPublishParams extends ApiParams {
+export interface ContentTranslationActionApiContentTranslationPublishParams extends ApiParams {
     title?: string;
     html?: string;
     from?: string;
@@ -310,13 +334,14 @@ export interface ContentTranslationActionApiSectionTranslationPublishParams exte
     sourcerevid?: string;
     sourcesectiontitle?: string;
     targetsectiontitle?: string;
-    sectionnumber?: string;
+    sectiontranslationid?: number;
+    issandbox?: boolean;
     captchaid?: string;
     captchaword?: string;
     token?: string;
 }
 
-export interface ApiContentTranslationSaveParams extends ApiParams {
+export interface ContentTranslationActionApiContentTranslationSaveParams extends ApiParams {
     from?: string;
     to?: string;
     sourcetitle?: string;
@@ -330,7 +355,8 @@ export interface ApiContentTranslationSaveParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiContentTranslationSuggestionListParams extends ApiParams {
+export interface ContentTranslationActionApiContentTranslationSuggestionListParams
+    extends ApiParams {
     listname?: string;
     listaction?: "add" | "remove" | "view";
     titles?: string | string[];
@@ -339,7 +365,7 @@ export interface ApiContentTranslationSuggestionListParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiContentTranslationTokenParams extends ApiParams {
+export interface ContentTranslationActionApiContentTranslationTokenParams extends ApiParams {
     token?: string;
 }
 
@@ -348,6 +374,7 @@ export interface ApiDeleteParams extends ApiParams {
     pageid?: number;
     reason?: string;
     tags?: string | string[];
+    deletetalk?: boolean;
     watch?: boolean;
     watchlist?: "nochange" | "preferences" | "unwatch" | "watch";
     watchlistexpiry?: expiry;
@@ -356,33 +383,98 @@ export interface ApiDeleteParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiDeleteGlobalAccountParams extends ApiParams {
+export interface CentralAuthApiDeleteGlobalAccountParams extends ApiParams {
     user?: string;
     reason?: string;
     token?: string;
 }
 
-export interface DiscussionToolsApiDiscussionToolsParams extends ApiParams {
-    paction?: "transcludedfrom";
-    page?: string;
-    oldid?: string;
+export interface DiscussionToolsApiDiscussionToolsCompareParams extends ApiParams {
+    fromtitle?: string;
+    fromrev?: number;
+    totitle?: string;
+    torev?: number;
 }
 
 export interface DiscussionToolsApiDiscussionToolsEditParams extends ApiParams {
     paction?: "addcomment" | "addtopic";
+    autosubscribe?: "default" | "no" | "yes";
     page?: string;
     token?: string;
+    formtoken?: string;
+    commentname?: string;
     commentid?: string;
     wikitext?: string;
     html?: string;
     summary?: string;
     sectiontitle?: string;
+    allownosectiontitle?: boolean;
+    useskin?:
+        | "apioutput"
+        | "cologneblue"
+        | "contenttranslation"
+        | "fallback"
+        | "minerva"
+        | "modern"
+        | "monobook"
+        | "timeless"
+        | "vector"
+        | "vector-2022";
     watchlist?: string;
     captchaid?: string;
     captchaword?: string;
+    nocontent?: string;
+    tags?: string | string[];
+    returnto?: string;
+    returntoquery?: string;
+    returntoanchor?: string;
+    mobileformat?: boolean;
 }
 
-export interface ApiEchoMarkReadParams extends ApiParams {
+export interface DiscussionToolsApiDiscussionToolsFindCommentParams extends ApiParams {
+    idorname?: string;
+    heading?: string;
+    page?: string;
+}
+
+export interface DiscussionToolsApiDiscussionToolsGetSubscriptionsParams extends ApiParams {
+    commentname?: string | string[];
+}
+
+export interface DiscussionToolsApiDiscussionToolsPageInfoParams extends ApiParams {
+    page?: string;
+    oldid?: number;
+    prop?: OneOrMore<"threaditemshtml" | "transcludedfrom">;
+    excludesignatures?: boolean;
+}
+
+export interface DiscussionToolsApiDiscussionToolsPreviewParams extends ApiParams {
+    type?: "reply" | "topic";
+    page?: string;
+    wikitext?: string;
+    sectiontitle?: string;
+    useskin?:
+        | "apioutput"
+        | "cologneblue"
+        | "contenttranslation"
+        | "fallback"
+        | "minerva"
+        | "modern"
+        | "monobook"
+        | "timeless"
+        | "vector"
+        | "vector-2022";
+    mobileformat?: boolean;
+}
+
+export interface DiscussionToolsApiDiscussionToolsSubscribeParams extends ApiParams {
+    page?: string;
+    token?: string;
+    commentname?: string;
+    subscribe?: boolean;
+}
+
+export interface NotificationsApiEchoMarkReadParams extends ApiParams {
     wikis?: string | string[];
     list?: string | string[];
     unreadlist?: string | string[];
@@ -391,19 +483,19 @@ export interface ApiEchoMarkReadParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiEchoMarkSeenParams extends ApiParams {
+export interface NotificationsApiEchoMarkSeenParams extends ApiParams {
     type?: "alert" | "all" | "message";
     timestampFormat?: "ISO_8601" | "MW";
 }
 
-export interface ApiEchoMuteParams extends ApiParams {
+export interface NotificationsApiEchoMuteParams extends ApiParams {
     type?: "page-linked-title" | "user";
     mute?: string | string[];
     unmute?: string | string[];
     token?: string;
 }
 
-export interface EchoPushApiEchoPushSubscriptionsParams extends ApiParams {
+export interface NotificationsPushApiEchoPushSubscriptionsParams extends ApiParams {
     command?: "create" | "delete";
     token?: string;
 }
@@ -460,6 +552,9 @@ export interface ApiEditPageParams extends ApiParams {
         | "unknown"
         | "wikitext";
     token?: string;
+    returnto?: string;
+    returntoquery?: string;
+    returntoanchor?: string;
     captchaword?: string;
     captchaid?: string;
 }
@@ -469,6 +564,8 @@ export interface MediaWikiMassMessageApiEditMassMessageListParams extends ApiPar
     description?: string;
     add?: string | string[];
     remove?: string | string[];
+    minor?: boolean;
+    watchlist?: "nochange" | "preferences" | "unwatch" | "watch";
     token?: string;
 }
 
@@ -496,6 +593,7 @@ export interface ApiExpandTemplatesParams extends ApiParams {
         | "wikitext"
     >;
     includecomments?: boolean;
+    showstrategykeys?: boolean;
     generatexml?: boolean;
     templatesandboxprefix?: string | string[];
     templatesandboxtitle?: string;
@@ -526,9 +624,9 @@ export interface ApiExpandTemplatesParams extends ApiParams {
         | "unknown/unknown";
 }
 
-export interface ApiFancyCaptchaReloadParams extends ApiParams {}
+export interface ConfirmEditFancyCaptchaApiFancyCaptchaReloadParams extends ApiParams {}
 
-export interface ApiFeaturedFeedsParams extends ApiParams {
+export interface FeaturedFeedsApiFeaturedFeedsParams extends ApiParams {
     feedformat?: "atom" | "rss";
     feed?: "featured" | "onthisday" | "potd";
     language?: string;
@@ -564,6 +662,7 @@ export interface ApiFeedRecentChangesParams extends ApiParams {
     hidemyself?: boolean;
     hidecategorization?: boolean;
     tagfilter?: string | string[];
+    inverttags?: boolean;
     target?: string;
     showlinkedto?: boolean;
 }
@@ -602,15 +701,17 @@ export interface ApiFileRevertParams extends ApiParams {
 
 export interface ApiFlagConfigParams extends ApiParams {}
 
-export interface ApiGlobalBlockParams extends ApiParams {
+export interface GlobalBlockingApiGlobalBlockParams extends ApiParams {
     target?: string;
-    expiry?: string;
+    expiry?: expiry;
     unblock?: boolean;
     reason?: string;
     anononly?: boolean;
     modify?: boolean;
     alsolocal?: boolean;
     localblockstalk?: boolean;
+    localblocksemail?: boolean;
+    localanononly?: boolean;
     token?: string;
 }
 
@@ -648,7 +749,7 @@ export interface GlobalPreferencesApiGlobalPreferencesParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiGlobalUserRightsParams extends ApiParams {
+export interface CentralAuthApiGlobalUserRightsParams extends ApiParams {
     user?: string;
     userid?: number;
     add?: OneOrMore<
@@ -667,14 +768,15 @@ export interface ApiGlobalUserRightsParams extends ApiParams {
         | "new-wikis-importer"
         | "oathauth-tester"
         | "ombuds"
-        | "otrs-member"
         | "recursive-export"
         | "staff"
         | "steward"
         | "sysadmin"
-        | "wmf-ops-monitoring"
+        | "vrt-permissions"
+        | "wmf-email-block-override"
         | "wmf-researcher"
     >;
+    expiry?: string | string[];
     remove?: OneOrMore<
         | "abusefilter-helper"
         | "abusefilter-maintainer"
@@ -691,12 +793,12 @@ export interface ApiGlobalUserRightsParams extends ApiParams {
         | "new-wikis-importer"
         | "oathauth-tester"
         | "ombuds"
-        | "otrs-member"
         | "recursive-export"
         | "staff"
         | "steward"
         | "sysadmin"
-        | "wmf-ops-monitoring"
+        | "vrt-permissions"
+        | "wmf-email-block-override"
         | "wmf-researcher"
     >;
     reason?: string;
@@ -704,11 +806,54 @@ export interface ApiGlobalUserRightsParams extends ApiParams {
     tags?: string | string[];
 }
 
-export interface GraphApiGraphParams extends ApiParams {
-    hash?: string;
+export interface GrowthExperimentsApiInvalidateImageRecommendationParams extends ApiParams {
+    tasktype?: "image-recommendation" | "section-image-recommendation";
     title?: string;
-    text?: string;
-    oldid?: number;
+    filename?: string;
+    sectiontitle?: string;
+    sectionnumber?: number;
+    token?: string;
+}
+
+export interface GrowthExperimentsApiInvalidatePersonalizedPraiseSuggestionParams
+    extends ApiParams {
+    mentee?: string;
+    reason?: "praised" | "skipped";
+    skipreason?: "already-praised" | "not-now" | "not-praiseworthy" | "other";
+    token?: string;
+}
+
+export interface GrowthExperimentsApiManageMentorListParams extends ApiParams {
+    geaction?: "add" | "change" | "remove";
+    message?: string;
+    weight?: "0" | "1" | "2" | "4";
+    isaway?: boolean;
+    awaytimestamp?: timestamp;
+    summary?: string;
+    username?: string;
+    token?: string;
+}
+
+export interface GrowthExperimentsApiMentorDashboardUpdateDataParams extends ApiParams {
+    token?: string;
+}
+
+export interface GrowthExperimentsApiSetMenteeStatusParams extends ApiParams {
+    state?: "disabled" | "enabled" | "optout";
+    token?: string;
+}
+
+export interface GrowthExperimentsApiSetMentorParams extends ApiParams {
+    mentee?: string;
+    mentor?: string;
+    reason?: string;
+    token?: string;
+}
+
+export interface GrowthExperimentsApiStarMenteeParams extends ApiParams {
+    gesaction?: "star" | "unstar";
+    gesmentee?: string;
+    token?: string;
 }
 
 export interface ApiHelpParams extends ApiParams {
@@ -717,6 +862,22 @@ export interface ApiHelpParams extends ApiParams {
     recursivesubmodules?: boolean;
     wrap?: boolean;
     toc?: boolean;
+}
+
+export interface GrowthExperimentsApiHelpPanelPostQuestionParams extends ApiParams {
+    body?: string;
+    source?:
+        | "helpdesk"
+        | "helppanel"
+        | "homepage-mentorship"
+        | "mentor-helppanel"
+        | "mentor-homepage";
+    relevanttitle?: string;
+    token?: string;
+}
+
+export interface GrowthExperimentsApiQuestionStoreParams extends ApiParams {
+    storage?: "growthexperiments-helppanel-questions" | "growthexperiments-mentor-questions";
 }
 
 export interface ApiDisabledParams extends ApiParams {}
@@ -772,25 +933,25 @@ export interface ApiFormatJsonParams extends ApiParams {
     formatversion?: "1" | "2" | "latest";
 }
 
-export interface ApiLanguageSearchParams extends ApiParams {
+export interface UniversalLanguageSelectorApiLanguageSearchParams extends ApiParams {
     search?: string;
     typos?: number;
 }
 
 export interface ApiLinkAccountParams extends ApiParams {
-    requests?: string | string[];
-    messageformat?: "html" | "none" | "raw" | "wikitext";
-    mergerequestfields?: boolean;
-    returnurl?: string;
-    continue?: boolean;
-    token?: string;
+    linkrequests?: string | string[];
+    linkmessageformat?: "html" | "none" | "raw" | "wikitext";
+    linkmergerequestfields?: boolean;
+    linkreturnurl?: string;
+    linkcontinue?: boolean;
+    linktoken?: string;
 }
 
 export interface ApiLoginParams extends ApiParams {
-    name?: string;
-    password?: password;
-    domain?: string;
-    token?: string;
+    lgname?: string;
+    lgpassword?: password;
+    lgdomain?: string;
+    lgtoken?: string;
 }
 
 export interface ApiLogoutParams extends ApiParams {
@@ -824,46 +985,6 @@ export interface ApiMergeHistoryParams extends ApiParams {
     token?: string;
 }
 
-export interface MobileFrontendApiMobileViewParams extends ApiParams {
-    page?: string;
-    redirect?: "no" | "yes";
-    sections?: string;
-    prop?: OneOrMore<
-        | "contentmodel"
-        | "description"
-        | "displaytitle"
-        | "editable"
-        | "hasvariants"
-        | "id"
-        | "image"
-        | "languagecount"
-        | "lastmodified"
-        | "lastmodifiedby"
-        | "namespace"
-        | "normalizedtitle"
-        | "pageprops"
-        | "protection"
-        | "revision"
-        | "sections"
-        | "text"
-        | "thumb"
-    >;
-    sectionprop?: OneOrMore<
-        "anchor" | "fromtitle" | "index" | "level" | "line" | "number" | "toclevel"
-    >;
-    pageprops?: string;
-    variant?: string;
-    noheadings?: boolean;
-    notransform?: boolean;
-    onlyrequestedsections?: boolean;
-    offset?: number;
-    maxlen?: number;
-    revision?: number;
-    thumbheight?: number;
-    thumbwidth?: number;
-    thumbsize?: number;
-}
-
 export interface ApiMoveParams extends ApiParams {
     from?: string;
     fromid?: number;
@@ -883,7 +1004,6 @@ export interface ApiFormatNoneParams extends ApiParams {}
 
 export interface OATHAuthApiModuleApiOATHValidateParams extends ApiParams {
     user?: string;
-    totp?: string;
     data?: string;
     token?: string;
 }
@@ -923,6 +1043,7 @@ export interface PageTriageApiPageTriageActionParams extends ApiParams {
     token?: string;
     note?: string;
     skipnotif?: boolean;
+    tags?: string | string[];
 }
 
 export interface PageTriageApiPageTriageListParams extends ApiParams {
@@ -938,6 +1059,7 @@ export interface PageTriageApiPageTriageListParams extends ApiParams {
     show_predicted_issues_none?: boolean;
     show_predicted_issues_copyvio?: boolean;
     showbots?: boolean;
+    showautopatrolled?: boolean;
     showredirs?: boolean;
     showothers?: boolean;
     showreviewed?: boolean;
@@ -975,6 +1097,7 @@ export interface PageTriageApiPageTriageStatsParams extends ApiParams {
     show_predicted_issues_none?: boolean;
     show_predicted_issues_copyvio?: boolean;
     showbots?: boolean;
+    showautopatrolled?: boolean;
     showredirs?: boolean;
     showothers?: boolean;
     showreviewed?: boolean;
@@ -992,19 +1115,18 @@ export interface PageTriageApiPageTriageStatsParams extends ApiParams {
     username?: string;
     date_range_from?: timestamp;
     date_range_to?: timestamp;
-    topreviewers?: string;
 }
 
 export interface PageTriageApiPageTriageTagCopyvioParams extends ApiParams {
     revid?: number;
+    untag?: boolean;
     token?: string;
 }
 
 export interface PageTriageApiPageTriageTaggingParams extends ApiParams {
     pageid?: number;
     token?: string;
-    top?: string;
-    bottom?: string;
+    wikitext?: string;
     deletion?: boolean;
     note?: string;
     taglist?: string | string[];
@@ -1068,7 +1190,6 @@ export interface ApiParamInfoParams extends ApiParams {
         | "gadgetcategories"
         | "gadgets"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "globalallusers"
         | "globalblocks"
         | "globalgroups"
@@ -1076,10 +1197,19 @@ export interface ApiParamInfoParams extends ApiParams {
         | "globalrenamestatus"
         | "globalusage"
         | "globaluserinfo"
+        | "growthimagesuggestiondata"
+        | "growthmenteestatus"
+        | "growthmentorlist"
+        | "growthmentormentee"
+        | "growthmentorstatus"
+        | "growthnextsuggestedtasktype"
+        | "growthstarredmentees"
+        | "growthtasks"
         | "imageinfo"
         | "images"
         | "imageusage"
         | "info"
+        | "isreviewed"
         | "iwbacklinks"
         | "iwlinks"
         | "langbacklinks"
@@ -1092,7 +1222,7 @@ export interface ApiParamInfoParams extends ApiParams {
         | "linterstats"
         | "logevents"
         | "mapdata"
-        | "mmsites"
+        | "mmcontent"
         | "mostviewed"
         | "mystashedfiles"
         | "notifications"
@@ -1183,6 +1313,7 @@ export interface ApiParseParams extends ApiParams {
         | "headitems"
     >;
     wrapoutputclass?: string;
+    parsoid?: boolean;
     pst?: boolean;
     onlypst?: boolean;
     effectivelanglinks?: boolean;
@@ -1192,11 +1323,22 @@ export interface ApiParseParams extends ApiParams {
     disablelimitreport?: boolean;
     disableeditsection?: boolean;
     disablestylededuplication?: boolean;
+    showstrategykeys?: boolean;
     generatexml?: boolean;
     preview?: boolean;
     sectionpreview?: boolean;
     disabletoc?: boolean;
-    useskin?: "minerva" | "modern" | "monobook" | "timeless" | "vector";
+    useskin?:
+        | "apioutput"
+        | "cologneblue"
+        | "contenttranslation"
+        | "fallback"
+        | "minerva"
+        | "modern"
+        | "monobook"
+        | "timeless"
+        | "vector"
+        | "vector-2022";
     contentformat?:
         | "application/json"
         | "application/octet-stream"
@@ -1222,7 +1364,6 @@ export interface ApiParseParams extends ApiParams {
         | "unknown"
         | "wikitext";
     mobileformat?: boolean;
-    mainpage?: boolean;
     templatesandboxprefix?: string | string[];
     templatesandboxtitle?: string;
     templatesandboxtext?: string;
@@ -1250,6 +1391,12 @@ export interface ApiParseParams extends ApiParams {
         | "text/unknown"
         | "text/x-wiki"
         | "unknown/unknown";
+}
+
+export interface ParserMigrationApiParserMigrationParams extends ApiParams {
+    title?: string;
+    config?: OneOrMore<"new" | "old">;
+    redirect?: string;
 }
 
 export interface ApiPatrolParams extends ApiParams {
@@ -1310,7 +1457,6 @@ export interface ApiPurgeParams extends ApiParams {
         | "exturlusage"
         | "fileusage"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "images"
         | "imageusage"
         | "iwbacklinks"
@@ -1334,6 +1480,7 @@ export interface ApiPurgeParams extends ApiParams {
         | "watchlist"
         | "watchlistraw"
         | "wblistentityusage"
+        | "growthtasks"
         | "readinglistentries";
     redirects?: boolean;
     converttitles?: boolean;
@@ -1355,14 +1502,17 @@ export interface ApiQueryParams extends ApiParams {
         | "fileusage"
         | "flagged"
         | "globalusage"
+        | "growthimagesuggestiondata"
         | "imageinfo"
         | "images"
         | "info"
+        | "isreviewed"
         | "iwlinks"
         | "langlinks"
         | "langlinkscount"
         | "links"
         | "linkshere"
+        | "mmcontent"
         | "pageassessments"
         | "pageimages"
         | "pageprops"
@@ -1413,10 +1563,12 @@ export interface ApiQueryParams extends ApiParams {
         | "gadgetcategories"
         | "gadgets"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "globalallusers"
         | "globalblocks"
         | "globalgroups"
+        | "growthmentorlist"
+        | "growthmentormentee"
+        | "growthstarredmentees"
         | "imageusage"
         | "iwbacklinks"
         | "langbacklinks"
@@ -1443,7 +1595,7 @@ export interface ApiQueryParams extends ApiParams {
         | "wblistentityusage"
         | "wikisets"
         | "deletedrevs"
-        | "mmsites"
+        | "growthtasks"
         | "readinglistentries"
     >;
     meta?: OneOrMore<
@@ -1455,6 +1607,8 @@ export interface ApiQueryParams extends ApiParams {
         | "globalpreferences"
         | "globalrenamestatus"
         | "globaluserinfo"
+        | "growthmenteestatus"
+        | "growthmentorstatus"
         | "languageinfo"
         | "linterstats"
         | "notifications"
@@ -1466,6 +1620,7 @@ export interface ApiQueryParams extends ApiParams {
         | "userinfo"
         | "wikibase"
         | "cxdeletedtranslations"
+        | "growthnextsuggestedtasktype"
         | "oath"
         | "readinglists"
     >;
@@ -1500,7 +1655,6 @@ export interface ApiQueryParams extends ApiParams {
         | "exturlusage"
         | "fileusage"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "images"
         | "imageusage"
         | "iwbacklinks"
@@ -1524,6 +1678,7 @@ export interface ApiQueryParams extends ApiParams {
         | "watchlist"
         | "watchlistraw"
         | "wblistentityusage"
+        | "growthtasks"
         | "readinglistentries";
     redirects?: boolean;
     converttitles?: boolean;
@@ -1536,12 +1691,6 @@ export interface ApiFormatJsonParams extends ApiParams {
 export interface ReadingListsApiReadingListsParams extends ApiParams {
     command?: "create" | "createentry" | "delete" | "deleteentry" | "setup" | "teardown" | "update";
     token?: string;
-}
-
-export interface MediaWikiLinterApiRecordLintParams extends ApiParams {
-    data?: string;
-    page?: string;
-    revision?: number;
 }
 
 export interface ApiRemoveAuthenticationDataParams extends ApiParams {
@@ -1559,13 +1708,6 @@ export interface ApiReviewParams extends ApiParams {
     revid?: string;
     comment?: string;
     unapprove?: boolean;
-    token?: string;
-}
-
-export interface ApiReviewActivityParams extends ApiParams {
-    previd?: string;
-    oldid?: string;
-    reviewing?: "0" | "1";
     token?: string;
 }
 
@@ -1600,15 +1742,21 @@ export interface KartographerApiSanitizeMapDataParams extends ApiParams {
     text?: string;
 }
 
-export interface ApiScribuntoConsoleParams extends ApiParams {
+export interface ScribuntoApiScribuntoConsoleParams extends ApiParams {
     title?: string;
     content?: string;
     session?: number;
     question?: string;
     clear?: boolean;
+    token?: string;
 }
 
-export interface ApiSetGlobalAccountStatusParams extends ApiParams {
+export interface SecurePollApiSecurePollAuthParams extends ApiParams {
+    token?: string;
+    id?: number;
+}
+
+export interface CentralAuthApiSetGlobalAccountStatusParams extends ApiParams {
     user?: string;
     locked?: "" | "lock" | "unlock";
     hidden?: "" | "lists" | "suppressed";
@@ -1647,7 +1795,6 @@ export interface ApiSetNotificationTimestampParams extends ApiParams {
         | "exturlusage"
         | "fileusage"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "images"
         | "imageusage"
         | "iwbacklinks"
@@ -1671,6 +1818,7 @@ export interface ApiSetNotificationTimestampParams extends ApiParams {
         | "watchlist"
         | "watchlistraw"
         | "wblistentityusage"
+        | "growthtasks"
         | "readinglistentries";
     redirects?: boolean;
     converttitles?: boolean;
@@ -1681,22 +1829,24 @@ export interface ApiSetPageLanguageParams extends ApiParams {
     title?: string;
     pageid?: number;
     lang?:
+        | "aae"
         | "ab"
         | "abs"
         | "ace"
+        | "acm"
         | "ady"
         | "ady-cyrl"
         | "aeb"
         | "aeb-arab"
         | "aeb-latn"
         | "af"
-        | "ak"
         | "aln"
         | "alt"
         | "am"
         | "ami"
         | "an"
         | "ang"
+        | "ann"
         | "anp"
         | "ar"
         | "arc"
@@ -1721,15 +1871,19 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "bbc"
         | "bbc-latn"
         | "bcc"
+        | "bci"
         | "bcl"
+        | "bdr"
         | "be"
         | "be-tarask"
+        | "bew"
         | "bg"
         | "bgn"
         | "bh"
         | "bho"
         | "bi"
         | "bjn"
+        | "blk"
         | "bm"
         | "bn"
         | "bo"
@@ -1753,21 +1907,27 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ckb"
         | "co"
         | "cps"
+        | "cpx"
+        | "cpx-hans"
+        | "cpx-hant"
         | "cr"
         | "crh"
         | "crh-cyrl"
         | "crh-latn"
+        | "crh-ro"
         | "cs"
         | "csb"
         | "cu"
         | "cv"
         | "cy"
         | "da"
+        | "dag"
         | "de"
         | "de-at"
         | "de-ch"
         | "de-formal"
         | "default"
+        | "dga"
         | "din"
         | "diq"
         | "dsb"
@@ -1776,6 +1936,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "dv"
         | "dz"
         | "ee"
+        | "efi"
         | "egl"
         | "el"
         | "eml"
@@ -1789,11 +1950,13 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "eu"
         | "ext"
         | "fa"
+        | "fat"
         | "ff"
         | "fi"
         | "fit"
         | "fj"
         | "fo"
+        | "fon"
         | "fr"
         | "frc"
         | "frp"
@@ -1801,13 +1964,16 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "fur"
         | "fy"
         | "ga"
+        | "gaa"
         | "gag"
         | "gan"
         | "gan-hans"
         | "gan-hant"
+        | "gcf"
         | "gcr"
         | "gd"
         | "gl"
+        | "gld"
         | "glk"
         | "gn"
         | "gom"
@@ -1815,10 +1981,13 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "gom-latn"
         | "gor"
         | "got"
+        | "gpe"
         | "grc"
         | "gsw"
         | "gu"
         | "guc"
+        | "gur"
+        | "guw"
         | "gv"
         | "ha"
         | "hak"
@@ -1828,9 +1997,11 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "hif"
         | "hif-latn"
         | "hil"
+        | "hno"
         | "hr"
         | "hrx"
         | "hsb"
+        | "hsn"
         | "ht"
         | "hu"
         | "hu-formal"
@@ -1840,6 +2011,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "id"
         | "ie"
         | "ig"
+        | "igl"
         | "ii"
         | "ik"
         | "ike-cans"
@@ -1858,14 +2030,18 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ka"
         | "kaa"
         | "kab"
+        | "kai"
         | "kbd"
         | "kbd-cyrl"
         | "kbp"
         | "kcg"
+        | "kea"
         | "kg"
+        | "kge"
         | "khw"
         | "ki"
         | "kiu"
+        | "kjh"
         | "kjp"
         | "kk"
         | "kk-arab"
@@ -1880,6 +2056,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ko"
         | "ko-kp"
         | "koi"
+        | "kr"
         | "krc"
         | "kri"
         | "krj"
@@ -1888,10 +2065,12 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ks-arab"
         | "ks-deva"
         | "ksh"
+        | "ksw"
         | "ku"
         | "ku-arab"
         | "ku-latn"
         | "kum"
+        | "kus"
         | "kv"
         | "kw"
         | "ky"
@@ -1920,6 +2099,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "lzh"
         | "lzz"
         | "mad"
+        | "mag"
         | "mai"
         | "map-bms"
         | "mdf"
@@ -1930,13 +2110,17 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "mk"
         | "ml"
         | "mn"
+        | "mnc"
+        | "mnc-mong"
         | "mni"
         | "mnw"
         | "mo"
+        | "mos"
         | "mr"
         | "mrh"
         | "mrj"
         | "ms"
+        | "ms-arab"
         | "mt"
         | "mwl"
         | "my"
@@ -1952,18 +2136,25 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ne"
         | "new"
         | "nia"
+        | "nit"
         | "niu"
         | "nl"
         | "nl-informal"
+        | "nmz"
         | "nn"
+        | "nod"
+        | "nog"
         | "nov"
         | "nqo"
         | "nrm"
         | "nso"
         | "nv"
         | "ny"
+        | "nyn"
+        | "nyo"
         | "nys"
         | "oc"
+        | "ojb"
         | "olo"
         | "om"
         | "or"
@@ -1973,6 +2164,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "pam"
         | "pap"
         | "pcd"
+        | "pcm"
         | "pdc"
         | "pdt"
         | "pfl"
@@ -1986,21 +2178,28 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "ps"
         | "pt"
         | "pt-br"
+        | "pwn"
         | "qu"
         | "qug"
         | "rgn"
         | "rif"
+        | "rki"
         | "rm"
+        | "rmc"
         | "rmy"
+        | "rn"
         | "ro"
         | "roa-tara"
+        | "rsk"
         | "ru"
         | "rue"
         | "rup"
         | "ruq"
         | "ruq-cyrl"
         | "ruq-latn"
+        | "rut"
         | "rw"
+        | "ryu"
         | "sa"
         | "sah"
         | "sat"
@@ -2011,16 +2210,23 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "sdc"
         | "sdh"
         | "se"
+        | "se-fi"
+        | "se-no"
+        | "se-se"
         | "sei"
         | "ses"
         | "sg"
         | "sgs"
         | "sh"
+        | "sh-cyrl"
+        | "sh-latn"
         | "shi"
         | "shn"
         | "shy"
         | "shy-latn"
         | "si"
+        | "sjd"
+        | "sje"
         | "sk"
         | "skr"
         | "skr-arab"
@@ -2029,6 +2235,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "sm"
         | "sma"
         | "smn"
+        | "sms"
         | "sn"
         | "so"
         | "sq"
@@ -2036,6 +2243,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "sr-ec"
         | "sr-el"
         | "srn"
+        | "sro"
         | "ss"
         | "st"
         | "stq"
@@ -2043,11 +2251,13 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "su"
         | "sv"
         | "sw"
+        | "syl"
         | "szl"
         | "szy"
         | "ta"
         | "tay"
         | "tcy"
+        | "tdd"
         | "te"
         | "tet"
         | "tg"
@@ -2060,6 +2270,7 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "tly"
         | "tn"
         | "to"
+        | "tok"
         | "tpi"
         | "tr"
         | "tru"
@@ -2068,6 +2279,8 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "tt"
         | "tt-cyrl"
         | "tt-latn"
+        | "ttj"
+        | "tum"
         | "tw"
         | "ty"
         | "tyv"
@@ -2085,20 +2298,28 @@ export interface ApiSetPageLanguageParams extends ApiParams {
         | "vi"
         | "vls"
         | "vmf"
+        | "vmw"
         | "vo"
         | "vot"
         | "vro"
         | "wa"
+        | "wal"
         | "war"
+        | "wls"
         | "wo"
         | "wuu"
+        | "wuu-hans"
+        | "wuu-hant"
         | "xal"
         | "xh"
         | "xmf"
         | "xsy"
         | "yi"
         | "yo"
+        | "yrl"
         | "yue"
+        | "yue-hans"
+        | "yue-hant"
         | "za"
         | "zea"
         | "zgh"
@@ -2117,20 +2338,21 @@ export interface ApiSetPageLanguageParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiShortenUrlParams extends ApiParams {
+export interface UrlShortenerApiShortenUrlParams extends ApiParams {
     url?: string;
+    qrcode?: boolean;
 }
 
 export interface SiteMatrixApiSiteMatrixParams extends ApiParams {
-    type?: OneOrMore<"language" | "special">;
-    state?: OneOrMore<"all" | "closed" | "fishbowl" | "nonglobal" | "private">;
-    langprop?: OneOrMore<"code" | "dir" | "localname" | "name" | "site">;
-    siteprop?: OneOrMore<"code" | "dbname" | "lang" | "sitename" | "url">;
-    limit?: limit;
-    continue?: string;
+    smtype?: OneOrMore<"language" | "special">;
+    smstate?: OneOrMore<"all" | "closed" | "fishbowl" | "nonglobal" | "private">;
+    smlangprop?: OneOrMore<"code" | "dir" | "localname" | "name" | "site">;
+    smsiteprop?: OneOrMore<"code" | "dbname" | "lang" | "sitename" | "url">;
+    smlimit?: limit;
+    smcontinue?: string;
 }
 
-export interface ApiSpamBlacklistParams extends ApiParams {
+export interface SpamBlacklistApiSpamBlacklistParams extends ApiParams {
     url?: string | string[];
 }
 
@@ -2138,8 +2360,6 @@ export interface ApiStabilizeProtectParams extends ApiParams {
     protectlevel?: "autoconfirmed" | "none";
     expiry?: string;
     reason?: string;
-    watch?: string;
-    watchlist?: "nochange" | "preferences" | "unwatch" | "watch";
     title?: string;
     token?: string;
 }
@@ -2192,27 +2412,58 @@ export interface SecurePollApiStrikeVoteParams extends ApiParams {
     token?: string;
 }
 
+export interface ContentTranslationActionApiSectionTranslationDeleteParams extends ApiParams {
+    sectiontranslationid?: number;
+    translationid?: number;
+    sectionid?: string;
+    token?: string;
+}
+
+export interface ContentTranslationActionApiSectionTranslationSaveParams extends ApiParams {
+    sourcelanguage?: string;
+    targetlanguage?: string;
+    sourcetitle?: string;
+    targettitle?: string;
+    content?: string;
+    sourcerevision?: number;
+    sourcesectiontitle?: string;
+    targetsectiontitle?: string;
+    sectionid?: string;
+    issandbox?: boolean;
+    progress?: string;
+    token?: string;
+}
+
 export interface ApiTagParams extends ApiParams {
     rcid?: number | number[];
     revid?: number | number[];
     logid?: number | number[];
     add?: OneOrMore<
         | "AWB"
-        | "Image up for deletion on Commons"
-        | "Manual revert"
+        | "AntiVandal script"
+        | "Deputy"
+        | "Newcomer task"
         | "ProveIt edit"
         | "RedWarn"
         | "STiki"
+        | "Single use"
+        | "Ultraviolet"
         | "WPCleaner"
         | "WikiLoop Battlefield"
         | "bot trial"
-        | "discretionary"
+        | "convenient-discussions"
         | "editProtectedHelper"
+        | "fixed lint errors"
         | "huggle"
         | "large non-free file"
+        | "moveToDraft"
+        | "new user moving page out of userspace"
         | "possible birth or death date change"
+        | "pronoun-change"
         | "self-published-blog"
         | "self-published source"
+        | "shortdesc helper"
+        | "talk banner shell conversion"
         | "twinkle"
     >;
     remove?: string | string[];
@@ -2221,7 +2472,7 @@ export interface ApiTagParams extends ApiParams {
     token?: string;
 }
 
-export interface ApiTemplateDataParams extends ApiParams {
+export interface TemplateDataApiTemplateDataParams extends ApiParams {
     includeMissingTitles?: boolean;
     doNotIgnoreMissingTitles?: boolean;
     lang?: string;
@@ -2249,7 +2500,6 @@ export interface ApiTemplateDataParams extends ApiParams {
         | "exturlusage"
         | "fileusage"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "images"
         | "imageusage"
         | "iwbacklinks"
@@ -2273,65 +2523,47 @@ export interface ApiTemplateDataParams extends ApiParams {
         | "watchlist"
         | "watchlistraw"
         | "wblistentityusage"
+        | "growthtasks"
         | "readinglistentries";
     redirects?: boolean;
     converttitles?: boolean;
 }
 
-export interface ApiCoreThankParams extends ApiParams {
+export interface ThanksApiCoreThankParams extends ApiParams {
     rev?: number;
     log?: number;
     token?: string;
     source?: string;
 }
 
-export interface ApiTimedTextParams extends ApiParams {
+export interface MediaWikiTimedMediaHandlerApiTimedTextParams extends ApiParams {
     title?: string;
     pageid?: number;
     trackformat?: "srt" | "vtt";
     lang?: string;
 }
 
-export interface ApiQueryTitleBlacklistParams extends ApiParams {
-    title?: string;
-    action?: "create" | "createpage" | "createtalk" | "edit" | "move" | "new-account" | "upload";
-    nooverride?: boolean;
+export interface TitleBlacklistApiTitleBlacklistParams extends ApiParams {
+    tbtitle?: string;
+    tbaction?: "create" | "createpage" | "createtalk" | "edit" | "move" | "new-account" | "upload";
+    tbnooverride?: boolean;
 }
 
-export interface ApiTokensParams extends ApiParams {
-    type?: OneOrMore<
-        | "block"
-        | "createaccount"
-        | "csrf"
-        | "delete"
-        | "deleteglobalaccount"
-        | "edit"
-        | "email"
-        | "import"
-        | "login"
-        | "move"
-        | "options"
-        | "patrol"
-        | "protect"
-        | "rollback"
-        | "setglobalaccountstatus"
-        | "unblock"
-        | "userrights"
-        | "watch"
-    >;
+export interface TorBlockApiTorBlockParams extends ApiParams {
+    ip?: string;
 }
 
-export interface ApiTranscodeResetParams extends ApiParams {
+export interface MediaWikiTimedMediaHandlerApiTranscodeResetParams extends ApiParams {
     title?: string;
     transcodekey?: string;
     token?: string;
 }
 
-export interface ApiULSLocalizationParams extends ApiParams {
+export interface UniversalLanguageSelectorApiULSLocalizationParams extends ApiParams {
     language?: string;
 }
 
-export interface ApiULSSetLanguageParams extends ApiParams {
+export interface UniversalLanguageSelectorApiULSSetLanguageParams extends ApiParams {
     languagecode?: string;
     token?: string;
 }
@@ -2342,6 +2574,8 @@ export interface ApiUnblockParams extends ApiParams {
     userid?: number;
     reason?: string;
     tags?: string | string[];
+    watchuser?: boolean;
+    watchlistexpiry?: expiry;
     token?: string;
 }
 
@@ -2351,6 +2585,7 @@ export interface ApiUndeleteParams extends ApiParams {
     tags?: string | string[];
     timestamps?: timestamp | timestamp[];
     fileids?: number | number[];
+    undeletetalk?: boolean;
     watchlist?: "nochange" | "preferences" | "unwatch" | "watch";
     watchlistexpiry?: expiry;
     token?: string;
@@ -2405,12 +2640,14 @@ export interface ApiUserrightsParams extends ApiParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
@@ -2435,12 +2672,14 @@ export interface ApiUserrightsParams extends ApiParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
@@ -2448,6 +2687,8 @@ export interface ApiUserrightsParams extends ApiParams {
     reason?: string;
     token?: string;
     tags?: string | string[];
+    watchuser?: boolean;
+    watchlistexpiry?: expiry;
 }
 
 export interface ApiValidatePasswordParams extends ApiParams {
@@ -2457,31 +2698,31 @@ export interface ApiValidatePasswordParams extends ApiParams {
     realname?: string;
 }
 
-export interface ApiVisualEditorParams extends ApiParams {
+export interface VisualEditorApiVisualEditorParams extends ApiParams {
     page?: string;
     badetag?: string;
     format?: "json" | "jsonfm";
-    paction?: "metadata" | "parse" | "parsedoc" | "parsefragment" | "templatesused" | "wikitext";
+    paction?: "metadata" | "parse" | "parsefragment" | "templatesused" | "wikitext";
     wikitext?: string;
     section?: string;
-    stash?: string;
-    oldid?: string;
+    stash?: boolean;
+    oldid?: number;
     editintro?: string;
     pst?: boolean;
     preload?: string;
     preloadparams?: string | string[];
 }
 
-export interface ApiVisualEditorEditParams extends ApiParams {
+export interface VisualEditorApiVisualEditorEditParams extends ApiParams {
     paction?: "diff" | "save" | "serialize" | "serializeforcache";
     page?: string;
     token?: string;
     wikitext?: string;
     section?: string;
     sectiontitle?: string;
-    basetimestamp?: string;
-    starttimestamp?: string;
-    oldid?: string;
+    basetimestamp?: timestamp;
+    starttimestamp?: timestamp;
+    oldid?: number;
     minor?: string;
     watchlist?: string;
     html?: string;
@@ -2490,7 +2731,24 @@ export interface ApiVisualEditorEditParams extends ApiParams {
     captchaid?: string;
     captchaword?: string;
     cachekey?: string;
+    nocontent?: boolean;
+    returnto?: string;
+    returntoquery?: string;
+    returntoanchor?: string;
+    useskin?:
+        | "apioutput"
+        | "cologneblue"
+        | "contenttranslation"
+        | "fallback"
+        | "minerva"
+        | "modern"
+        | "monobook"
+        | "timeless"
+        | "vector"
+        | "vector-2022";
     tags?: string | string[];
+    plugins?: string | string[];
+    mobileformat?: boolean;
 }
 
 export interface ApiWatchParams extends ApiParams {
@@ -2522,7 +2780,6 @@ export interface ApiWatchParams extends ApiParams {
         | "exturlusage"
         | "fileusage"
         | "geosearch"
-        | "gettingstartedgetpages"
         | "images"
         | "imageusage"
         | "iwbacklinks"
@@ -2546,6 +2803,7 @@ export interface ApiWatchParams extends ApiParams {
         | "watchlist"
         | "watchlistraw"
         | "wblistentityusage"
+        | "growthtasks"
         | "readinglistentries";
     redirects?: boolean;
     converttitles?: boolean;
@@ -2555,8 +2813,7 @@ export interface ApiWatchParams extends ApiParams {
 export interface MobileFrontendApiWebappManifestParams extends ApiParams {}
 
 export interface WebAuthnApiWebAuthnParams extends ApiParams {
-    func?: string;
-    data?: string;
+    func?: "getAuthInfo" | "getRegisterInfo";
 }
 
 export interface WikiLoveApiWikiLoveParams extends ApiParams {
@@ -2568,6 +2825,12 @@ export interface WikiLoveApiWikiLoveParams extends ApiParams {
     type?: string;
     email?: string;
     tags?: string | string[];
+}
+
+export interface WikimediaEventsApiWikimediaEventsBlockedEditParams extends ApiParams {
+    page?: string;
+    interface?: "discussiontools" | "mobilefrontend" | "other" | "visualeditor" | "wikieditor";
+    platform?: "desktop" | "mobile";
 }
 
 export interface ApiFormatXmlParams extends ApiParams {
@@ -2773,15 +3036,15 @@ export interface ApiQueryAllPagesParams extends ApiQueryParams {
     apprefix?: string;
     apnamespace?: namespace;
     apfilterredir?: "all" | "nonredirects" | "redirects";
+    apfilterlanglinks?: "all" | "withlanglinks" | "withoutlanglinks";
     apminsize?: number;
     apmaxsize?: number;
     apprtype?: OneOrMore<"edit" | "move" | "upload">;
     apprlevel?: OneOrMore<"" | "autoconfirmed" | "extendedconfirmed" | "sysop" | "templateeditor">;
     apprfiltercascade?: "all" | "cascading" | "noncascading";
+    apprexpiry?: "all" | "definite" | "indefinite";
     aplimit?: limit;
     apdir?: "ascending" | "descending";
-    apfilterlanglinks?: "all" | "withlanglinks" | "withoutlanglinks";
-    apprexpiry?: "all" | "definite" | "indefinite";
 }
 
 export interface ApiQueryAllLinksParams extends ApiQueryParams {
@@ -2882,12 +3145,14 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
@@ -2911,23 +3176,27 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
     >;
     aurights?: OneOrMore<
+        | "abusefilter-bypass-blocked-external-domains"
         | "abusefilter-hidden-log"
         | "abusefilter-hide-log"
         | "abusefilter-log"
         | "abusefilter-log-detail"
         | "abusefilter-log-private"
         | "abusefilter-modify"
+        | "abusefilter-modify-blocked-external-domains"
         | "abusefilter-modify-global"
         | "abusefilter-modify-restricted"
         | "abusefilter-privatedetails"
@@ -2942,6 +3211,8 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "autopatrol"
         | "autoreview"
         | "autoreviewrestore"
+        | "badcaptcha"
+        | "badoath"
         | "bigdelete"
         | "block"
         | "blockemail"
@@ -2950,15 +3221,19 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "centralauth-createlocal"
         | "centralauth-lock"
         | "centralauth-merge"
-        | "centralauth-oversight"
         | "centralauth-rename"
+        | "centralauth-suppress"
         | "centralauth-unmerge"
-        | "centralauth-usermerge"
+        | "changeemail"
         | "changetags"
         | "checkuser"
         | "checkuser-log"
+        | "checkuser-temporary-account"
+        | "checkuser-temporary-account-log"
+        | "checkuser-temporary-account-no-preference"
         | "collectionsaveascommunitypage"
         | "collectionsaveasuserpage"
+        | "confirmemail"
         | "createaccount"
         | "createpage"
         | "createpagemainns"
@@ -2971,6 +3246,7 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "deletelogentry"
         | "deleterevision"
         | "edit"
+        | "editautopatrolprotected"
         | "editautoreviewprotected"
         | "editcontentmodel"
         | "editeditorprotected"
@@ -2988,9 +3264,11 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "editsitecss"
         | "editsitejs"
         | "editsitejson"
+        | "edittrustedprotected"
         | "editusercss"
         | "edituserjs"
         | "edituserjson"
+        | "enrollasmentor"
         | "extendedconfirmed"
         | "flow-create-board"
         | "flow-delete"
@@ -2998,19 +3276,27 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "flow-hide"
         | "flow-suppress"
         | "gadgets-definition-edit"
-        | "gadgets-edit"
         | "globalblock"
         | "globalblock-exempt"
         | "globalblock-whitelist"
         | "globalgroupmembership"
         | "globalgrouppermissions"
-        | "gwtoolset"
+        | "growthexperiments-apiqueryimagesuggestiondata"
+        | "growthexperimentsuserimpacthandler"
+        | "growthmentordashboardupdatedata"
         | "hideuser"
         | "import"
         | "importupload"
         | "ipblock-exempt"
+        | "ipinfo"
+        | "ipinfo-view-basic"
+        | "ipinfo-view-full"
+        | "ipinfo-view-log"
+        | "linkpurge"
+        | "mailpassword"
         | "manage-all-push-subscriptions"
         | "managechangetags"
+        | "managementors"
         | "markbotedits"
         | "massmessage"
         | "mergehistory"
@@ -3044,30 +3330,40 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "override-export-depth"
         | "pagelang"
         | "pagetriage-copyvio"
+        | "pagetriage-mark-action"
+        | "pagetriage-tagging-action"
         | "patrol"
         | "patrolmarks"
         | "protect"
         | "purge"
         | "read"
         | "renameuser"
+        | "renderfile"
+        | "renderfile-nonstandard"
         | "reupload"
         | "reupload-own"
         | "reupload-shared"
         | "review"
         | "rollback"
+        | "sboverride"
         | "securepoll-create-poll"
+        | "securepoll-view-voter-pii"
         | "sendemail"
         | "setmentor"
+        | "sfsblock-bypass"
         | "siteadmin"
         | "skipcaptcha"
         | "spamblacklistlog"
         | "stablesettings"
+        | "stashbasehtml"
+        | "stashedit"
         | "suppressionlog"
         | "suppressredirect"
         | "suppressrevision"
         | "tboverride"
         | "tboverride-account"
         | "templateeditor"
+        | "thanks-notification"
         | "titleblacklistlog"
         | "torunblocked"
         | "transcode-reset"
@@ -3078,10 +3374,10 @@ export interface ApiQueryAllUsersParams extends ApiQueryParams {
         | "unwatchedpages"
         | "upload"
         | "upload_by_url"
+        | "urlshortcode"
         | "urlshortener-create-url"
         | "urlshortener-manage-url"
         | "urlshortener-view-log"
-        | "usermerge"
         | "userrights"
         | "userrights-interwiki"
         | "validate"
@@ -3138,7 +3434,7 @@ export interface ApiQueryBacklinksParams extends ApiQueryParams {
     blredirect?: boolean;
 }
 
-export interface ApiQueryBetaFeaturesParams extends ApiQueryParams {
+export interface BetaFeaturesApiQueryBetaFeaturesParams extends ApiQueryParams {
     bfcounts?: string;
 }
 
@@ -3216,7 +3512,7 @@ export interface ApiCentralNoticeLogsParams extends ApiQueryParams {
 }
 
 export interface MediaWikiCheckUserApiQueryCheckUserParams extends ApiQueryParams {
-    curequest?: "edits" | "ipusers" | "userips";
+    curequest?: "actions" | "ipusers" | "userips" | "edits";
     cutarget?: string;
     cureason?: string;
     culimit?: limit;
@@ -3228,6 +3524,7 @@ export interface MediaWikiCheckUserApiQueryCheckUserParams extends ApiQueryParam
 export interface MediaWikiCheckUserApiQueryCheckUserLogParams extends ApiQueryParams {
     culuser?: string;
     cultarget?: string;
+    culreason?: string;
     cullimit?: limit;
     culdir?: "newer" | "older";
     culfrom?: timestamp;
@@ -3235,39 +3532,50 @@ export interface MediaWikiCheckUserApiQueryCheckUserLogParams extends ApiQueryPa
     culcontinue?: string;
 }
 
-export interface CirrusSearchApiQueryBuildDocumentParams extends ApiQueryParams {}
+export interface CirrusSearchApiQueryBuildDocumentParams extends ApiQueryParams {
+    cbbuilders?: OneOrMore<"content" | "links">;
+    cblimiterprofile?: string;
+}
 
 export interface CirrusSearchApiQueryCompSuggestBuildDocParams extends ApiQueryParams {
     csbmethod?: string;
 }
 
-export interface CirrusSearchApiQueryCirrusDocParams extends ApiQueryParams {}
+export interface CirrusSearchApiQueryCirrusDocParams extends ApiQueryParams {
+    cdincludes?: string | string[];
+}
 
-export interface ApiQueryContentTranslationParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryContentTranslationParams extends ApiQueryParams {
     translationid?: string;
     from?: string;
     to?: string;
     sourcetitle?: string;
+    sourcesectiontitle?: string;
     limit?: limit;
     offset?: string;
     type?: "draft" | "published";
+    usecase?: "desktop-editor-draft" | "translation-corpora-units" | "unified-dashboard";
 }
 
-export interface ApiQueryContentTranslationCorporaParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryContentTranslationCorporaParams
+    extends ApiQueryParams {
     translationid?: number;
     striphtml?: boolean;
     types?: OneOrMore<"mt" | "source" | "user">;
 }
 
-export interface ApiQueryContentTranslationLanguageTrendParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryContentTranslationLanguageTrendParams
+    extends ApiQueryParams {
     source?: string;
     target?: string;
     interval?: "month" | "week";
 }
 
-export interface ApiQueryContentTranslationStatsParams extends ApiQueryParams {}
+export interface ContentTranslationActionApiQueryContentTranslationStatsParams
+    extends ApiQueryParams {}
 
-export interface ApiQueryContentTranslationSuggestionsParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryContentTranslationSuggestionsParams
+    extends ApiQueryParams {
     from?: string;
     to?: string;
     listid?: string;
@@ -3296,12 +3604,14 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
@@ -3325,23 +3635,27 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "interface-admin"
         | "ipblock-exempt"
         | "massmessage-sender"
-        | "oversight"
+        | "no-ipinfo"
         | "patroller"
+        | "push-subscription-manager"
         | "researcher"
         | "reviewer"
         | "rollbacker"
         | "steward"
+        | "suppress"
         | "sysop"
         | "templateeditor"
         | "transwiki"
     >;
     pcrights?: OneOrMore<
+        | "abusefilter-bypass-blocked-external-domains"
         | "abusefilter-hidden-log"
         | "abusefilter-hide-log"
         | "abusefilter-log"
         | "abusefilter-log-detail"
         | "abusefilter-log-private"
         | "abusefilter-modify"
+        | "abusefilter-modify-blocked-external-domains"
         | "abusefilter-modify-global"
         | "abusefilter-modify-restricted"
         | "abusefilter-privatedetails"
@@ -3364,13 +3678,15 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "centralauth-createlocal"
         | "centralauth-lock"
         | "centralauth-merge"
-        | "centralauth-oversight"
         | "centralauth-rename"
+        | "centralauth-suppress"
         | "centralauth-unmerge"
-        | "centralauth-usermerge"
         | "changetags"
         | "checkuser"
         | "checkuser-log"
+        | "checkuser-temporary-account"
+        | "checkuser-temporary-account-log"
+        | "checkuser-temporary-account-no-preference"
         | "collectionsaveascommunitypage"
         | "collectionsaveasuserpage"
         | "createaccount"
@@ -3385,6 +3701,7 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "deletelogentry"
         | "deleterevision"
         | "edit"
+        | "editautopatrolprotected"
         | "editautoreviewprotected"
         | "editcontentmodel"
         | "editeditorprotected"
@@ -3402,9 +3719,11 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "editsitecss"
         | "editsitejs"
         | "editsitejson"
+        | "edittrustedprotected"
         | "editusercss"
         | "edituserjs"
         | "edituserjson"
+        | "enrollasmentor"
         | "extendedconfirmed"
         | "flow-create-board"
         | "flow-delete"
@@ -3412,19 +3731,22 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "flow-hide"
         | "flow-suppress"
         | "gadgets-definition-edit"
-        | "gadgets-edit"
         | "globalblock"
         | "globalblock-exempt"
         | "globalblock-whitelist"
         | "globalgroupmembership"
         | "globalgrouppermissions"
-        | "gwtoolset"
         | "hideuser"
         | "import"
         | "importupload"
         | "ipblock-exempt"
+        | "ipinfo"
+        | "ipinfo-view-basic"
+        | "ipinfo-view-full"
+        | "ipinfo-view-log"
         | "manage-all-push-subscriptions"
         | "managechangetags"
+        | "managementors"
         | "markbotedits"
         | "massmessage"
         | "mergehistory"
@@ -3461,7 +3783,6 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "patrol"
         | "patrolmarks"
         | "protect"
-        | "purge"
         | "read"
         | "renameuser"
         | "reupload"
@@ -3469,9 +3790,12 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "reupload-shared"
         | "review"
         | "rollback"
+        | "sboverride"
         | "securepoll-create-poll"
+        | "securepoll-view-voter-pii"
         | "sendemail"
         | "setmentor"
+        | "sfsblock-bypass"
         | "siteadmin"
         | "skipcaptcha"
         | "spamblacklistlog"
@@ -3495,7 +3819,6 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "urlshortener-create-url"
         | "urlshortener-manage-url"
         | "urlshortener-view-log"
-        | "usermerge"
         | "userrights"
         | "userrights-interwiki"
         | "validate"
@@ -3507,12 +3830,14 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "writeapi"
     >;
     pcexcluderights?: OneOrMore<
+        | "abusefilter-bypass-blocked-external-domains"
         | "abusefilter-hidden-log"
         | "abusefilter-hide-log"
         | "abusefilter-log"
         | "abusefilter-log-detail"
         | "abusefilter-log-private"
         | "abusefilter-modify"
+        | "abusefilter-modify-blocked-external-domains"
         | "abusefilter-modify-global"
         | "abusefilter-modify-restricted"
         | "abusefilter-privatedetails"
@@ -3535,13 +3860,15 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "centralauth-createlocal"
         | "centralauth-lock"
         | "centralauth-merge"
-        | "centralauth-oversight"
         | "centralauth-rename"
+        | "centralauth-suppress"
         | "centralauth-unmerge"
-        | "centralauth-usermerge"
         | "changetags"
         | "checkuser"
         | "checkuser-log"
+        | "checkuser-temporary-account"
+        | "checkuser-temporary-account-log"
+        | "checkuser-temporary-account-no-preference"
         | "collectionsaveascommunitypage"
         | "collectionsaveasuserpage"
         | "createaccount"
@@ -3556,6 +3883,7 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "deletelogentry"
         | "deleterevision"
         | "edit"
+        | "editautopatrolprotected"
         | "editautoreviewprotected"
         | "editcontentmodel"
         | "editeditorprotected"
@@ -3573,9 +3901,11 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "editsitecss"
         | "editsitejs"
         | "editsitejson"
+        | "edittrustedprotected"
         | "editusercss"
         | "edituserjs"
         | "edituserjson"
+        | "enrollasmentor"
         | "extendedconfirmed"
         | "flow-create-board"
         | "flow-delete"
@@ -3583,19 +3913,22 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "flow-hide"
         | "flow-suppress"
         | "gadgets-definition-edit"
-        | "gadgets-edit"
         | "globalblock"
         | "globalblock-exempt"
         | "globalblock-whitelist"
         | "globalgroupmembership"
         | "globalgrouppermissions"
-        | "gwtoolset"
         | "hideuser"
         | "import"
         | "importupload"
         | "ipblock-exempt"
+        | "ipinfo"
+        | "ipinfo-view-basic"
+        | "ipinfo-view-full"
+        | "ipinfo-view-log"
         | "manage-all-push-subscriptions"
         | "managechangetags"
+        | "managementors"
         | "markbotedits"
         | "massmessage"
         | "mergehistory"
@@ -3632,7 +3965,6 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "patrol"
         | "patrolmarks"
         | "protect"
-        | "purge"
         | "read"
         | "renameuser"
         | "reupload"
@@ -3640,9 +3972,12 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "reupload-shared"
         | "review"
         | "rollback"
+        | "sboverride"
         | "securepoll-create-poll"
+        | "securepoll-view-voter-pii"
         | "sendemail"
         | "setmentor"
+        | "sfsblock-bypass"
         | "siteadmin"
         | "skipcaptcha"
         | "spamblacklistlog"
@@ -3666,7 +4001,6 @@ export interface ApiQueryContributorsParams extends ApiQueryParams {
         | "urlshortener-create-url"
         | "urlshortener-manage-url"
         | "urlshortener-view-log"
-        | "usermerge"
         | "userrights"
         | "userrights-interwiki"
         | "validate"
@@ -3690,19 +4024,20 @@ export interface GeoDataApiQueryCoordinatesParams extends ApiQueryParams {
     codistancefrompage?: string;
 }
 
-export interface ApiQueryDeletedTranslationsParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryDeletedTranslationsParams extends ApiQueryParams {
     dtafter?: timestamp;
     dtnamespace?: namespace;
 }
 
-export interface ApiQueryPublishedTranslationsParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryPublishedTranslationsParams
+    extends ApiQueryParams {
     from?: string;
     to?: string;
     limit?: limit;
     offset?: string;
 }
 
-export interface ApiQueryTranslatorStatsParams extends ApiQueryParams {
+export interface ContentTranslationActionApiQueryTranslatorStatsParams extends ApiQueryParams {
     translator?: string;
 }
 
@@ -3776,9 +4111,9 @@ export interface ApiQueryDeletedrevsParams extends ApiQueryParams {
         | "revid"
         | "sha1"
         | "tags"
-        | "token"
         | "user"
         | "userid"
+        | "token"
     >;
     drlimit?: limit;
     drcontinue?: string;
@@ -3823,6 +4158,7 @@ export interface ApiQueryExternalLinksParams extends ApiQueryParams {
         | "ircs"
         | "magnet"
         | "mailto"
+        | "matrix"
         | "mms"
         | "news"
         | "nntp"
@@ -3869,6 +4205,7 @@ export interface ApiQueryExtLinksUsageParams extends ApiQueryParams {
         | "ircs"
         | "magnet"
         | "mailto"
+        | "matrix"
         | "mms"
         | "news"
         | "nntp"
@@ -3890,7 +4227,7 @@ export interface ApiQueryExtLinksUsageParams extends ApiQueryParams {
     euexpandurl?: boolean;
 }
 
-export interface ApiQueryFeatureUsageParams extends ApiQueryParams {
+export interface ApiFeatureUsageApiQueryFeatureUsageParams extends ApiQueryParams {
     afustart?: timestamp;
     afuend?: timestamp;
     afuagent?: string;
@@ -3950,12 +4287,12 @@ export interface ApiQueryBacklinkspropParams extends ApiQueryParams {
 
 export interface ApiQueryFlaggedParams extends ApiQueryParams {}
 
-export interface ApiQueryGadgetCategoriesParams extends ApiQueryParams {
+export interface GadgetsApiQueryGadgetCategoriesParams extends ApiQueryParams {
     gcprop?: OneOrMore<"members" | "name" | "title">;
     gcnames?: string | string[];
 }
 
-export interface ApiQueryGadgetsParams extends ApiQueryParams {
+export interface GadgetsApiQueryGadgetsParams extends ApiQueryParams {
     gaprop?: OneOrMore<"desc" | "id" | "metadata">;
     gacategories?: string | string[];
     gaids?: string | string[];
@@ -3969,6 +4306,7 @@ export interface GeoDataApiQueryGeoSearchElasticParams extends ApiQueryParams {
     gsbbox?: string;
     gsradius?: number;
     gsmaxdim?: number;
+    gssort?: "distance" | "relevance";
     gslimit?: limit;
     gsglobe?: "earth";
     gsnamespace?: namespace | namespace[];
@@ -3977,13 +4315,7 @@ export interface GeoDataApiQueryGeoSearchElasticParams extends ApiQueryParams {
     gsdebug?: boolean;
 }
 
-export interface GettingStartedApiGettingStartedGetPagesParams extends ApiQueryParams {
-    gsgptaskname?: string;
-    gsgpexcludedtitle?: string;
-    gsgpcount?: number;
-}
-
-export interface ApiQueryGlobalAllUsersParams extends ApiQueryParams {
+export interface CentralAuthApiQueryGlobalAllUsersParams extends ApiQueryParams {
     agufrom?: string;
     aguto?: string;
     aguprefix?: string;
@@ -4004,12 +4336,12 @@ export interface ApiQueryGlobalAllUsersParams extends ApiQueryParams {
         | "new-wikis-importer"
         | "oathauth-tester"
         | "ombuds"
-        | "otrs-member"
         | "recursive-export"
         | "staff"
         | "steward"
         | "sysadmin"
-        | "wmf-ops-monitoring"
+        | "vrt-permissions"
+        | "wmf-email-block-override"
         | "wmf-researcher"
     >;
     aguexcludegroup?: OneOrMore<
@@ -4028,19 +4360,19 @@ export interface ApiQueryGlobalAllUsersParams extends ApiQueryParams {
         | "new-wikis-importer"
         | "oathauth-tester"
         | "ombuds"
-        | "otrs-member"
         | "recursive-export"
         | "staff"
         | "steward"
         | "sysadmin"
-        | "wmf-ops-monitoring"
+        | "vrt-permissions"
+        | "wmf-email-block-override"
         | "wmf-researcher"
     >;
     aguprop?: OneOrMore<"existslocally" | "groups" | "lockinfo">;
     agulimit?: limit;
 }
 
-export interface ApiQueryGlobalBlocksParams extends ApiQueryParams {
+export interface GlobalBlockingApiQueryGlobalBlocksParams extends ApiQueryParams {
     bgstart?: timestamp;
     bgend?: timestamp;
     bgdir?: "newer" | "older";
@@ -4051,7 +4383,7 @@ export interface ApiQueryGlobalBlocksParams extends ApiQueryParams {
     bgprop?: OneOrMore<"address" | "by" | "expiry" | "id" | "range" | "reason" | "timestamp">;
 }
 
-export interface ApiQueryGlobalGroupsParams extends ApiQueryParams {
+export interface CentralAuthApiQueryGlobalGroupsParams extends ApiQueryParams {
     ggpprop?: OneOrMore<"rights">;
 }
 
@@ -4059,11 +4391,11 @@ export interface GlobalPreferencesApiQueryGlobalPreferencesParams extends ApiQue
     gprprop?: OneOrMore<"localoverrides" | "preferences">;
 }
 
-export interface ApiQueryGlobalRenameStatusParams extends ApiQueryParams {
+export interface CentralAuthApiQueryGlobalRenameStatusParams extends ApiQueryParams {
     grsuser?: string;
 }
 
-export interface ApiQueryGlobalUsageParams extends ApiQueryParams {
+export interface GlobalUsageApiQueryGlobalUsageParams extends ApiQueryParams {
     guprop?: OneOrMore<"namespace" | "pageid" | "url">;
     gulimit?: limit;
     gunamespace?: namespace | namespace[];
@@ -4072,10 +4404,81 @@ export interface ApiQueryGlobalUsageParams extends ApiQueryParams {
     gufilterlocal?: boolean;
 }
 
-export interface ApiQueryGlobalUserInfoParams extends ApiQueryParams {
+export interface CentralAuthApiQueryGlobalUserInfoParams extends ApiQueryParams {
     guiuser?: string;
     guiid?: number;
     guiprop?: OneOrMore<"editcount" | "groups" | "merged" | "rights" | "unattached">;
+}
+
+export interface GrowthExperimentsApiQueryImageSuggestionDataParams extends ApiQueryParams {
+    gisdtasktype?: "image-recommendation" | "section-image-recommendation";
+    gisdcontinue?: string;
+}
+
+export interface GrowthExperimentsApiQueryMenteeStatusParams extends ApiQueryParams {}
+
+export interface GrowthExperimentsApiQueryMentorListParams extends ApiQueryParams {}
+
+export interface GrowthExperimentsApiQueryMentorMenteeParams extends ApiQueryParams {
+    gemmmentor?: string;
+}
+
+export interface GrowthExperimentsApiQueryMentorStatusParams extends ApiQueryParams {}
+
+export interface GrowthExperimentsApiQueryNextSuggestedTaskTypeParams extends ApiQueryParams {
+    gnsttactivetasktype?: "copyedit" | "expand" | "links" | "references" | "update";
+}
+
+export interface GrowthExperimentsApiQueryStarredMenteesParams extends ApiQueryParams {}
+
+export interface GrowthExperimentsApiQueryGrowthTasksParams extends ApiQueryParams {
+    gttasktypes?: OneOrMore<"copyedit" | "expand" | "links" | "references" | "update">;
+    gttopics?: OneOrMore<
+        | "africa"
+        | "architecture"
+        | "art"
+        | "asia"
+        | "biography"
+        | "biology"
+        | "business-and-economics"
+        | "central-america"
+        | "chemistry"
+        | "comics-and-anime"
+        | "computers-and-internet"
+        | "earth-and-environment"
+        | "education"
+        | "engineering"
+        | "entertainment"
+        | "europe"
+        | "fashion"
+        | "food-and-drink"
+        | "general-science"
+        | "history"
+        | "literature"
+        | "mathematics"
+        | "medicine-and-health"
+        | "military-and-warfare"
+        | "music"
+        | "north-america"
+        | "oceania"
+        | "performing-arts"
+        | "philosophy-and-religion"
+        | "physics"
+        | "politics-and-government"
+        | "society"
+        | "south-america"
+        | "sports"
+        | "technology"
+        | "transportation"
+        | "tv-and-film"
+        | "video-games"
+        | "women"
+    >;
+    gttopicsmode?: "AND" | "OR";
+    gtlimit?: limit;
+    gtoffset?: number;
+    gtdebug?: boolean;
+    gtexcludepageids?: number | number[];
 }
 
 export interface ApiQueryImageInfoParams extends ApiQueryParams {
@@ -4136,10 +4539,12 @@ export interface ApiQueryBacklinksParams extends ApiQueryParams {
 
 export interface ApiQueryInfoParams extends ApiQueryParams {
     inprop?: OneOrMore<
+        | "associatedpage"
         | "displaytitle"
+        | "editintro"
         | "linkclasses"
         | "notificationtimestamp"
-        | "preload"
+        | "preloadcontent"
         | "protection"
         | "subjectid"
         | "talkid"
@@ -4148,16 +4553,23 @@ export interface ApiQueryInfoParams extends ApiQueryParams {
         | "visitingwatchers"
         | "watched"
         | "watchers"
+        | "preload"
         | "readable"
     >;
     inlinkcontext?: string;
     intestactions?: string | string[];
     intestactionsdetail?: "boolean" | "full" | "quick";
-    intoken?: OneOrMore<
-        "block" | "delete" | "edit" | "email" | "import" | "move" | "protect" | "unblock" | "watch"
-    >;
+    intestactionsautocreate?: boolean;
+    inpreloadcustom?: string;
+    inpreloadparams?: string | string[];
+    inpreloadnewsection?: boolean;
+    ineditintrostyle?: "lessframes" | "moreframes";
+    ineditintroskip?: string | string[];
+    ineditintrocustom?: string;
     incontinue?: string;
 }
+
+export interface PageTriageApiIsReviewedParams extends ApiQueryParams {}
 
 export interface ApiQueryIWBacklinksParams extends ApiQueryParams {
     iwblprefix?: string;
@@ -4198,10 +4610,12 @@ export interface ApiQueryLangLinksParams extends ApiQueryParams {
     llurl?: boolean;
 }
 
-export interface ApiQueryLangLinksCountParams extends ApiQueryParams {}
+export interface ContentTranslationActionApiQueryLangLinksCountParams extends ApiQueryParams {}
 
 export interface ApiQueryLanguageinfoParams extends ApiQueryParams {
-    liprop?: OneOrMore<"autonym" | "bcp47" | "code" | "dir" | "fallbacks" | "name" | "variants">;
+    liprop?: OneOrMore<
+        "autonym" | "bcp47" | "code" | "dir" | "fallbacks" | "name" | "variantnames" | "variants"
+    >;
     licode?: string | string[];
     licontinue?: string;
 }
@@ -4223,7 +4637,7 @@ export interface ApiQueryBacklinkspropParams extends ApiQueryParams {
 }
 
 export interface MediaWikiLinterApiQueryLintErrorsParams extends ApiQueryParams {
-    lntcategories?: OneOrMore<
+    "lntcategories"?: OneOrMore<
         | "bogus-image-options"
         | "deletable-table-tag"
         | "fostered"
@@ -4231,6 +4645,7 @@ export interface MediaWikiLinterApiQueryLintErrorsParams extends ApiQueryParams 
         | "misc-tidy-replacement-issues"
         | "misnested-tag"
         | "missing-end-tag"
+        | "missing-end-tag-in-heading"
         | "multi-colon-escape"
         | "multiline-html-table-in-list"
         | "multiple-unclosed-formatting-tags"
@@ -4243,11 +4658,12 @@ export interface MediaWikiLinterApiQueryLintErrorsParams extends ApiQueryParams 
         | "unclosed-quotes-in-heading"
         | "wikilink-in-extlink"
     >;
-    lntlimit?: limit;
-    lntnamespace?: namespace | namespace[];
-    lntpageid?: number | number[];
-    lnttitle?: string;
-    lntfrom?: number;
+    "lntinvisible-categories"?: OneOrMore<"large-tables">;
+    "lntlimit"?: limit;
+    "lntnamespace"?: namespace | namespace[];
+    "lntpageid"?: number | number[];
+    "lnttitle"?: string;
+    "lntfrom"?: number;
 }
 
 export interface MediaWikiLinterApiQueryLinterStatsParams extends ApiQueryParams {}
@@ -4268,8 +4684,10 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
     letype?:
         | ""
         | "abusefilter"
+        | "abusefilterblockeddomainhit"
         | "abusefilterprivatedetails"
         | "block"
+        | "checkuser-temporary-account"
         | "contentmodel"
         | "create"
         | "delete"
@@ -4277,7 +4695,9 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
         | "gblrename"
         | "gblrights"
         | "globalauth"
+        | "growthexperiments"
         | "import"
+        | "ipinfo"
         | "managetags"
         | "massmessage"
         | "merge"
@@ -4286,7 +4706,6 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
         | "oath"
         | "pagetriage-copyvio"
         | "pagetriage-curation"
-        | "pagetriage-deletion"
         | "patrol"
         | "protect"
         | "renameuser"
@@ -4306,10 +4725,13 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
         | "abusefilter/create"
         | "abusefilter/hit"
         | "abusefilter/modify"
+        | "abusefilterblockeddomainhit/*"
         | "abusefilterprivatedetails/access"
         | "block/block"
         | "block/reblock"
         | "block/unblock"
+        | "checkuser-private-event/*"
+        | "checkuser-temporary-account/*"
         | "contentmodel/change"
         | "contentmodel/new"
         | "create/create"
@@ -4345,9 +4767,17 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
         | "globalauth/setstatus"
         | "globalauth/unhide"
         | "globalauth/unlock"
+        | "growthexperiments/addimage"
+        | "growthexperiments/addlink"
+        | "growthexperiments/addsectionimage"
+        | "growthexperiments/claimmentee"
+        | "growthexperiments/claimmentee-no-previous-mentor"
+        | "growthexperiments/setmentor"
+        | "growthexperiments/setmentor-no-previous-mentor"
         | "import/interwiki"
         | "import/upload"
         | "interwiki/*"
+        | "ipinfo/*"
         | "managetags/activate"
         | "managetags/create"
         | "managetags/deactivate"
@@ -4368,13 +4798,17 @@ export interface ApiQueryLogEventsParams extends ApiQueryParams {
         | "newusers/forcecreatelocal"
         | "newusers/newusers"
         | "oath/*"
+        | "pagetriage-copyvio/delete"
         | "pagetriage-copyvio/insert"
         | "pagetriage-curation/delete"
         | "pagetriage-curation/enqueue"
         | "pagetriage-curation/reviewed"
+        | "pagetriage-curation/reviewed-article"
+        | "pagetriage-curation/reviewed-redirect"
         | "pagetriage-curation/tag"
         | "pagetriage-curation/unreviewed"
-        | "pagetriage-deletion/delete"
+        | "pagetriage-curation/unreviewed-article"
+        | "pagetriage-curation/unreviewed-redirect"
         | "patrol/autopatrol"
         | "patrol/patrol"
         | "protect/modify"
@@ -4438,9 +4872,7 @@ export interface KartographerApiQueryMapDataParams extends ApiQueryParams {
     mpdcontinue?: number;
 }
 
-export interface MediaWikiMassMessageApiQueryMMSitesParams extends ApiQueryParams {
-    term?: string;
-}
+export interface MediaWikiMassMessageApiQueryMMContentParams extends ApiQueryParams {}
 
 export interface PageViewInfoApiQueryMostViewedParams extends ApiQueryParams {
     pvimmetric?: "pageviews";
@@ -4454,7 +4886,7 @@ export interface ApiQueryMyStashedFilesParams extends ApiQueryParams {
     msfcontinue?: string;
 }
 
-export interface ApiEchoNotificationsParams extends ApiQueryParams {
+export interface NotificationsApiEchoNotificationsParams extends ApiQueryParams {
     notwikis?: string | string[];
     notfilter?: OneOrMore<"!read" | "read">;
     notprop?: OneOrMore<"count" | "list" | "seenTime">;
@@ -4466,6 +4898,7 @@ export interface ApiEchoNotificationsParams extends ApiQueryParams {
     notunreadfirst?: boolean;
     nottitles?: string | string[];
     notbundle?: boolean;
+    notnotifiertypes?: OneOrMore<"email" | "push" | "web">;
     notalertcontinue?: string;
     notalertunreadfirst?: boolean;
     notmessagecontinue?: string;
@@ -4527,6 +4960,591 @@ export interface ApiQueryPagesWithPropParams extends ApiQueryParams {
 
 export interface WikibaseClientApiPageTermsParams extends ApiQueryParams {
     wbptcontinue?: number;
+    wbptlanguage?:
+        | "aa"
+        | "aae"
+        | "ab"
+        | "abs"
+        | "ace"
+        | "acm"
+        | "ady"
+        | "ady-cyrl"
+        | "aeb"
+        | "aeb-arab"
+        | "aeb-latn"
+        | "af"
+        | "agq"
+        | "aln"
+        | "als"
+        | "alt"
+        | "am"
+        | "ami"
+        | "an"
+        | "ang"
+        | "ann"
+        | "anp"
+        | "ar"
+        | "arc"
+        | "arn"
+        | "arq"
+        | "ary"
+        | "arz"
+        | "as"
+        | "ase"
+        | "ast"
+        | "atj"
+        | "av"
+        | "avk"
+        | "awa"
+        | "ay"
+        | "az"
+        | "azb"
+        | "ba"
+        | "bag"
+        | "ban"
+        | "ban-bali"
+        | "bar"
+        | "bas"
+        | "bat-smg"
+        | "bax"
+        | "bbc"
+        | "bbc-latn"
+        | "bbj"
+        | "bcc"
+        | "bci"
+        | "bcl"
+        | "bdr"
+        | "be"
+        | "be-tarask"
+        | "be-x-old"
+        | "bew"
+        | "bfd"
+        | "bg"
+        | "bgn"
+        | "bh"
+        | "bho"
+        | "bi"
+        | "bjn"
+        | "bkc"
+        | "bkh"
+        | "bkm"
+        | "blk"
+        | "bm"
+        | "bn"
+        | "bo"
+        | "bpy"
+        | "bqi"
+        | "bqz"
+        | "br"
+        | "brh"
+        | "bs"
+        | "btm"
+        | "bto"
+        | "bug"
+        | "bxr"
+        | "byv"
+        | "ca"
+        | "cak"
+        | "cal"
+        | "cbk-zam"
+        | "cdo"
+        | "ce"
+        | "ceb"
+        | "ch"
+        | "cho"
+        | "chr"
+        | "chy"
+        | "ckb"
+        | "cnh"
+        | "co"
+        | "cps"
+        | "cpx"
+        | "cpx-hans"
+        | "cpx-hant"
+        | "cpx-latn"
+        | "cr"
+        | "crh"
+        | "crh-cyrl"
+        | "crh-latn"
+        | "crh-ro"
+        | "cs"
+        | "csb"
+        | "cu"
+        | "cv"
+        | "cy"
+        | "da"
+        | "dag"
+        | "de"
+        | "de-at"
+        | "de-ch"
+        | "de-formal"
+        | "dga"
+        | "din"
+        | "diq"
+        | "dsb"
+        | "dtp"
+        | "dty"
+        | "dua"
+        | "dv"
+        | "dz"
+        | "ee"
+        | "efi"
+        | "egl"
+        | "el"
+        | "eml"
+        | "en"
+        | "en-ca"
+        | "en-gb"
+        | "en-us"
+        | "eo"
+        | "es"
+        | "es-419"
+        | "es-formal"
+        | "et"
+        | "eto"
+        | "etu"
+        | "eu"
+        | "ewo"
+        | "ext"
+        | "fa"
+        | "fat"
+        | "ff"
+        | "fi"
+        | "fit"
+        | "fiu-vro"
+        | "fj"
+        | "fkv"
+        | "fmp"
+        | "fo"
+        | "fon"
+        | "fr"
+        | "frc"
+        | "frp"
+        | "frr"
+        | "fur"
+        | "fy"
+        | "ga"
+        | "gaa"
+        | "gag"
+        | "gan"
+        | "gan-hans"
+        | "gan-hant"
+        | "gcf"
+        | "gcr"
+        | "gd"
+        | "gl"
+        | "gld"
+        | "glk"
+        | "gn"
+        | "gom"
+        | "gom-deva"
+        | "gom-latn"
+        | "gor"
+        | "got"
+        | "gpe"
+        | "grc"
+        | "gsw"
+        | "gu"
+        | "guc"
+        | "gur"
+        | "guw"
+        | "gv"
+        | "gya"
+        | "ha"
+        | "hak"
+        | "haw"
+        | "he"
+        | "hi"
+        | "hif"
+        | "hif-latn"
+        | "hil"
+        | "hno"
+        | "ho"
+        | "hr"
+        | "hrx"
+        | "hsb"
+        | "hsn"
+        | "ht"
+        | "hu"
+        | "hu-formal"
+        | "hy"
+        | "hyw"
+        | "hz"
+        | "ia"
+        | "id"
+        | "ie"
+        | "ig"
+        | "igl"
+        | "ii"
+        | "ik"
+        | "ike-cans"
+        | "ike-latn"
+        | "ilo"
+        | "inh"
+        | "io"
+        | "is"
+        | "isu"
+        | "it"
+        | "iu"
+        | "ja"
+        | "jam"
+        | "jbo"
+        | "jut"
+        | "jv"
+        | "ka"
+        | "kaa"
+        | "kab"
+        | "kai"
+        | "kbd"
+        | "kbd-cyrl"
+        | "kbp"
+        | "kcg"
+        | "kea"
+        | "ker"
+        | "kg"
+        | "kge"
+        | "khw"
+        | "ki"
+        | "kiu"
+        | "kj"
+        | "kjh"
+        | "kjp"
+        | "kk"
+        | "kk-arab"
+        | "kk-cn"
+        | "kk-cyrl"
+        | "kk-kz"
+        | "kk-latn"
+        | "kk-tr"
+        | "kl"
+        | "km"
+        | "kn"
+        | "ko"
+        | "ko-kp"
+        | "koi"
+        | "kr"
+        | "krc"
+        | "kri"
+        | "krj"
+        | "krl"
+        | "ks"
+        | "ks-arab"
+        | "ks-deva"
+        | "ksf"
+        | "ksh"
+        | "ksw"
+        | "ku"
+        | "ku-arab"
+        | "ku-latn"
+        | "kum"
+        | "kus"
+        | "kv"
+        | "kw"
+        | "ky"
+        | "la"
+        | "lad"
+        | "lb"
+        | "lbe"
+        | "lem"
+        | "lez"
+        | "lfn"
+        | "lg"
+        | "li"
+        | "lij"
+        | "liv"
+        | "lki"
+        | "lld"
+        | "lmo"
+        | "ln"
+        | "lns"
+        | "lo"
+        | "loz"
+        | "lrc"
+        | "lt"
+        | "ltg"
+        | "lus"
+        | "luz"
+        | "lv"
+        | "lzh"
+        | "lzz"
+        | "mad"
+        | "mag"
+        | "mai"
+        | "map-bms"
+        | "mcn"
+        | "mcp"
+        | "mdf"
+        | "mg"
+        | "mh"
+        | "mhr"
+        | "mi"
+        | "min"
+        | "mk"
+        | "ml"
+        | "mn"
+        | "mnc"
+        | "mnc-latn"
+        | "mnc-mong"
+        | "mni"
+        | "mnw"
+        | "mo"
+        | "mos"
+        | "mr"
+        | "mrh"
+        | "mrj"
+        | "ms"
+        | "ms-arab"
+        | "mt"
+        | "mua"
+        | "mus"
+        | "mwl"
+        | "my"
+        | "myv"
+        | "mzn"
+        | "na"
+        | "nah"
+        | "nan"
+        | "nan-hani"
+        | "nap"
+        | "nb"
+        | "nds"
+        | "nds-nl"
+        | "ne"
+        | "new"
+        | "ng"
+        | "nge"
+        | "nia"
+        | "nit"
+        | "niu"
+        | "nl"
+        | "nl-informal"
+        | "nla"
+        | "nmg"
+        | "nmz"
+        | "nn"
+        | "nnh"
+        | "nnz"
+        | "no"
+        | "nod"
+        | "nog"
+        | "nov"
+        | "nqo"
+        | "nrm"
+        | "nso"
+        | "nv"
+        | "ny"
+        | "nyn"
+        | "nyo"
+        | "nys"
+        | "oc"
+        | "ojb"
+        | "olo"
+        | "om"
+        | "or"
+        | "os"
+        | "osa-latn"
+        | "ota"
+        | "pa"
+        | "pag"
+        | "pam"
+        | "pap"
+        | "pap-aw"
+        | "pcd"
+        | "pcm"
+        | "pdc"
+        | "pdt"
+        | "pfl"
+        | "pi"
+        | "pih"
+        | "pl"
+        | "pms"
+        | "pnb"
+        | "pnt"
+        | "prg"
+        | "ps"
+        | "pt"
+        | "pt-br"
+        | "pwn"
+        | "qu"
+        | "quc"
+        | "qug"
+        | "rgn"
+        | "rif"
+        | "rki"
+        | "rm"
+        | "rmc"
+        | "rmf"
+        | "rmy"
+        | "rn"
+        | "ro"
+        | "roa-rup"
+        | "roa-tara"
+        | "rsk"
+        | "ru"
+        | "rue"
+        | "rup"
+        | "ruq"
+        | "ruq-cyrl"
+        | "ruq-latn"
+        | "rut"
+        | "rw"
+        | "rwr"
+        | "ryu"
+        | "sa"
+        | "sah"
+        | "sat"
+        | "sc"
+        | "scn"
+        | "sco"
+        | "sd"
+        | "sdc"
+        | "sdh"
+        | "se"
+        | "se-fi"
+        | "se-no"
+        | "se-se"
+        | "sei"
+        | "ses"
+        | "sg"
+        | "sgs"
+        | "sh"
+        | "sh-cyrl"
+        | "sh-latn"
+        | "shi"
+        | "shi-latn"
+        | "shi-tfng"
+        | "shn"
+        | "shy"
+        | "shy-latn"
+        | "si"
+        | "simple"
+        | "sjd"
+        | "sje"
+        | "sju"
+        | "sk"
+        | "skr"
+        | "skr-arab"
+        | "sl"
+        | "sli"
+        | "sm"
+        | "sma"
+        | "smj"
+        | "smn"
+        | "sms"
+        | "sn"
+        | "so"
+        | "sq"
+        | "sr"
+        | "sr-ec"
+        | "sr-el"
+        | "srn"
+        | "sro"
+        | "srq"
+        | "ss"
+        | "st"
+        | "stq"
+        | "sty"
+        | "su"
+        | "sv"
+        | "sw"
+        | "syl"
+        | "szl"
+        | "szy"
+        | "ta"
+        | "tay"
+        | "tcy"
+        | "tdd"
+        | "te"
+        | "tet"
+        | "tg"
+        | "tg-cyrl"
+        | "tg-latn"
+        | "th"
+        | "ti"
+        | "tk"
+        | "tl"
+        | "tly"
+        | "tly-cyrl"
+        | "tn"
+        | "to"
+        | "tok"
+        | "tpi"
+        | "tpv"
+        | "tr"
+        | "tru"
+        | "trv"
+        | "ts"
+        | "tt"
+        | "tt-cyrl"
+        | "tt-latn"
+        | "ttj"
+        | "tum"
+        | "tvu"
+        | "tw"
+        | "ty"
+        | "tyv"
+        | "tzm"
+        | "udm"
+        | "ug"
+        | "ug-arab"
+        | "ug-latn"
+        | "uk"
+        | "ur"
+        | "uselang"
+        | "uz"
+        | "uz-cyrl"
+        | "uz-latn"
+        | "ve"
+        | "vec"
+        | "vep"
+        | "vi"
+        | "vls"
+        | "vmf"
+        | "vmw"
+        | "vo"
+        | "vot"
+        | "vro"
+        | "vut"
+        | "wa"
+        | "wal"
+        | "war"
+        | "wes"
+        | "wls"
+        | "wo"
+        | "wuu"
+        | "wuu-hans"
+        | "wuu-hant"
+        | "wya"
+        | "xal"
+        | "xh"
+        | "xmf"
+        | "xsy"
+        | "yas"
+        | "yat"
+        | "yav"
+        | "ybb"
+        | "yi"
+        | "yo"
+        | "yrl"
+        | "yue"
+        | "yue-hans"
+        | "yue-hant"
+        | "za"
+        | "zea"
+        | "zgh"
+        | "zh"
+        | "zh-classical"
+        | "zh-cn"
+        | "zh-hans"
+        | "zh-hant"
+        | "zh-hk"
+        | "zh-min-nan"
+        | "zh-mo"
+        | "zh-my"
+        | "zh-sg"
+        | "zh-tw"
+        | "zh-yue"
+        | "zu";
     wbptterms?: OneOrMore<"alias" | "description" | "label">;
 }
 
@@ -4592,6 +5610,7 @@ export interface ApiQueryQueryPageParams extends ApiQueryParams {
         | "Mostlinkedcategories"
         | "Mostlinkedtemplates"
         | "Mostrevisions"
+        | "OrphanedTimedText"
         | "Shortpages"
         | "Uncategorizedcategories"
         | "Uncategorizedimages"
@@ -4664,7 +5683,6 @@ export interface ApiQueryRecentChangesParams extends ApiQueryParams {
         | "user"
         | "userid"
     >;
-    rctoken?: OneOrMore<"patrol">;
     rcshow?: OneOrMore<
         | "!anon"
         | "!autopatrolled"
@@ -4748,7 +5766,6 @@ export interface ApiQueryRevisionsParams extends ApiQueryParams {
     rvuser?: string;
     rvexcludeuser?: string;
     rvtag?: string;
-    rvtoken?: OneOrMore<"rollback">;
     rvcontinue?: string;
 }
 
@@ -4762,6 +5779,7 @@ export interface ApiQuerySearchParams extends ApiQueryParams {
         | "classic_noboostlinks"
         | "empty"
         | "engine_autoselect"
+        | "growth_underlinked"
         | "mlr-1024rs"
         | "popular_inclinks"
         | "popular_inclinks_pv"
@@ -4797,11 +5815,16 @@ export interface ApiQuerySearchParams extends ApiQueryParams {
         | "last_edit_desc"
         | "none"
         | "random"
-        | "relevance";
+        | "relevance"
+        | "user_random";
 }
 
 export interface ApiQuerySiteinfoParams extends ApiQueryParams {
     siprop?: OneOrMore<
+        | "autocreatetempuser"
+        | "autopromote"
+        | "autopromoteonce"
+        | "clientlibraries"
         | "dbrepllag"
         | "defaultoptions"
         | "extensions"
@@ -4899,9 +5922,9 @@ export interface ApiQueryBacklinkspropParams extends ApiQueryParams {
     ticontinue?: string;
 }
 
-export interface ApiTranscodeStatusParams extends ApiQueryParams {}
+export interface MediaWikiTimedMediaHandlerApiTranscodeStatusParams extends ApiQueryParams {}
 
-export interface ApiEchoUnreadNotificationPagesParams extends ApiQueryParams {
+export interface NotificationsApiEchoUnreadNotificationPagesParams extends ApiQueryParams {
     unpwikis?: string | string[];
     unpgrouppages?: boolean;
     unplimit?: limit;
@@ -4915,6 +5938,7 @@ export interface ApiQueryUserContribsParams extends ApiQueryParams {
     ucuser?: string | string[];
     ucuserids?: number | number[];
     ucuserprefix?: string;
+    uciprange?: string;
     ucdir?: "newer" | "older";
     ucnamespace?: namespace | namespace[];
     ucprop?: OneOrMore<
@@ -4952,6 +5976,7 @@ export interface ApiQueryUserInfoParams extends ApiQueryParams {
     uiprop?: OneOrMore<
         | "acceptlang"
         | "blockinfo"
+        | "cancreateaccount"
         | "centralids"
         | "changeablegroups"
         | "editcount"
@@ -4968,7 +5993,6 @@ export interface ApiQueryUserInfoParams extends ApiQueryParams {
         | "rights"
         | "theoreticalratelimits"
         | "unreadcount"
-        | "preferencestoken"
     >;
     uiattachedwiki?: string;
 }
@@ -4990,10 +6014,9 @@ export interface ApiQueryUsersParams extends ApiQueryParams {
     usattachedwiki?: string;
     ususers?: string | string[];
     ususerids?: number | number[];
-    ustoken?: OneOrMore<"userrights">;
 }
 
-export interface ApiQueryVideoInfoParams extends ApiQueryParams {
+export interface MediaWikiTimedMediaHandlerApiQueryVideoInfoParams extends ApiQueryParams {
     viprop?: OneOrMore<
         | "archivename"
         | "badfile"
@@ -5030,7 +6053,7 @@ export interface ApiQueryVideoInfoParams extends ApiQueryParams {
     viurlparam?: string;
     vibadfilecontexttitle?: string;
     vicontinue?: string;
-    vilocalonly?: string;
+    vilocalonly?: boolean;
 }
 
 export interface ApiQueryWatchlistParams extends ApiQueryParams {
@@ -5103,18 +6126,18 @@ export interface WikibaseClientApiPropsEntityUsageParams extends ApiQueryParams 
 }
 
 export interface WikibaseClientApiListEntityUsageParams extends ApiQueryParams {
-    wbeuprop?: OneOrMore<"url">;
-    wbeuaspect?: OneOrMore<"C" | "D" | "L" | "O" | "S" | "T" | "X">;
-    wbeuentities?: string | string[];
-    wbeulimit?: limit;
-    wbeucontinue?: string;
+    wbleuprop?: OneOrMore<"url">;
+    wbleuaspect?: OneOrMore<"C" | "D" | "L" | "O" | "S" | "T" | "X">;
+    wbleuentities?: string | string[];
+    wbleulimit?: limit;
+    wbleucontinue?: string;
 }
 
 export interface WikibaseClientApiClientInfoParams extends ApiQueryParams {
     wbprop?: OneOrMore<"siteid" | "url">;
 }
 
-export interface ApiQueryWikiSetsParams extends ApiQueryParams {
+export interface CentralAuthApiQueryWikiSetsParams extends ApiQueryParams {
     wsfrom?: string;
     wsprop?: OneOrMore<"type" | "wikisincluded" | "wikisnotincluded">;
     wslimit?: limit;

--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -2,6 +2,8 @@ declare global {
     interface JQueryStatic {
         /**
          * User-agent detection
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.client
          */
         client: Client;
     }
@@ -74,9 +76,10 @@ interface Client {
      * - `solaris` (untested)
      * - `win`
      *
-     * @param {Object} [nav] An object with a 'userAgent' and 'platform' property.
+     * @param {ClientNavigator} [nav] An object with a 'userAgent' and 'platform' property.
      *  Defaults to the global `navigator` object.
-     * @return {Object} The client object
+     * @returns {ClientProfile} The client object
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.client-method-profile
      */
     profile(nav?: ClientNavigator): ClientProfile;
 
@@ -117,10 +120,11 @@ interface Client {
      * ```
      *
      * @param {Object} map Browser support map
-     * @param {Object} [profile] A client-profile object
+     * @param {ClientProfile} [profile] A client-profile object
      * @param {boolean} [exactMatchOnly=false] Only return true if the browser is matched,
      *  otherwise returns true if the browser is not found.
-     * @return {boolean} The current browser is in the support map
+     * @returns {boolean} The current browser is in the support map
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.client-method-test
      */
     test(
         map: ClientSupportMap | { ltr: ClientSupportMap; rtl: ClientSupportMap },

--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -1,5 +1,8 @@
 declare global {
     interface JQueryStatic {
+        /**
+         * User-agent detection
+         */
         client: Client;
     }
 }
@@ -10,26 +13,30 @@ interface Client {
      *
      * The resulting client object will be in the following format:
      *
-     *     {
-     *         'name': 'firefox',
-     *         'layout': 'gecko',
-     *         'layoutVersion': 20101026,
-     *         'platform': 'linux'
-     *         'version': '3.5.1',
-     *         'versionBase': '3',
-     *         'versionNumber': 3.5,
-     *     }
+     * ```js
+     * {
+     *     'name': 'firefox',
+     *     'layout': 'gecko',
+     *     'layoutVersion': 20101026,
+     *     'platform': 'linux'
+     *     'version': '3.5.1',
+     *     'versionBase': '3',
+     *     'versionNumber': 3.5,
+     * }
+     * ```
      *
      * Example:
      *
-     *     if ( $.client.profile().layout == 'gecko' ) {
-     *         // This will only run in Gecko browsers, such as Mozilla Firefox.
-     *     }
+     * ```js
+     * if ( $.client.profile().layout == 'gecko' ) {
+     *     // This will only run in Gecko browsers, such as Mozilla Firefox.
+     * }
      *
-     *     var profile = $.client.profile();
-     *     if ( profile.layout == 'gecko' && profile.platform == 'linux' ) {
-     *         // This will only run in Gecko browsers on Linux.
-     *     }
+     * var profile = $.client.profile();
+     * if ( profile.layout == 'gecko' && profile.platform == 'linux' ) {
+     *     // This will only run in Gecko browsers on Linux.
+     * }
+     * ```
      *
      * Recognised browser names:
      *
@@ -82,34 +89,37 @@ interface Client {
      *
      * A browser map is in the following format:
      *
-     *     {
-     *         // Multiple rules with configurable operators
-     *         'msie': [['>=', 7], ['!=', 9]],
-     *         // Match no versions
-     *         'iphone': false,
-     *         // Match any version
-     *         'android': null
-     *     }
+     * ```js
+     * {
+     *     // Multiple rules with configurable operators
+     *     'msie': [['>=', 7], ['!=', 9]],
+     *     // Match no versions
+     *     'iphone': false,
+     *     // Match any version
+     *     'android': null
+     * }
+     * ```
      *
      * It can optionally be split into ltr/rtl sections:
      *
-     *     {
-     *         'ltr': {
-     *             'android': null,
-     *             'iphone': false
-     *         },
-     *         'rtl': {
-     *             'android': false,
-     *             // rules are not inherited from ltr
-     *             'iphone': false
-     *         }
+     * ```js
+     * {
+     *     'ltr': {
+     *         'android': null,
+     *         'iphone': false
+     *     },
+     *     'rtl': {
+     *         'android': false,
+     *         // rules are not inherited from ltr
+     *         'iphone': false
      *     }
+     * }
+     * ```
      *
      * @param {Object} map Browser support map
      * @param {Object} [profile] A client-profile object
      * @param {boolean} [exactMatchOnly=false] Only return true if the browser is matched,
      *  otherwise returns true if the browser is not found.
-     *
      * @return {boolean} The current browser is in the support map
      */
     test(map: any, profile?: ClientProfile, exactMatchOnly?: boolean): boolean;

--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -119,18 +119,14 @@ interface Client {
      * }
      * ```
      *
-     * @param {Object} map Browser support map
+     * @param {ClientSupportMap} map Browser support map
      * @param {ClientProfile} [profile] A client-profile object
      * @param {boolean} [exactMatchOnly=false] Only return true if the browser is matched,
      *  otherwise returns true if the browser is not found.
      * @returns {boolean} The current browser is in the support map
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.client-method-test
      */
-    test(
-        map: ClientSupportMap | { ltr: ClientSupportMap; rtl: ClientSupportMap },
-        profile?: ClientProfile,
-        exactMatchOnly?: boolean
-    ): boolean;
+    test(map: ClientSupportMap, profile?: ClientProfile, exactMatchOnly?: boolean): boolean;
 }
 
 export interface ClientNavigator {
@@ -152,11 +148,15 @@ type ClientProfileName =
     | "safari"
     | "silk";
 
-type ClientSupportMap = Partial<Record<ClientProfileName, false | null | ClientSupportCondition[]>>;
-type ClientSupportCondition = [
-    "==" | "===" | "!=" | "!==" | "<" | "<=" | ">" | ">=",
-    string | number
-];
+type ComparisonOperator = "==" | "===" | "!=" | "!==" | "<" | "<=" | ">" | ">=";
+type ClientSupportCondition = [ComparisonOperator, string | number];
+
+type UndirectedClientSupportMap = Partial<
+    Record<ClientProfileName, false | null | ClientSupportCondition[]>
+>;
+type ClientSupportMap =
+    | UndirectedClientSupportMap
+    | Record<"ltr" | "rtl", UndirectedClientSupportMap>;
 
 interface ClientProfile {
     name: ClientProfileName;

--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -78,7 +78,7 @@ interface Client {
      *  Defaults to the global `navigator` object.
      * @return {Object} The client object
      */
-    profile(nav?: { userAgent: string; platform: string }): ClientProfile;
+    profile(nav?: ClientNavigator): ClientProfile;
 
     /**
      * Checks the current browser against a support map object.
@@ -122,23 +122,40 @@ interface Client {
      *  otherwise returns true if the browser is not found.
      * @return {boolean} The current browser is in the support map
      */
-    test(map: any, profile?: ClientProfile, exactMatchOnly?: boolean): boolean;
+    test(
+        map: ClientSupportMap | { ltr: ClientSupportMap; rtl: ClientSupportMap },
+        profile?: ClientProfile,
+        exactMatchOnly?: boolean
+    ): boolean;
 }
 
+export interface ClientNavigator {
+    userAgent: string;
+    platform: string;
+}
+
+type ClientProfileName =
+    | "android"
+    | "chrome"
+    | "crios"
+    | "edge"
+    | "firefox"
+    | "fxios"
+    | "konqueror"
+    | "msie"
+    | "opera"
+    | "rekong"
+    | "safari"
+    | "silk";
+
+type ClientSupportMap = Partial<Record<ClientProfileName, false | null | ClientSupportCondition[]>>;
+type ClientSupportCondition = [
+    "==" | "===" | "!=" | "!==" | "<" | "<=" | ">" | ">=",
+    string | number
+];
+
 interface ClientProfile {
-    name:
-        | "android"
-        | "chrome"
-        | "crios"
-        | "edge"
-        | "firefox"
-        | "fxios"
-        | "konqueror"
-        | "msie"
-        | "opera"
-        | "rekong"
-        | "safari"
-        | "silk";
+    name: ClientProfileName;
     layout: "edge" | "gecko" | "khtml" | "presto" | "trident" | "webkit";
     layoutVersion: number;
     platform: "ipad" | "iphone" | "linux" | "mac" | "solaris" | "win";

--- a/jquery/collapsibleTabs.d.ts
+++ b/jquery/collapsibleTabs.d.ts
@@ -13,13 +13,21 @@ declare global {
     }
 }
 
-/** A jQuery plugin that makes collapsible tabs for the Vector skin. */
+/**
+ * A jQuery plugin that makes collapsible tabs for the Vector skin.
+ */
 interface CollapsibleTabsOptions {
-    /** Optional tab selector. Defaults to `#p-views ul`. */
+    /**
+     * Optional tab selector. Defaults to `#p-views ul`.
+     */
     expandedContainer: string;
-    /** Optional menu item selector. Defaults to `#p-cactions ul`. */
+    /**
+     * Optional menu item selector. Defaults to `#p-cactions ul`.
+     */
     collapsedContainer: string;
-    /** Optional selector for tabs that are collapsible. Defaults to `li.collapsible`. */
+    /**
+     * Optional selector for tabs that are collapsible. Defaults to `li.collapsible`.
+     */
     collapsible: string;
     shifting: boolean;
     expandedWidth: number;

--- a/jquery/colorUtil.d.ts
+++ b/jquery/colorUtil.d.ts
@@ -67,10 +67,12 @@ interface ColorUtil {
      *
      * Usage:
      *
-     *     $.colorUtil.getColorBrightness( 'red', +0.1 );
-     *     // > "rgb(255,50,50)"
-     *     $.colorUtil.getColorBrightness( 'rgb(200,50,50)', -0.2 );
-     *     // > "rgb(118,29,29)"
+     * ```js
+     * $.colorUtil.getColorBrightness( 'red', +0.1 );
+     * // > "rgb(255,50,50)"
+     * $.colorUtil.getColorBrightness( 'rgb(200,50,50)', -0.2 );
+     * // > "rgb(118,29,29)"
+     * ```
      *
      * @param {Mixed} currentColor Current value in css
      * @param {number} mod Wanted brightness modification between -1 and 1

--- a/jquery/colorUtil.d.ts
+++ b/jquery/colorUtil.d.ts
@@ -4,6 +4,8 @@ declare global {
     }
 }
 
+type Color = [number, number, number];
+
 interface ColorUtil {
     /**
      * Parse CSS color strings looking for color tuples
@@ -11,10 +13,10 @@ interface ColorUtil {
      * Based on highlightFade by Blair Mitchelmore
      * <http://jquery.offput.ca/highlightFade/>
      *
-     * @param {Array|string} color
-     * @returns {Array}
+     * @param {Color|string} color
+     * @returns {Color}
      */
-    getRGB(color: string | number[]): number[];
+    getRGB<T extends Color>(color: string | T): T;
 
     /**
      * Named color map
@@ -22,7 +24,7 @@ interface ColorUtil {
      * Based on Interface by Stefan Petre
      * <http://interface.eyecon.ro/>
      */
-    colors: Record<string, [number, number, number]>;
+    colors: Record<string, Color>;
 
     /**
      * Convert an RGB color value to HSL.
@@ -38,9 +40,9 @@ interface ColorUtil {
      * @param {number} r The red color value
      * @param {number} g The green color value
      * @param {number} b The blue color value
-     * @returns {number[]} The HSL representation
+     * @returns {Color} The HSL representation
      */
-    rgbToHsl(r: number, g: number, b: number): number[];
+    rgbToHsl(r: number, g: number, b: number): Color;
 
     /**
      * Convert an HSL color value to RGB.
@@ -56,9 +58,9 @@ interface ColorUtil {
      * @param {number} h The hue
      * @param {number} s The saturation
      * @param {number} l The lightness
-     * @returns {number[]} The RGB representation
+     * @returns {Color} The RGB representation
      */
-    hslToRgb(h: number, s: number, l: number): number[];
+    hslToRgb(h: number, s: number, l: number): Color;
 
     /**
      * Get a brighter or darker rgb() value string.
@@ -72,11 +74,14 @@ interface ColorUtil {
      * // > "rgb(118,29,29)"
      * ```
      *
-     * @param {Mixed} currentColor Current value in css
+     * @param {Color|string} currentColor Current value in css
      * @param {number} mod Wanted brightness modification between -1 and 1
      * @returns {string} Like `'rgb(r,g,b)'`
      */
-    getColorBrightness(currentColor: any, mod: number): `rgb(${number},${number},${number})`;
+    getColorBrightness(
+        currentColor: string | Color,
+        mod: number
+    ): `rgb(${number},${number},${number})`;
 }
 
 export {};

--- a/jquery/colorUtil.d.ts
+++ b/jquery/colorUtil.d.ts
@@ -12,7 +12,7 @@ interface ColorUtil {
      * <http://jquery.offput.ca/highlightFade/>
      *
      * @param {Array|string} color
-     * @return {Array}
+     * @returns {Array}
      */
     getRGB(color: string | number[]): number[];
 
@@ -21,8 +21,6 @@ interface ColorUtil {
      *
      * Based on Interface by Stefan Petre
      * <http://interface.eyecon.ro/>
-     *
-     * @property {Object}
      */
     colors: Record<string, [number, number, number]>;
 
@@ -40,7 +38,7 @@ interface ColorUtil {
      * @param {number} r The red color value
      * @param {number} g The green color value
      * @param {number} b The blue color value
-     * @return {number[]} The HSL representation
+     * @returns {number[]} The HSL representation
      */
     rgbToHsl(r: number, g: number, b: number): number[];
 
@@ -58,7 +56,7 @@ interface ColorUtil {
      * @param {number} h The hue
      * @param {number} s The saturation
      * @param {number} l The lightness
-     * @return {number[]} The RGB representation
+     * @returns {number[]} The RGB representation
      */
     hslToRgb(h: number, s: number, l: number): number[];
 
@@ -76,7 +74,7 @@ interface ColorUtil {
      *
      * @param {Mixed} currentColor Current value in css
      * @param {number} mod Wanted brightness modification between -1 and 1
-     * @return {string} Like `'rgb(r,g,b)'`
+     * @returns {string} Like `'rgb(r,g,b)'`
      */
     getColorBrightness(currentColor: any, mod: number): `rgb(${number},${number},${number})`;
 }

--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -1,6 +1,6 @@
 import "jquery";
 
-import "./textSelection";
-import "./collapsibleTabs";
 import "./client";
+import "./collapsibleTabs";
 import "./colorUtil";
+import "./textSelection";

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -1,17 +1,55 @@
 declare global {
     interface JQuery {
-        // one overload for each command
+        /**
+         * Get the contents of the textarea.
+         *
+         * @param {string} command Command to execute
+         * @return {string}
+         */
         textSelection(command: "getContents"): string;
 
+        /**
+         * Set the contents of the textarea, replacing anything that was there before.
+         *
+         * @param {string} command Command to execute
+         * @param {string} content
+         * @return {JQuery}
+         * @chainable
+         */
         textSelection(command: "setContents"): JQuery;
 
+        /**
+         * Get the currently selected text in this textarea.
+         *
+         * @param {string} command Command to execute
+         * @return {string}
+         */
         textSelection(command: "getSelection"): string;
 
+        /**
+         * Replace the selected text in the textarea with the given text, or insert it at the cursor.
+         *
+         * @param {string} command Command to execute
+         * @param {string} value
+         * @return {JQuery}
+         * @chainable
+         */
         textSelection(command: "replaceSelection"): JQuery;
 
+        /**
+         * Insert text at the beginning and end of a text selection, optionally
+         * inserting text at the caret when selection is empty.
+         *
+         * Also focusses the textarea.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} [options]
+         * @return {JQuery}
+         * @chainable
+         */
         textSelection(
             command: "encapsulateSelection",
-            commandOptions: {
+            options: {
                 pre?: string;
                 peri?: string;
                 post?: string;
@@ -24,38 +62,73 @@ declare global {
             }
         ): JQuery;
 
+        /**
+         * Get the current cursor position (in UTF-16 code units) in a textarea.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} [options]
+         * @param {Object} [options.startAndEnd=false] Return range of the selection rather than just start
+         * @return {Array} Array with two numbers, for start and end of selection
+         */
         textSelection(
             command: "getCaretPosition",
-            commandOptions?: {
-                startAndEnd?: false;
-            }
-        ): number;
-
-        textSelection(
-            command: "getCaretPosition",
-            commandOptions: {
-                startAndEnd: true;
-            }
+            options: { startAndEnd: true }
         ): [number, number];
 
-        textSelection(
-            command: "setSelection",
-            commandOptions: {
-                start?: number;
-                end?: number;
-            }
-        ): JQuery;
+        /**
+         * Get the current cursor position (in UTF-16 code units) in a textarea.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} [options]
+         * @param {Object} [options.startAndEnd=false] Return range of the selection rather than just start
+         * @return {number}
+         */
+        textSelection(command: "getCaretPosition", options?: { startAndEnd?: false }): number;
 
-        textSelection(
-            command: "scrollToCaretPosition",
-            commandOptions: {
-                force?: boolean;
-            }
-        ): JQuery;
+        /**
+         * Set the current cursor position (in UTF-16 code units) in a textarea.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} options
+         * @param {number} options.start
+         * @param {number} [options.end=options.start]
+         * @return {JQuery}
+         * @chainable
+         */
+        textSelection(command: "setSelection", options: { start?: number; end?: number }): JQuery;
 
+        /**
+         * Scroll a textarea to the current cursor position. You can set the cursor
+         * position with 'setSelection'.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} [options]
+         * @param {string} [options.force=false] Whether to force a scroll even if the caret position
+         *  is already visible.
+         * @return {JQuery}
+         * @chainable
+         */
+        textSelection(command: "scrollToCaretPosition", options: { force?: boolean }): JQuery;
+
+        /**
+         * Register an alternative textSelection API for this element.
+         *
+         * @param {string} command Command to execute
+         * @param {Object} functions Functions to replace. Keys are command names (as in {@link textSelection},
+         *  except 'register' and 'unregister'). Values are functions to execute when a given command is
+         *  called.
+         */
+        textSelection(
+            command: "register",
+            functions: Record<string, (...commandOptions: any[]) => any>
+        ): void;
+
+        /**
+         * Unregister the alternative textSelection API for this element (see 'register').
+         *
+         * @param {string} command Command to execute
+         */
         textSelection(command: "unregister"): void;
-
-        textSelection(command: "register", commandOptions: Record<string, (...args: any[]) => any>): void;
     }
 }
 

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -4,7 +4,8 @@ declare global {
          * Get the contents of the textarea.
          *
          * @param {string} command Command to execute
-         * @return {string}
+         * @returns {string}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "getContents"): string;
 
@@ -13,8 +14,8 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {string} content
-         * @return {JQuery}
-         * @chainable
+         * @returns {JQuery}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "setContents", content: string): this;
 
@@ -22,7 +23,8 @@ declare global {
          * Get the currently selected text in this textarea.
          *
          * @param {string} command Command to execute
-         * @return {string}
+         * @returns {string}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "getSelection"): string;
 
@@ -31,8 +33,8 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {string} value
-         * @return {JQuery}
-         * @chainable
+         * @returns {JQuery}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "replaceSelection", value: string): this;
 
@@ -43,9 +45,9 @@ declare global {
          * Also focusses the textarea.
          *
          * @param {string} command Command to execute
-         * @param {Object} [options]
-         * @return {JQuery}
-         * @chainable
+         * @param {TextSelectionEncapsulateOptions} [options]
+         * @returns {JQuery}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(
             command: "encapsulateSelection",
@@ -57,8 +59,9 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {Object} [options]
-         * @param {Object} [options.startAndEnd=false] Return range of the selection rather than just start
-         * @return {Array} Array with two numbers, for start and end of selection
+         * @param {boolean} [options.startAndEnd=false] Return range of the selection rather than just start
+         * @returns {number[]} Array with two numbers, for start and end of selection
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(
             command: "getCaretPosition",
@@ -70,8 +73,9 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {Object} [options]
-         * @param {Object} [options.startAndEnd=false] Return range of the selection rather than just start
-         * @return {number}
+         * @param {boolean} [options.startAndEnd=false] Return range of the selection rather than just start
+         * @returns {number}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "getCaretPosition", options?: { startAndEnd?: false }): number;
 
@@ -82,8 +86,8 @@ declare global {
          * @param {Object} options
          * @param {number} options.start
          * @param {number} [options.end=options.start]
-         * @return {JQuery}
-         * @chainable
+         * @returns {JQuery}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "setSelection", options: { start: number; end?: number }): this;
 
@@ -93,10 +97,10 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {Object} [options]
-         * @param {string} [options.force=false] Whether to force a scroll even if the caret position
+         * @param {boolean} [options.force=false] Whether to force a scroll even if the caret position
          *  is already visible.
-         * @return {JQuery}
-         * @chainable
+         * @returns {JQuery}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "scrollToCaretPosition", options: { force?: boolean }): this;
 
@@ -104,9 +108,10 @@ declare global {
          * Register an alternative textSelection API for this element.
          *
          * @param {string} command Command to execute
-         * @param {Object} functions Functions to replace. Keys are command names (as in {@link textSelection},
+         * @param {Object.<string, Function>} functions Functions to replace. Keys are command names (as in {@link textSelection},
          *  except 'register' and 'unregister'). Values are functions to execute when a given command is
          *  called.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(
             command: "register",
@@ -117,6 +122,7 @@ declare global {
          * Unregister the alternative textSelection API for this element (see 'register').
          *
          * @param {string} command Command to execute
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: "unregister"): void;
 
@@ -125,7 +131,8 @@ declare global {
          *
          * @param {string} command Command to execute
          * @param {Mixed} [commandOptions] Options to pass to the command
-         * @return {Mixed} Depending on the command
+         * @returns {Mixed} Depending on the command
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: string, commandOptions?: any): void;
     }

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -16,7 +16,7 @@ declare global {
          * @return {JQuery}
          * @chainable
          */
-        textSelection(command: "setContents"): JQuery;
+        textSelection(command: "setContents", content: string): this;
 
         /**
          * Get the currently selected text in this textarea.
@@ -34,7 +34,7 @@ declare global {
          * @return {JQuery}
          * @chainable
          */
-        textSelection(command: "replaceSelection"): JQuery;
+        textSelection(command: "replaceSelection", value: string): this;
 
         /**
          * Insert text at the beginning and end of a text selection, optionally
@@ -49,18 +49,8 @@ declare global {
          */
         textSelection(
             command: "encapsulateSelection",
-            options: {
-                pre?: string;
-                peri?: string;
-                post?: string;
-                ownline?: boolean;
-                replace?: boolean;
-                selectPeri?: boolean;
-                splitlines?: boolean;
-                selectionStart?: number;
-                selectionEnd?: number;
-            }
-        ): JQuery;
+            options?: Partial<TextSelectionEncapsulateOptions>
+        ): this;
 
         /**
          * Get the current cursor position (in UTF-16 code units) in a textarea.
@@ -95,7 +85,7 @@ declare global {
          * @return {JQuery}
          * @chainable
          */
-        textSelection(command: "setSelection", options: { start?: number; end?: number }): JQuery;
+        textSelection(command: "setSelection", options: { start: number; end?: number }): this;
 
         /**
          * Scroll a textarea to the current cursor position. You can set the cursor
@@ -108,7 +98,7 @@ declare global {
          * @return {JQuery}
          * @chainable
          */
-        textSelection(command: "scrollToCaretPosition", options: { force?: boolean }): JQuery;
+        textSelection(command: "scrollToCaretPosition", options: { force?: boolean }): this;
 
         /**
          * Register an alternative textSelection API for this element.
@@ -120,7 +110,7 @@ declare global {
          */
         textSelection(
             command: "register",
-            functions: Record<string, (...commandOptions: any[]) => any>
+            functions: Record<string, (commandOptions: unknown) => any>
         ): void;
 
         /**
@@ -129,7 +119,55 @@ declare global {
          * @param {string} command Command to execute
          */
         textSelection(command: "unregister"): void;
+
+        /**
+         * Do things to the selection in the textarea, using a command from the alternative textSelection API for this element.
+         *
+         * @param {string} command Command to execute
+         * @param {Mixed} [commandOptions] Options to pass to the command
+         * @return {Mixed} Depending on the command
+         */
+        textSelection(command: string, commandOptions?: any): void;
     }
+}
+
+interface TextSelectionEncapsulateOptions {
+    /**
+     * Text to insert before the cursor/selection.
+     */
+    pre: string;
+    /**
+     * Text to insert between pre and post and select afterwards.
+     */
+    peri: string;
+    /**
+     * Text to insert after the cursor/selection.
+     */
+    post: string;
+    /**
+     * Put the inserted text on a line of its own. Defaults to false.
+     */
+    ownline: boolean;
+    /**
+     * If there is a selection, replace it with peri instead of leaving it alone. Defaults to false.
+     */
+    replace: boolean;
+    /**
+     * Select the peri text if it was inserted (but not if there was a selection and replace==false, or if splitlines==true). Defaults to true.
+     */
+    selectPeri: boolean;
+    /**
+     * If multiple lines are selected, encapsulate each line individually. Defaults to false.
+     */
+    splitlines: boolean;
+    /**
+     * Position to start selection at.
+     */
+    selectionStart: number;
+    /**
+     * Position to end selection at. Defaults to the position to start setection at.
+     */
+    selectionEnd: number;
 }
 
 export {};

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -134,7 +134,7 @@ declare global {
          * @returns {Mixed} Depending on the command
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
-        textSelection(command: string, commandOptions?: any): void;
+        textSelection(command: string, commandOptions?: unknown): any;
     }
 }
 

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -45,7 +45,7 @@ declare global {
          * Also focusses the textarea.
          *
          * @param {string} command Command to execute
-         * @param {TextSelectionEncapsulateOptions} [options]
+         * @param {Partial<TextSelectionEncapsulateOptions>} [options]
          * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
@@ -60,24 +60,18 @@ declare global {
          * @param {string} command Command to execute
          * @param {Object} [options]
          * @param {boolean} [options.startAndEnd=false] Return range of the selection rather than just start
-         * @returns {number[]} Array with two numbers, for start and end of selection
+         * @returns {number|number[]} Array with two numbers, for start and end of selection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(
             command: "getCaretPosition",
             options: { startAndEnd: true }
         ): [number, number];
-
-        /**
-         * Get the current cursor position (in UTF-16 code units) in a textarea.
-         *
-         * @param {string} command Command to execute
-         * @param {Object} [options]
-         * @param {boolean} [options.startAndEnd=false] Return range of the selection rather than just start
-         * @returns {number}
-         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
-         */
         textSelection(command: "getCaretPosition", options?: { startAndEnd?: false }): number;
+        textSelection(
+            command: "getCaretPosition",
+            options?: { startAndEnd: boolean }
+        ): number | [number, number];
 
         /**
          * Set the current cursor position (in UTF-16 code units) in a textarea.
@@ -130,8 +124,8 @@ declare global {
          * Do things to the selection in the textarea, using a command from the alternative textSelection API for this element.
          *
          * @param {string} command Command to execute
-         * @param {Mixed} [commandOptions] Options to pass to the command
-         * @returns {Mixed} Depending on the command
+         * @param {any} [commandOptions] Options to pass to the command
+         * @returns {any} Depending on the command
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/jQuery.plugin.textSelection-method-textSelection
          */
         textSelection(command: string, commandOptions?: unknown): any;

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -80,6 +80,9 @@ interface RollbackInfo {
 interface FinishUpload {
     /**
      * Call this function to finish the upload.
+     *
+     * @param {ApiUploadParams} data Additional data for the upload.
+     * @returns {JQuery.Promise<ApiResponse>} API promise for the final upload.
      */
     (data?: ApiUploadParams): JQuery.Promise<ApiResponse>;
 }
@@ -154,7 +157,7 @@ declare global {
             abort(): void;
 
             /**
-             * Perform API get request.
+             * Perform API get request. See {@link ajax()} for details.
              *
              * @param {UnknownApiParams} parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
@@ -167,7 +170,7 @@ declare global {
             ): JQuery.Promise<ApiResponse>;
 
             /**
-             * Perform API post request.
+             * Perform API post request. See {@link ajax()} for details.
              *
              * @param {UnknownApiParams} parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
@@ -191,9 +194,30 @@ declare global {
             /**
              * Perform the API call.
              *
-             * @param {UnknownApiParams} parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {JQuery.Promise<ApiResponse>} API response data and the jqXHR object
+             * @param {UnknownApiParams} parameters Parameters to the API. See also {@link ApiOptions.parameters}
+             * @param {JQuery.AjaxSettings} [ajaxOptions] Parameters to pass to jQuery.ajax. See also {@link ApiOptions.ajax}
+             * @returns {JQuery.Promise<ApiResponse>} A promise that settles when the API response is processed.
+             *   Has an 'abort' method which can be used to abort the request.
+             *
+             *   - On success, resolves to `( result, jqXHR )` where `result` is the parsed API response.
+             *   - On an API error, rejects with `( code, result, result, jqXHR )` where `code` is the
+             *     [API error code](https://www.mediawiki.org/wiki/API:Errors_and_warnings), and `result`
+             *     is as above. When there are multiple errors, the code from the first one will be used.
+             *     If there is no error code, "unknown" is used.
+             *   - On other types of errors, rejects with `( 'http', details )` where `details` is an object
+             *     with three fields: `xhr` (the jqXHR object), `textStatus`, and `exception`.
+             *     The meaning of the last two fields is as follows:
+             *     - When the request is aborted (the abort method of the promise is called), textStatus
+             *       and exception are both set to "abort".
+             *     - On a network timeout, textStatus and exception are both set to "timeout".
+             *     - On a network error, textStatus is "error" and exception is the empty string.
+             *     - When the HTTP response code is anything other than 2xx or 304 (the API does not
+             *       use such response codes but some intermediate layer might), textStatus is "error"
+             *       and exception is the HTTP status text (the text following the status code in the
+             *       first line of the server response). For HTTP/2, `exception` is always an empty string.
+             *     - When the response is not valid JSON but the previous error conditions aren't met,
+             *       textStatus is "parsererror" and exception is the exception object thrown by
+             *       `JSON.parse`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-ajax
              */
             ajax(
@@ -202,9 +226,9 @@ declare global {
             ): JQuery.Promise<ApiResponse>;
 
             /**
-             * Post to API with specified type of token. If we have no token, get one and try to post.
-             * If we have a cached token try using that, and if it fails, blank out the
-             * cached token and start over. For example to change an user option you could do:
+             * Post to API with the specified type of token. If we have no token, get one and try to post.
+             * If we already have a cached token, try using that, and if the request fails using the cached token,
+             * blank it out and start over. For example, to change a user option, you could do:
              *
              * ```js
              * new mw.Api().postWithToken( 'csrf', {
@@ -215,10 +239,10 @@ declare global {
              * ```
              *
              * @since 1.22
-             * @param {string} tokenType The name of the token, like `options` or `edit`
+             * @param {string} tokenType The name of the token, like `options` or `edit`.
              * @param {UnknownApiParams} params API parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {JQuery.Promise<ApiResponse>}
+             * @returns {JQuery.Promise<ApiResponse>} See {@link post}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-postWithToken
              */
             postWithToken(
@@ -319,7 +343,7 @@ declare global {
              * Post to API with csrf token. If we have no token, get one and try to post. If we have a cached token try using that, and if it fails, blank out the cached token and start over.
              *
              * @param {UnknownApiParams} params API parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
+             * @param {JQuery.AjaxSettings} [ajaxOptions] See {@link post}
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-postWithEditToken
              */
@@ -419,7 +443,7 @@ declare global {
              * @since 1.28
              * @param {TitleLike} title Page title
              * @param {function(Revision):string|ApiEditPageParams} transform Callback that prepares the edit
-             * @returns {JQuery.Promise<EditResult>}
+             * @returns {JQuery.Promise<EditResult>} Edit API response
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-edit
              */
             edit(
@@ -483,7 +507,7 @@ declare global {
             saveOption(name: string, value: string | null): JQuery.Promise<ApiResponse>;
 
             /**
-             * Asynchronously save the values of user options using the API.
+             * Asynchronously save the values of user options using the [Options API](https://www.mediawiki.org/wiki/API:Options).
              *
              * If a value of `null` is provided, the given option will be reset to the default value.
              *
@@ -541,7 +565,7 @@ declare global {
              * @since 1.27
              * @param {string|string[]} messages Messages to retrieve
              * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
-             * @returns {JQuery.Promise<Partial<Record<T, string>>>}
+             * @returns {JQuery.Promise<Object.<string, string>>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-getMessages
              */
             getMessages<T extends string>(
@@ -711,7 +735,7 @@ declare global {
             /**
              * @param {string} username
              * @param {string} password
-             * @returns {JQuery.Promise<ApiResponse>}
+             * @returns {JQuery.Promise<ApiResponse>} See {@link post()}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.login-method-login
              */
             login(username: string, password: string): JQuery.Promise<ApiResponse>;

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -8,7 +8,9 @@ import {
 import { TitleLike } from "./Title";
 import { UserInfo } from "./user";
 
-type TitleLikeArray = string[] | mw.Title[]; // TitleLike[] would be a mixed array
+type TypeOrArray<T> = T extends any ? T | T[] : never; // T[] would be a mixed array
+type ReplaceValue<T extends U | U[], U, V> = T extends U[] ? V[] : V;
+
 type ApiParams = Record<string, string | string[] | boolean | number | number[]>;
 type ApiResponse = Record<string, any>; // it will always be a JSON object, the rest is uncertain ...
 
@@ -22,11 +24,11 @@ export interface ApiOptions {
     /**
      * Default query parameters for API requests
      */
-    parameters?: ApiParams;
+    parameters: ApiParams;
     /**
      * Default options for {@link jQuery.ajax}
      */
-    ajax?: JQuery.AjaxSettings;
+    ajax: JQuery.AjaxSettings;
     /**
      * Whether to use U+001F when joining multi-valued parameters (since 1.28).
      * Default is true if ajax.url is not set, false otherwise for compatibility.
@@ -70,7 +72,7 @@ declare global {
              * @param {ApiOptions} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-constructor
              */
-            constructor(options?: ApiOptions);
+            constructor(options?: Partial<ApiOptions>);
 
             private defaults: ApiOptions;
 
@@ -405,34 +407,30 @@ declare global {
             /**
              * Convenience method for `action=watch`.
              *
-             * @param {TitleLike | TitleLikeArray} pages
+             * @param {TypeOrArray<TitleLike>} pages
              * @param {string} [expiry]
-             * @returns {JQuery.Promise<{ watch: { title: string, watched: boolean } | Array<{ title: string, watched: boolean }> }>}
+             * @returns {JQuery.Promise<{ watch: TypeOrArray<{ title: string, watched: boolean }> }>}
              * @since 1.35: expiry parameter can be passed when watchlist expiry is enabled
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-watch
              */
-            watch<P extends TitleLike | TitleLikeArray>(
+            watch<P extends TypeOrArray<TitleLike>>(
                 pages: P,
                 expiry?: string
             ): JQuery.Promise<{
-                watch: P extends TitleLikeArray
-                    ? Array<{ title: string; watched: boolean }>
-                    : { title: string; watched: boolean };
+                watch: ReplaceValue<P, TitleLike, { title: string; watched: boolean }>;
             }>;
 
             /**
              * Convenience method for `action=watch&unwatch=1`.
              *
-             * @param {TitleLike | TitleLikeArray} pages
-             * @returns {JQuery.Promise<{ watch: { title: string, watched: boolean } | Array<{ title: string, watched: boolean }> }>}
+             * @param {TypeOrArray<TitleLike>} pages
+             * @returns {JQuery.Promise<{ watch: TypeOrArray<{ title: string, watched: boolean }> }>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-unwatch
              */
-            unwatch<P extends TitleLike | TitleLikeArray>(
+            unwatch<P extends TypeOrArray<TitleLike>>(
                 pages: P
             ): JQuery.Promise<{
-                watch: P extends TitleLikeArray
-                    ? Array<{ title: string; watched: boolean }>
-                    : { title: string; watched: boolean };
+                watch: ReplaceValue<P, TitleLike, { title: string; watched: boolean }>;
             }>;
 
             /**
@@ -559,7 +557,7 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-chunkedUploadToStash
              */
             chunkedUploadToStash(
-                file: File,
+                file: File | HTMLInputElement,
                 data?: ApiUploadParams,
                 chunkSize?: number,
                 chunkRetries?: number

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -136,6 +136,7 @@ declare global {
              *
              * @param {ApiParams} parameters (modified in-place)
              * @param {boolean} useUS Whether to use U+001F when joining multi-valued parameters.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-preprocessParameters
              */
             private preprocessParameters(parameters: ApiParams, useUS: boolean): void;
 
@@ -165,11 +166,11 @@ declare global {
              * } );
              * ```
              *
+             * @since 1.22
              * @param {string} tokenType The name of the token, like `options` or `edit`
              * @param {ApiParams} params API parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>}
-             * @since 1.22
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-postWithToken
              */
             postWithToken(
@@ -181,10 +182,10 @@ declare global {
             /**
              * Get a token for a certain action from the API.
              *
+             * @since 1.22
              * @param {string} type Token type
              * @param {ApiParams|string} [additionalParams] Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
              * @returns {JQuery.Promise<string>} Received token
-             * @since 1.22
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getToken
              */
             getToken(type: string, additionalParams?: ApiParams | string): JQuery.Promise<string>;
@@ -196,8 +197,8 @@ declare global {
              * You may also want to use `postWithToken()` instead, which invalidates bad cached tokens
              * automatically.
              *
-             * @param {string} type Token type
              * @since 1.26
+             * @param {string} type Token type
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-badToken
              */
             badToken(type: string): void;
@@ -273,6 +274,7 @@ declare global {
              * );
              * ```
              *
+             * @since 1.28
              * @param {TitleLike} title Page title
              * @param {ApiEditPageParams} params Edit API parameters
              * @param {string} content Page content
@@ -340,6 +342,7 @@ declare global {
              *     } );
              * ```
              *
+             * @since 1.28
              * @param {TitleLike} title Page title
              * @param {function(Revision):string|ApiEditPageParams} transform Callback that prepares the edit
              * @returns {JQuery.Promise<any>}
@@ -370,6 +373,7 @@ declare global {
             /**
              * Get the current user's groups and rights.
              *
+             * @since 1.27
              * @returns {JQuery.Promise<UserInfo>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.user-method-getUserInfo
              */
@@ -385,6 +389,7 @@ declare global {
              * * `apierror-assertuserfailed`: when the client-side logic thinks the user is logged in but the server thinks it is anonymous
              * * `apierror-assertnameduserfailed`: when both the client-side logic and the server thinks the user is logged in but they see it logged in under a different username.
              *
+             * @since 1.27
              * @param {ApiParams} query Query parameters. The object will not be changed
              * @returns {JQuery.Promise<AssertUser>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.user-method-assertCurrentUser
@@ -412,7 +417,7 @@ declare global {
              *
              * If a request from a previous `saveOptions()` call is still pending, this will wait for it to be completed, otherwise MediaWiki gets sad. No requests are sent for anonymous users, as they would fail anyway. See T214963.
              *
-             * @param {Object} options Options as a `{ name: value, … }` object
+             * @param {Object.<string, string|null>} options Options as a `{ name: value, … }` object
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOptions
              */
@@ -421,10 +426,10 @@ declare global {
             /**
              * Convenience method for `action=watch`.
              *
+             * @since 1.35 - expiry parameter can be passed when Watchlist Expiry is enabled
              * @param {TypeOrArray<TitleLike>} pages
              * @param {string} [expiry]
              * @returns {JQuery.Promise<{ watch: TypeOrArray<WatchStatus> }>}
-             * @since 1.35: expiry parameter can be passed when watchlist expiry is enabled
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-watch
              */
             watch<P extends TypeOrArray<TitleLike>>(
@@ -457,32 +462,34 @@ declare global {
             /**
              * Get a set of messages.
              *
-             * @param {string[]} messages Messages to retrieve
+             * @since 1.27
+             * @param {string|string[]} messages Messages to retrieve
              * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-getMessages
              */
             getMessages(
-                messages: string[],
+                messages: string | string[],
                 options?: ApiQueryAllMessagesParams
             ): JQuery.Promise<ApiResponse>;
 
             /**
              * Load a set of messages and add them to `mw.messages`.
              *
-             * @param {string[]} messages Messages to retrieve
+             * @param {string|string[]} messages Messages to retrieve
              * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-loadMessages
              */
             loadMessages(
-                messages: string[],
+                messages: string | string[],
                 options?: ApiQueryAllMessagesParams
             ): JQuery.Promise<ApiResponse>;
 
             /**
              * Load a set of messages and add them to `mw.messages`. Only messages that are not already known are loaded. If all messages are known, the returned promise is resolved immediately.
              *
+             * @since 1.27
              * @param {string[]} messages Messages to retrieve
              * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
@@ -525,6 +532,7 @@ declare global {
             /**
              * Convenience method for `action=rollback`.
              *
+             * @since 1.28
              * @param {TitleLike} page
              * @param {string} user
              * @param {ApiRollbackParams} [params] Additional parameters

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -5,9 +5,9 @@ import {
     ApiRollbackParams,
     ApiUploadParams,
 } from "../api_params";
+import { TitleLike } from "./Title";
 import { UserInfo } from "./user";
 
-type TitleLike = string | mw.Title;
 type TitleLikeArray = string[] | mw.Title[]; // TitleLike[] would be a mixed array
 type ApiParams = Record<string, string | string[] | boolean | number | number[]>;
 type ApiResponse = Record<string, any>; // it will always be a JSON object, the rest is uncertain ...
@@ -72,15 +72,11 @@ declare global {
              */
             constructor(options?: ApiOptions);
 
-            /**
-             * @private
-             */
-            defaults: ApiOptions;
+            private defaults: ApiOptions;
 
             /**
              * Abort all unfinished requests issued by this Api object.
              *
-             * @returns {void}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-abort
              */
             abort(): void;
@@ -114,10 +110,8 @@ declare global {
             /**
              * Massage parameters from the nice format we accept into a format suitable for the API.
              *
-             * @private
              * @param {ApiParams} parameters (modified in-place)
              * @param {boolean} useUS Whether to use U+001F when joining multi-valued parameters.
-             * @returns {void}
              */
             private preprocessParameters(parameters: ApiParams, useUS: boolean): void;
 
@@ -164,7 +158,7 @@ declare global {
              * Get a token for a certain action from the API.
              *
              * @param {string} type Token type
-             * @param {ApiParams | string} [additionalParams] Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
+             * @param {ApiParams|string} [additionalParams] Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
              * @returns {JQuery.Promise<string>} Received token
              * @since 1.22
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getToken
@@ -179,7 +173,6 @@ declare global {
              * automatically.
              *
              * @param {string} type Token type
-             * @returns {void}
              * @since 1.26
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-badToken
              */
@@ -217,7 +210,7 @@ declare global {
              * } );
              * ```
              *
-             * @param {Object} data API response indicating an error
+             * @param {ApiResponse} data API response indicating an error
              * @returns {JQuery} Error messages, each wrapped in a `<div>`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getErrorMessage
              */
@@ -324,7 +317,7 @@ declare global {
              * ```
              *
              * @param {TitleLike} title Page title
-             * @param {(data: { timestamp: string, content: string }) => string | ApiEditPageParams} transform Callback that prepares the edit
+             * @param {function({ timestamp: string, content: string }):string|ApiEditPageParams} transform Callback that prepares the edit
              * @returns {JQuery.Promise<any>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-edit
              */
@@ -516,10 +509,10 @@ declare global {
              * Get the categories that a particular page on the wiki belongs to.
              *
              * @param {TitleLike} title
-             * @returns {JQuery.Promise<false | mw.Title[]>} List of category titles or false if title was not found
+             * @returns {JQuery.Promise<false|Title[]>} List of category titles or false if title was not found
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.category-method-getCategories
              */
-            getCategories(title: TitleLike): JQuery.Promise<false | mw.Title[]>;
+            getCategories(title: TitleLike): JQuery.Promise<false | Title[]>;
 
             /**
              * Convenience method for `action=rollback`.
@@ -558,7 +551,7 @@ declare global {
              *
              * This function will return a promise that will resolve with a function to finish the stash upload.
              *
-             * @param {File | HTMLInputElement} file
+             * @param {File|HTMLInputElement} file
              * @param {ApiUploadParams} [data]
              * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
              * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
@@ -577,9 +570,9 @@ declare global {
              *
              * The file will be uploaded using AJAX and FormData.
              *
-             * @param {HTMLInputElement | File | Blob} file HTML `input type=file` element with a file already inside of it, or a File object.
+             * @param {File|Blob|HTMLInputElement} file HTML `input type=file` element with a file already inside of it, or a File object.
              * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
-             * @return {JQuery.Promise<ApiResponse>}
+             * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-upload
              */
             upload(
@@ -613,9 +606,8 @@ declare global {
              * } );
              * ```
              *
-             * @param {File | HTMLInputElement} file
+             * @param {File|HTMLInputElement} file
              * @param {ApiUploadParams} [data]
-             * @return {JQuery.Promise}
              * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-uploadToStash
              */

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -12,7 +12,7 @@ type ApiParams = Record<string, string | string[] | boolean | number | number[]>
 type ApiResponse = Record<string, any>; // it will always be a JSON object, the rest is uncertain ...
 
 /**
- * Default options for jQuery#ajax calls. Can be overridden by passing
+ * Default options for {@link jQuery.ajax} calls. Can be overridden by passing
  * `options` to {@link mw.Api} constructor.
  *
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-property-defaultOptions
@@ -23,7 +23,7 @@ export interface ApiOptions {
      */
     parameters?: ApiParams;
     /**
-     * Default options for jQuery#ajax
+     * Default options for {@link jQuery.ajax}
      */
     ajax?: JQuery.AjaxSettings;
     /**
@@ -41,6 +41,7 @@ declare global {
         class Api {
             /**
              * Constructor to create an object to interact with the API of a particular MediaWiki server. mw.Api objects represent the API of a particular MediaWiki server.
+             *
              * ```js
              * var api = new mw.Api();
              * api.get( {
@@ -50,7 +51,9 @@ declare global {
              *     console.log( data );
              * } );
              * ```
+             *
              * Since MW 1.25, multiple values for a parameter can be specified using an array:
+             *
              * ```js
              * var api = new mw.Api();
              * api.get( {
@@ -60,9 +63,10 @@ declare global {
              *     console.log( data );
              * } );
              * ```
+             *
              * Since MW 1.26, boolean values for a parameter can be specified directly. If the value is false or undefined, the parameter will be omitted from the request, as required by the API.
              *
-             * @param {ApiOptions} options
+             * @param {ApiOptions} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-constructor
              */
             constructor(options?: ApiOptions);
@@ -84,7 +88,7 @@ declare global {
              * Perform API get request.
              *
              * @param {ApiParams} parameters
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-get
              */
@@ -97,7 +101,7 @@ declare global {
              * Perform API post request.
              *
              * @param {ApiParams} parameters
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-post
              */
@@ -120,7 +124,7 @@ declare global {
              * Perform the API call.
              *
              * @param {ApiParams} parameters
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>} API response data and the jqXHR object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-ajax
              */
@@ -133,6 +137,7 @@ declare global {
              * Post to API with specified type of token. If we have no token, get one and try to post.
              * If we have a cached token try using that, and if it fails, blank out the
              * cached token and start over. For example to change an user option you could do:
+             *
              * ```js
              * new mw.Api().postWithToken( 'csrf', {
              *     action: 'options',
@@ -143,7 +148,7 @@ declare global {
              *
              * @param {string} tokenType The name of the token, like `options` or `edit`
              * @param {ApiParams} params API parameters
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>}
              * @since 1.22
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-postWithToken
@@ -158,7 +163,7 @@ declare global {
              * Get a token for a certain action from the API.
              *
              * @param {string} type Token type
-             * @param {(ApiParams | string)?} additionalParams Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
+             * @param {ApiParams | string} [additionalParams] Additional parameters for the API (since 1.35). When given a string, it's treated as the `assert` parameter (since 1.25)
              * @returns {JQuery.Promise<string>} Received token
              * @since 1.22
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-getToken
@@ -221,7 +226,7 @@ declare global {
              * Post to API with csrf token. If we have no token, get one and try to post. If we have a cached token try using that, and if it fails, blank out the cached token and start over.
              *
              * @param {APIParams} params API parameters
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-postWithEditToken
              */
@@ -233,7 +238,7 @@ declare global {
             /**
              * API helper to grab a csrf token.
              *
-             * @returns {JQuery.Promise<string>}
+             * @returns {JQuery.Promise<string>} Received token.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-getEditToken
              */
             getEditToken(): JQuery.Promise<string>;
@@ -242,6 +247,7 @@ declare global {
              * Create a new page.
              *
              * Example:
+             *
              * ```js
              * new mw.Api().create( 'Sandbox',
              *     { summary: 'Load sand particles.' },
@@ -252,7 +258,7 @@ declare global {
              * @param {TitleLike} title Page title
              * @param {ApiEditPageParams} params Edit API parameters
              * @param {string} content Page content
-             * @returns {}
+             * @returns {JQuery.Promise<ApiResponse>} API response
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.edit-method-create
              */
             create(
@@ -267,6 +273,7 @@ declare global {
              * To create a new page, use create() instead.
              *
              * Simple transformation:
+             *
              * ```js
              * new mw.Api()
              *     .edit( 'Sandbox', function ( revision ) {
@@ -276,7 +283,9 @@ declare global {
              *         console.log( 'Saved!' );
              *     } );
              * ```
+             *
              * Set save parameters by returning an object instead of a string:
+             *
              * ```js
              * new mw.Api().edit(
              *     'Sandbox',
@@ -293,7 +302,9 @@ declare global {
              *     console.log( 'Saved!' );
              * } );
              * ```
+             *
              * Transform asynchronously by returning a promise.
+             *
              * ```js
              * new mw.Api()
              *     .edit( 'Sandbox', function ( revision ) {
@@ -394,7 +405,7 @@ declare global {
              *
              * If a request from a previous `saveOptions()` call is still pending, this will wait for it to be completed, otherwise MediaWiki gets sad. No requests are sent for anonymous users, as they would fail anyway. See T214963.
              *
-             * @param {Object} options
+             * @param {Object} options Options as a `{ name: value, … }` object
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.options-method-saveOptions
              */
@@ -404,7 +415,7 @@ declare global {
              * Convenience method for `action=watch`.
              *
              * @param {TitleLike | TitleLikeArray} pages
-             * @param {string?} expiry
+             * @param {string} [expiry]
              * @returns {JQuery.Promise<{ watch: { title: string, watched: boolean } | Array<{ title: string, watched: boolean }> }>}
              * @since 1.35: expiry parameter can be passed when watchlist expiry is enabled
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.watch-method-watch
@@ -436,21 +447,19 @@ declare global {
             /**
              * Convenience method for `action=parse`.
              *
-             * @param {string | mw.Title} content Content to parse, either as a wikitext string or a mw.Title
-             * @param {ApiParseParams} additionalParams
-             * @returns {JQuery.Promise<string>}
+             * @param {TitleLike} content Content to parse, either as a wikitext string or a mw.Title
+             * @param {ApiParseParams} [additionalParams] Parameters object to set custom settings, e.g.
+             *   redirects, sectionpreview.  prop should not be overridden.
+             * @returns {JQuery.Promise<string>} Parsed HTML of `wikitext`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.parse-method-parse
              */
-            parse(
-                content: string | mw.Title,
-                additionalParams?: ApiParseParams
-            ): JQuery.Promise<string>;
+            parse(content: TitleLike, additionalParams?: ApiParseParams): JQuery.Promise<string>;
 
             /**
              * Get a set of messages.
              *
              * @param {string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-getMessages
              */
@@ -463,7 +472,7 @@ declare global {
              * Load a set of messages and add them to `mw.messages`.
              *
              * @param {string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-loadMessages
              */
@@ -476,7 +485,7 @@ declare global {
              * Load a set of messages and add them to `mw.messages`. Only messages that are not already known are loaded. If all messages are known, the returned promise is resolved immediately.
              *
              * @param {string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams?} options Additional parameters for the API call
+             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.messages-method-loadMessagesIfMissing
              */
@@ -519,7 +528,8 @@ declare global {
              *
              * @param {TitleLike} page
              * @param {string} user
-             * @param {ApiRollbackParams?} params Additional parameters
+             * @param {ApiRollbackParams} [params] Additional parameters
+             * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.rollback-method-rollback
              */
             rollback(
@@ -533,8 +543,8 @@ declare global {
              *
              * @param {File} file
              * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
-             * @param {number?} chunkSize Size (in bytes) per chunk (default: 5MB)
-             * @param {number?} chunkRetries Amount of times to retry a failed chunk (default: 1)
+             * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
+             * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
              * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-chunkedUpload
              */
@@ -551,9 +561,9 @@ declare global {
              * This function will return a promise that will resolve with a function to finish the stash upload.
              *
              * @param {File | HTMLInputElement} file
-             * @param {ApiUploadParams?} data
-             * @param {number?} chunkSize Size (in bytes) per chunk (default: 5MB)
-             * @param {number?} chunkRetries Amount of times to retry a failed chunk (default: 1)
+             * @param {ApiUploadParams} [data]
+             * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
+             * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
              * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-chunkedUploadToStash
              */
@@ -593,6 +603,7 @@ declare global {
              * Upload a file to the stash.
              *
              * This function will return a promise that will resolve with a function to finish the stash upload. You can call that function with an argument containing more, or conflicting, data to pass to the server. For example:
+             *
              * ```js
              * // upload a file to the stash with a placeholder filename
              * api.uploadToStash( file, { filename: 'testing.png' } ).done( function ( finish ) {
@@ -605,7 +616,7 @@ declare global {
              * ```
              *
              * @param {File | HTMLInputElement} file
-             * @param {ApiUploadParams?} data
+             * @param {ApiUploadParams} [data]
              * @return {JQuery.Promise}
              * @returns {JQuery.Promise<(data?: ApiUploadParams) => JQuery.Promise<ApiResponse>>} Call this function to finish the upload
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.upload-method-uploadToStash

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -5,6 +5,7 @@ import {
     ApiRollbackParams,
     ApiUploadParams,
 } from "../api_params";
+import { UserInfo } from "./user";
 
 type TitleLike = string | mw.Title;
 type TitleLikeArray = string[] | mw.Title[]; // TitleLike[] would be a mixed array
@@ -355,13 +356,10 @@ declare global {
             /**
              * Get the current user's groups and rights.
              *
-             * @returns {JQuery.Promise<{ groups: string[], rights: string[] }>}
+             * @returns {JQuery.Promise<UserInfo>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api.plugin.user-method-getUserInfo
              */
-            getUserInfo(): JQuery.Promise<{
-                groups: string[];
-                rights: string[];
-            }>;
+            getUserInfo(): JQuery.Promise<UserInfo>;
 
             /**
              * Extend an API parameter object with an assertion that the user won't change.

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -4,7 +4,7 @@ interface ForeignApiOptions extends ApiOptions {
     /**
      * Whether to perform all requests anonymously. Use this option if the target wiki may otherwise not accept cross-origin requests, or if you don't need to perform write actions or read restricted information and want to avoid the overhead.
      */
-    anonymous?: boolean;
+    anonymous: boolean;
 }
 
 declare global {
@@ -39,11 +39,11 @@ declare global {
              * ```
              *
              * @param {string | Uri} url URL pointing to another wiki's `api.php` endpoint.
-             * @param {ForeignApiOptions} [options]
+             * @param {Partial<ForeignApiOptions>} [options]
              * @since 1.26
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
-            constructor(url: string | Uri, options?: ForeignApiOptions);
+            constructor(url: string | Uri, options?: Partial<ForeignApiOptions>);
 
             /**
              * Return the origin to use for API requests, in the required format (protocol, host and port, if any).

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -13,6 +13,11 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi
          */
         class ForeignApi extends Api {
+            static static: {};
+            static super: typeof Api;
+            /** @deprecated Use `super` instead */
+            static parent: typeof Api;
+
             /**
              * Create an object like {@link mw.Api}, but automatically handling everything required to communicate with another MediaWiki wiki via cross-origin requests (CORS).
              *
@@ -51,7 +56,7 @@ declare global {
              * @returns {string|undefined}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-getOrigin
              */
-            protected getOrigin(): string | undefined;
+            protected getOrigin(): "*" | `${string}//${string}` | undefined;
         }
     }
 }

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -49,7 +49,7 @@ declare global {
              * Return the origin to use for API requests, in the required format (protocol, host and port, if any).
              *
              * @protected
-             * @return {string | undefined}
+             * @returns {string|undefined}
              */
             protected getOrigin(): string | undefined;
         }

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -12,11 +12,12 @@ declare global {
         /**
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi
          */
-        class ForeignApi extends mw.Api {
+        class ForeignApi extends Api {
             /**
-             * Create an object like `mw.Api`, but automatically handling everything required to communicate with another MediaWiki wiki via cross-origin requests (CORS).
+             * Create an object like {@link mw.Api}, but automatically handling everything required to communicate with another MediaWiki wiki via cross-origin requests (CORS).
              *
              * The foreign wiki must be configured to accept requests from the current wiki. See <https://www.mediawiki.org/wiki/Manual:$wgCrossSiteAJAXdomains> for details.
+             *
              * ```js
              * var api = new mw.ForeignApi( 'https://commons.wikimedia.org/w/api.php' );
              * api.get( {
@@ -30,18 +31,19 @@ declare global {
              * To ensure that the user at the foreign wiki is logged in, pass the `assert: 'user'` parameter to `get()`/`post()` (since MW 1.23): if they are not, the API request will fail. (Note that this doesn't guarantee that it's the same user.)
              *
              * Authentication-related MediaWiki extensions may extend this class to ensure that the user authenticated on the current wiki will be automatically authenticated on the foreign one. These extension modules should be registered using the ResourceLoaderForeignApiModules hook. See CentralAuth for a practical example. The general pattern to extend and override the name is:
+             *
              * ```js
              * function MyForeignApi() {};
              * OO.inheritClass( MyForeignApi, mw.ForeignApi );
              * mw.ForeignApi = MyForeignApi;
              * ```
              *
-             * @param {string | mw.Uri} url URL pointing to another wiki's `api.php` endpoint.
-             * @param {ForeignApiOptions?} options
+             * @param {string | Uri} url URL pointing to another wiki's `api.php` endpoint.
+             * @param {ForeignApiOptions} [options]
              * @since 1.26
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
-            constructor(url: string | mw.Uri, options?: ForeignApiOptions);
+            constructor(url: string | Uri, options?: ForeignApiOptions);
 
             /**
              * Return the origin to use for API requests, in the required format (protocol, host and port, if any).

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -38,9 +38,9 @@ declare global {
              * mw.ForeignApi = MyForeignApi;
              * ```
              *
-             * @param {string | Uri} url URL pointing to another wiki's `api.php` endpoint.
-             * @param {Partial<ForeignApiOptions>} [options]
              * @since 1.26
+             * @param {string|Uri} url URL pointing to another wiki's `api.php` endpoint.
+             * @param {Partial<ForeignApiOptions>} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
             constructor(url: string | Uri, options?: Partial<ForeignApiOptions>);
@@ -48,8 +48,8 @@ declare global {
             /**
              * Return the origin to use for API requests, in the required format (protocol, host and port, if any).
              *
-             * @protected
              * @returns {string|undefined}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-getOrigin
              */
             protected getOrigin(): string | undefined;
         }

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -6,7 +6,7 @@ interface ForeignRestOptions extends RestOptions {
      * accept cross-origin requests, or if you don't need to perform write actions or read
      * restricted information and want to avoid the overhead.
      */
-    anonymous?: boolean;
+    anonymous: boolean;
 }
 
 declare global {
@@ -41,16 +41,16 @@ declare global {
              * mw.ForeignRest = MyForeignRest;
              * ```
              *
-             * @param {string | Uri} url URL pointing to another wiki's rest.php endpoint.
+             * @param {string} url URL pointing to another wiki's `rest.php` endpoint.
              * @param {ForeignApi} foreignActionApi
-             * @param {ForeignRestOptions} [options]
+             * @param {Partial<ForeignRestOptions>} [options]
              * @since 1.36
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
             constructor(
-                url: string | Uri,
+                url: string,
                 foreignActionApi: ForeignApi,
-                options?: ForeignRestOptions
+                options?: Partial<ForeignRestOptions>
             );
         }
     }

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -41,11 +41,11 @@ declare global {
              * mw.ForeignRest = MyForeignRest;
              * ```
              *
+             * @since 1.36
              * @param {string} url URL pointing to another wiki's `rest.php` endpoint.
              * @param {ForeignApi} foreignActionApi
              * @param {Partial<ForeignRestOptions>} [options]
-             * @since 1.36
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignRest-method-constructor
              */
             constructor(
                 url: string,

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -44,7 +44,7 @@ declare global {
              * @param {string | Uri} url URL pointing to another wiki's rest.php endpoint.
              * @param {ForeignApi} foreignActionApi
              * @param {ForeignRestOptions} [options]
-             * @since 1.26
+             * @since 1.36
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
             constructor(

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -15,6 +15,11 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignRest
          */
         class ForeignRest extends Rest {
+            static static: {};
+            static super: typeof Rest;
+            /** @deprecated Use `super` instead */
+            static parent: typeof Rest;
+
             /**
              * Create an object like {@link mw.Rest}, but automatically handling everything required
              * to communicate with another MediaWiki wiki via cross-origin requests (CORS).

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -14,9 +14,9 @@ declare global {
         /**
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignRest
          */
-        class ForeignRest extends mw.Rest {
+        class ForeignRest extends Rest {
             /**
-             * Create an object like `mw.Rest`, but automatically handling everything required
+             * Create an object like {@link mw.Rest}, but automatically handling everything required
              * to communicate with another MediaWiki wiki via cross-origin requests (CORS).
              *
              * The foreign wiki must be configured to accept requests from the current wiki. See https://www.mediawiki.org/wiki/Manual:$wgCrossSiteAJAXdomains for details.
@@ -41,15 +41,15 @@ declare global {
              * mw.ForeignRest = MyForeignRest;
              * ```
              *
-             * @param {string | mw.Uri} url URL pointing to another wiki's rest.php endpoint.
-             * @param {mw.ForeignApi} foreignActionApi
-             * @param {ForeignRestOptions?} options
+             * @param {string | Uri} url URL pointing to another wiki's rest.php endpoint.
+             * @param {ForeignApi} foreignActionApi
+             * @param {ForeignRestOptions} [options]
              * @since 1.26
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.ForeignApi-method-constructor
              */
             constructor(
-                url: string | mw.Uri,
-                foreignActionApi: mw.ForeignApi,
+                url: string | Uri,
+                foreignActionApi: ForeignApi,
                 options?: ForeignRestOptions
             );
         }

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -1,10 +1,68 @@
-type KeyOrArray<T> = keyof T | Array<keyof T>;
-type GetOrDefault<V, K extends keyof V, T> = V extends Required<Pick<V, K>>
-    ? V[K]
-    : Required<V>[K] | T;
-type PickOrDefault<V, S extends keyof V | Array<keyof V>, T> = S extends Array<infer SS>
-    ? { [K in SS & keyof V]-?: GetOrDefault<V, K, T> }
-    : GetOrDefault<V, S & keyof V, null>;
+type TypeOrArray<T> = T | T[];
+
+// Get/PickOrDefault<V, S, TD, TX> extracts values from V using key selection S
+//  - TD is the value type of missing properties
+//  - TX is the value type of unknown properties
+
+type GetOrDefault<V, K extends PropertyKey, TD, TX = unknown> = K extends keyof V
+    ? V extends Required<Pick<V, K>>
+        ? V[K]
+        : Required<V>[K] | TD
+    : TX | TD;
+
+type PickOrDefault<V, S extends TypeOrArray<PropertyKey>, TD, TX = unknown> = S extends Array<
+    infer K
+>
+    ? { [P in K & PropertyKey]-?: GetOrDefault<V, P, TD, TX> }
+    : GetOrDefault<V, S & PropertyKey, TD, TX>;
+
+// `ExtensibleMap<V, TX>` is an alternative to `Map<V & { [k: string]: TX; }>`
+// but unlike the latter, ExtensibleMap provides additional overloads to improve selection
+// autocompletion and type checking.
+
+export interface ExtensibleMap<V extends Record<string, any>, TX = unknown> extends mw.Map<V> {
+    /**
+     * Check if a given key exists in the map.
+     *
+     * @param selection Key to check
+     * @returns True if the key exists
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
+     */
+    exists<S extends keyof V>(selection: S): selection is S;
+    exists<S extends string>(selection: S): selection is S;
+
+    /**
+     * Get the value of one or more keys.
+     *
+     * If called with no arguments, all values are returned.
+     *
+     * @param selection Key or array of keys to retrieve values for.
+     * @param fallback Value for keys that don't exist.
+     * @returns If selection was a string, returns the value. If selection was an array, returns
+     * an object of key/values. If no selection is passed, a new object with all key/values is returned.
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
+     */
+    get<S extends TypeOrArray<keyof V>, TD>(
+        selection: S,
+        fallback: TD
+    ): PickOrDefault<V, S, TD, TX>;
+    get<S extends TypeOrArray<string>, TD>(selection: S, fallback: TD): PickOrDefault<V, S, TD, TX>;
+    get<S extends TypeOrArray<keyof V>>(selection: S): PickOrDefault<V, S, null, TX>;
+    get<S extends TypeOrArray<string>>(selection: S): PickOrDefault<V, S, null, TX>;
+    get<T extends Record<string, any> = V | Record<string, TX>>(): T;
+
+    /**
+     * Set the value of one or more keys.
+     *
+     * @param selection Key to set value for, or object mapping keys to values
+     * @param value Value to set (optional, only in use when key is a string)
+     * @returns True on success, false on failure
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-set
+     */
+    set<S extends keyof V>(selection: S, value: V[S]): boolean;
+    set<S extends string>(selection: S, value: TX): boolean;
+    set<S extends Partial<V> & Record<string, TX>>(selection: S): boolean;
+}
 
 declare global {
     namespace mw {
@@ -40,8 +98,11 @@ declare global {
              * an object of key/values. If no selection is passed, a new object with all key/values is returned.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
              */
-            get<S extends KeyOrArray<V>, T>(selection: S, fallback: T): PickOrDefault<V, S, T>;
-            get<S extends KeyOrArray<V>>(selection: S): PickOrDefault<V, S, null>;
+            get<S extends TypeOrArray<keyof V>, TD>(
+                selection: S,
+                fallback: TD
+            ): PickOrDefault<V, S, TD>;
+            get<S extends TypeOrArray<keyof V>>(selection: S): PickOrDefault<V, S, null>;
             get<T extends V = V>(): T;
 
             /**

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -27,7 +27,7 @@ declare global {
              * @returns True if the key exists
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
              */
-            exists(selection: keyof V): boolean;
+            exists<S extends keyof V>(selection: S): selection is S;
 
             /**
              * Get the value of one or more keys.
@@ -53,7 +53,7 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-set
              */
             set<S extends keyof V>(selection: S, value: V[S]): boolean;
-            set(selection: Partial<V>): boolean;
+            set<S extends Partial<V>>(selection: S): boolean;
         }
     }
 }

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -34,7 +34,7 @@ declare global {
              */
             get<S extends keyof V>(selection: S[], fallback?: any): Pick<V, S>;
             get<S extends keyof V>(selection: S, fallback?: V[S]): V[S];
-            get(): V;
+            get<S extends V = V>(): S;
 
             /**
              * Set the value of one or more keys.

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -13,6 +13,15 @@ declare global {
             private values: V;
 
             /**
+             * Check if a given key exists in the map.
+             *
+             * @param selection Key to check
+             * @returns True if the key exists
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
+             */
+            exists(selection: keyof V): boolean;
+
+            /**
              * Get the value of one or more keys.
              *
              * If called with no arguments, all values are returned.
@@ -23,9 +32,9 @@ declare global {
              * an object of key/values. If no selection is passed, a new object with all key/values is returned.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
              */
-            get(): V;
             get<S extends keyof V>(selection: S[], fallback?: any): Pick<V, S>;
             get<S extends keyof V>(selection: S, fallback?: V[S]): V[S];
+            get(): V;
 
             /**
              * Set the value of one or more keys.
@@ -37,15 +46,6 @@ declare global {
              */
             set<S extends keyof V>(selection: S, value: V[S]): boolean;
             set(selection: Partial<V>): boolean;
-
-            /**
-             * Check if a given key exists in the map.
-             *
-             * @param selection Key to check
-             * @returns True if the key exists
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists
-             */
-            exists(selection: keyof V): boolean;
         }
     }
 }

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -16,11 +16,11 @@ type PickOrDefault<V, S extends TypeOrArray<PropertyKey>, TD, TX = unknown> = S 
     ? { [P in K & PropertyKey]-?: GetOrDefault<V, P, TD, TX> }
     : GetOrDefault<V, S & PropertyKey, TD, TX>;
 
-// `ExtensibleMap<V, TX>` is an alternative to `Map<V & { [k: string]: TX; }>`
-// but unlike the latter, ExtensibleMap provides additional overloads to improve selection
-// autocompletion and type checking.
+// `ExtensibleMap<V, TX>` is an alternative to `Map<V & Record<string, TX>>`, but unlike the latter
+// ExtensibleMap provides additional overloads to improve selection autocompletion and type checking.
 
-export interface ExtensibleMap<V extends Record<string, any>, TX = unknown> extends mw.Map<V> {
+export interface ExtensibleMap<V extends Record<string, any>, TX = unknown>
+    extends mw.Map<V & Record<string, TX>> {
     /**
      * Check if a given key exists in the map.
      *
@@ -49,7 +49,7 @@ export interface ExtensibleMap<V extends Record<string, any>, TX = unknown> exte
     get<S extends TypeOrArray<string>, TD>(selection: S, fallback: TD): PickOrDefault<V, S, TD, TX>;
     get<S extends TypeOrArray<keyof V>>(selection: S): PickOrDefault<V, S, null, TX>;
     get<S extends TypeOrArray<string>>(selection: S): PickOrDefault<V, S, null, TX>;
-    get<T extends Record<string, any> = V | Record<string, TX>>(): T;
+    get(): V & Record<string, TX>;
 
     /**
      * Set the value of one or more keys.
@@ -103,7 +103,7 @@ declare global {
                 fallback: TD
             ): PickOrDefault<V, S, TD>;
             get<S extends TypeOrArray<keyof V>>(selection: S): PickOrDefault<V, S, null>;
-            get<T extends V = V>(): T;
+            get(): V;
 
             /**
              * Set the value of one or more keys.

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -24,10 +24,7 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
              */
             get(): V;
-            get<S extends Array<keyof V>>(
-                selection: S,
-                fallback?: any
-            ): Pick<V, S extends Array<infer SS> ? SS : never>;
+            get<S extends keyof V>(selection: S[], fallback?: any): Pick<V, S>;
             get<S extends keyof V>(selection: S, fallback?: V[S]): V[S];
 
             /**

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -1,3 +1,11 @@
+type KeyOrArray<T> = keyof T | Array<keyof T>;
+type GetOrDefault<V, K extends keyof V, T> = V extends Required<Pick<V, K>>
+    ? V[K]
+    : Required<V>[K] | T;
+type PickOrDefault<V, S extends keyof V | Array<keyof V>, T> = S extends Array<infer SS>
+    ? { [K in SS & keyof V]-?: GetOrDefault<V, K, T> }
+    : GetOrDefault<V, S & keyof V, null>;
+
 declare global {
     namespace mw {
         /**
@@ -32,9 +40,9 @@ declare global {
              * an object of key/values. If no selection is passed, a new object with all key/values is returned.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-get
              */
-            get<S extends keyof V>(selection: S[], fallback?: any): Pick<V, S>;
-            get<S extends keyof V>(selection: S, fallback?: V[S]): V[S];
-            get<S extends V = V>(): S;
+            get<S extends KeyOrArray<V>, T>(selection: S, fallback: T): PickOrDefault<V, S, T>;
+            get<S extends KeyOrArray<V>>(selection: S): PickOrDefault<V, S, null>;
+            get<T extends V = V>(): T;
 
             /**
              * Set the value of one or more keys.

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -6,6 +6,7 @@ declare global {
          *
          * **NOTE**: This is a private utility class for internal use by the framework.
          * Don't rely on its existence.
+         *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map
          */
         class Map<V extends Record<string, any> = any> {
@@ -15,6 +16,7 @@ declare global {
              * Get the value of one or more keys.
              *
              * If called with no arguments, all values are returned.
+             *
              * @param selection Key or array of keys to retrieve values for.
              * @param fallback Value for keys that don't exist.
              * @returns If selection was a string, returns the value. If selection was an array, returns
@@ -41,6 +43,7 @@ declare global {
 
             /**
              * Check if a given key exists in the map.
+             *
              * @param selection Key to check
              * @returns True if the key exists
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Map-method-exists

--- a/mw/RegExp.d.ts
+++ b/mw/RegExp.d.ts
@@ -11,8 +11,8 @@ declare global {
              *
              *     \ { } ( ) | . ? * + - ^ $ [ ]
              *
-             * @deprecated
-             * @since 1.26; deprecated since 1.34
+             * @deprecated since 1.34
+             * @since 1.26
              * @param {string} str String to escape
              * @returns {string} Escaped string
              * @see https://doc.wikimedia.org/mediawiki-core/REL1_29/js/source/mediawiki.RegExp.html#mw-RegExp-static-method-escape

--- a/mw/RegExp.d.ts
+++ b/mw/RegExp.d.ts
@@ -14,7 +14,7 @@ declare global {
              * @deprecated
              * @since 1.26; deprecated since 1.34
              * @param {string} str String to escape
-             * @return {string} Escaped string
+             * @returns {string} Escaped string
              * @see https://doc.wikimedia.org/mediawiki-core/REL1_29/js/source/mediawiki.RegExp.html#mw-RegExp-static-method-escape
              */
             function escape(str: string): string;

--- a/mw/RegExp.d.ts
+++ b/mw/RegExp.d.ts
@@ -1,7 +1,6 @@
 declare global {
     namespace mw {
         /**
-         * @class mw.RegExp
          * @see https://doc.wikimedia.org/mediawiki-core/REL1_29/js/source/mediawiki.RegExp.html
          */
         namespace RegExp {

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -38,12 +38,12 @@ declare global {
              * @param {RestOptions} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Rest-method-constructor
              */
-            constructor(options?: RestOptions);
+            constructor(options?: Partial<RestOptions>);
 
             /**
              * @private
              */
-            defaultOptions: RestOptions;
+            defaults: RestOptions;
 
             /**
              * Abort all unfinished requests issued by this Api object.

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -35,7 +35,7 @@ declare global {
              * } );
              * ```
              *
-             * @param {RestOptions} [options]
+             * @param {Partial<RestOptions>} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Rest-method-constructor
              */
             constructor(options?: Partial<RestOptions>);

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -1,11 +1,3 @@
-import {
-    ApiEditPageParams,
-    ApiParseParams,
-    ApiQueryAllMessagesParams,
-    ApiRollbackParams,
-    ApiUploadParams,
-} from "../api_params";
-
 export interface RestOptions {
     ajax: JQuery.AjaxSettings;
 }
@@ -43,7 +35,7 @@ declare global {
              * } );
              * ```
              *
-             * @param {RestOptions} options
+             * @param {RestOptions} [options]
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Rest-method-constructor
              */
             constructor(options?: RestOptions);
@@ -131,7 +123,7 @@ declare global {
              * Perform the API call.
              *
              * @param {string} path
-             * @param {JQuery.AjaxSettings?} ajaxOptions
+             * @param {JQuery.AjaxSettings} [ajaxOptions]
              * @returns {JQuery.Promise<RestResponse>} API response data and the jqXHR object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-ajax
              */

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -120,7 +120,7 @@ declare global {
              *
              * @param {string} path
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {JQuery.Promise<RestResponse>} API response data and the jqXHR object
+             * @returns {JQuery.Promise<RestResponse>} Done: API response data and the jqXHR object.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Api-method-ajax
              */
             ajax(path: string, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<RestResponse>;

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -40,15 +40,11 @@ declare global {
              */
             constructor(options?: Partial<RestOptions>);
 
-            /**
-             * @private
-             */
-            defaults: RestOptions;
+            private defaults: RestOptions;
 
             /**
              * Abort all unfinished requests issued by this Api object.
              *
-             * @returns {void}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Rest-method-abort
              */
             abort(): void;

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -4,54 +4,62 @@ declare global {
     namespace mw {
         /**
          * Parse titles into an object structure. Note that when using the constructor
-         * directly, passing invalid titles will result in an exception. Use #newFromText to use the
+         * directly, passing invalid titles will result in an exception. Use {@link newFromText} to use the
          * logic directly and get null for invalid titles which is easier to work with.
          *
-         * Note that in the constructor and #newFromText method, `namespace` is the **default** namespace
+         * Note that in the constructor and {@link newFromText} method, `namespace` is the **default** namespace
          * only, and can be overridden by a namespace prefix in `title`. If you do not want this behavior,
-         * use #makeTitle. Compare:
+         * use {@link makeTitle}. Compare:
          *
-         *     new mw.Title( 'Foo', NS_TEMPLATE ).getPrefixedText();                  // => 'Template:Foo'
-         *     mw.Title.newFromText( 'Foo', NS_TEMPLATE ).getPrefixedText();          // => 'Template:Foo'
-         *     mw.Title.makeTitle( NS_TEMPLATE, 'Foo' ).getPrefixedText();            // => 'Template:Foo'
+         * ```js
+         * new mw.Title( 'Foo', NS_TEMPLATE ).getPrefixedText();                  // => 'Template:Foo'
+         * mw.Title.newFromText( 'Foo', NS_TEMPLATE ).getPrefixedText();          // => 'Template:Foo'
+         * mw.Title.makeTitle( NS_TEMPLATE, 'Foo' ).getPrefixedText();            // => 'Template:Foo'
          *
-         *     new mw.Title( 'Category:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Category:Foo'
-         *     mw.Title.newFromText( 'Category:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Category:Foo'
-         *     mw.Title.makeTitle( NS_TEMPLATE, 'Category:Foo' ).getPrefixedText();   // => 'Template:Category:Foo'
+         * new mw.Title( 'Category:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Category:Foo'
+         * mw.Title.newFromText( 'Category:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Category:Foo'
+         * mw.Title.makeTitle( NS_TEMPLATE, 'Category:Foo' ).getPrefixedText();   // => 'Template:Category:Foo'
          *
-         *     new mw.Title( 'Template:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Template:Foo'
-         *     mw.Title.newFromText( 'Template:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Template:Foo'
-         *     mw.Title.makeTitle( NS_TEMPLATE, 'Template:Foo' ).getPrefixedText();   // => 'Template:Template:Foo'
+         * new mw.Title( 'Template:Foo', NS_TEMPLATE ).getPrefixedText();         // => 'Template:Foo'
+         * mw.Title.newFromText( 'Template:Foo', NS_TEMPLATE ).getPrefixedText(); // => 'Template:Foo'
+         * mw.Title.makeTitle( NS_TEMPLATE, 'Template:Foo' ).getPrefixedText();   // => 'Template:Template:Foo'
+         * ```
          *
-         * @class mw.Title
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title
          */
         class Title {
             /**
              * Store page existence
              *
-             * @static
              * @property {Object} exist
-             * @property {Object} exist.pages Keyed by title. Boolean true value indicates page does exist.
-             *
-             * @property {Function} exist.set The setter function.
-             *
-             *  Example to declare existing titles:
-             *
-             *     Title.exist.set( ['User:John_Doe', ...] );
-             *
-             *  Example to declare titles nonexistent:
-             *
-             *     Title.exist.set( ['File:Foo_bar.jpg', ...], false );
-             *
-             * @property {string|Array} exist.set.titles Title(s) in strict prefixedDb title form
-             * @property {boolean} [exist.set.state=true] State of the given titles
-             * @return {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-property-exist
              */
             static exist: {
+                /**
+                 * Keyed by title. Boolean true value indicates page does exist.
+                 */
                 pages: { [title: string]: boolean };
-                set: (titles: string | string[], state?: boolean) => boolean;
+
+                /**
+                 * The setter function.
+                 *
+                 * Example to declare existing titles:
+                 *
+                 * ```js
+                 * Title.exist.set( ['User:John_Doe', ...] );
+                 * ```
+                 *
+                 * Example to declare titles nonexistent:
+                 *
+                 * ```js
+                 * Title.exist.set( ['File:Foo_bar.jpg', ...], false );
+                 * ```
+                 *
+                 * @param {string|Array} titles Title(s) in strict prefixedDb title form
+                 * @param {boolean} [state=true] State of the given titles
+                 * @return {boolean}
+                 */
+                set(titles: string | string[], state?: boolean): boolean;
             };
 
             /**
@@ -94,7 +102,7 @@ declare global {
              * "File:Example_image.svg" will be returned as "Example image".
              *
              * Note that this method will work for non-file titles but probably give nonsensical results.
-             * A title like "User:Dr._J._Fail" will be returned as "Dr. J"! Use #getMainText instead.
+             * A title like "User:Dr._J._Fail" will be returned as "Dr. J"! Use {@link getMainText} instead.
              *
              * @return {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameTextWithoutExtension
@@ -107,7 +115,7 @@ declare global {
              * "File:Example_image.svg" will be returned as "Example_image".
              *
              * Note that this method will work for non-file titles but probably give nonsensical results.
-             * A title like "User:Dr._J._Fail" will be returned as "Dr._J"! Use #getMain instead.
+             * A title like "User:Dr._J._Fail" will be returned as "Dr._J"! Use {@link getMain} instead.
              *
              * @return {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameWithoutExtension
@@ -146,6 +154,19 @@ declare global {
             getMainText(): string;
 
             /**
+             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
+             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
+             * "Dr. J"! Use {@link getMain} or {@link getMainText} for the actual page name.
+             *
+             * @deprecated since 1.40, use {@link getFileNameWithoutExtension} instead
+             * @return {string} File name without file extension, in the canonical form with underscores
+             *  instead of spaces. For example, the title "File:Example_image.svg" will be returned as
+             *  "Example_image".
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getName
+             */
+            getName(): string;
+
+            /**
              * Get the namespace number
              *
              * Example: 6 for "File:Example_image.svg".
@@ -165,6 +186,19 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNamespacePrefix
              */
             getNamespacePrefix(): string;
+
+            /**
+             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
+             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
+             * "Dr. J"! Use {@link getMainText} for the actual page name.
+             *
+             * @deprecated since 1.40, use {@link getFileNameTextWithoutExtension} instead
+             * @return {string} File name without file extension, formatted with spaces instead of
+             *  underscores. For example, the title "File:Example_image.svg" will be returned as
+             *  "Example image".
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNameText
+             */
+            getNameText(): string;
 
             /**
              * Get the full page name
@@ -205,7 +239,7 @@ declare global {
             /**
              * Get the title for the subject page of a talk page
              *
-             * @return {mw.Title|null} The title for the subject page of a talk page, null if not available
+             * @return {Title|null} The title for the subject page of a talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getSubjectPage
              */
             getSubjectPage(): Title | null;
@@ -213,7 +247,7 @@ declare global {
             /**
              * Get the title for the associated talk page
              *
-             * @return {mw.Title|null} The title for the associated talk page, null if not available
+             * @return {Title|null} The title for the associated talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getTalkPage
              */
             getTalkPage(): Title | null;
@@ -229,17 +263,6 @@ declare global {
             getUrl(params?: any): string;
 
             /**
-             * Check if a given namespace is a talk namespace
-             *
-             * See NamespaceInfo::isTalk in PHP
-             *
-             * @param {number} namespaceId Namespace ID
-             * @return {boolean} Namespace is a talk namespace
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkNamespace
-             */
-            isTalkNamespace(namespaceId: number): boolean;
-
-            /**
              * Check if the title is in a talk namespace
              *
              * @return {boolean} The title is in a talk namespace
@@ -248,27 +271,7 @@ declare global {
             isTalkPage(): boolean;
 
             /**
-             * Normalize a file extension to the common form, making it lowercase and checking some synonyms,
-             * and ensure it's clean. Extensions with non-alphanumeric characters will be discarded.
-             * Keep in sync with File::normalizeExtension() in PHP.
-             *
-             * @param {string} extension File extension (without the leading dot)
-             * @return {string} File extension in canonical form
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-normalizeExtension
-             */
-            normalizeExtension(extension: string): string;
-
-            /**
-             * PHP's strtoupper differs from String.toUpperCase in a number of cases (T147646).
-             *
-             * @param {string} chr Unicode character
-             * @return {string} Unicode character, in upper case, according to the same rules as in PHP
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-phpCharToUpper
-             */
-            phpCharToUpper(chr: string): string;
-
-            /**
-             * Alias of mw.Title#getPrefixedDb
+             * Alias of {@link mw.Title.getPrefixedDb}
              *
              * TODO: Use @-alias when we switch to JSDoc
              *
@@ -278,7 +281,7 @@ declare global {
             toString(): string;
 
             /**
-             * Alias of mw.Title#getPrefixedText
+             * Alias of {@link mw.Title.getPrefixedText}
              *
              * TODO: Use @-alias when we switch to JSDoc
              *
@@ -288,47 +291,9 @@ declare global {
             toText(): string;
 
             /**
-             * Check if signature buttons should be shown in a given namespace
-             *
-             * See NamespaceInfo::wantSignatures in PHP
-             *
-             * @param {number} namespaceId Namespace ID
-             * @return {boolean} Namespace is a signature namespace
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-wantSignaturesNamespace
-             */
-            wantSignatureNamespace(namespaceId: number): boolean;
-
-            /**
-             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
-             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
-             * "Dr. J"! Use #getMain or #getMainText for the actual page name.
-             *
-             * @deprecated since 1.40, use #getFileNameWithoutExtension instead
-             * @return {string} File name without file extension, in the canonical form with underscores
-             *  instead of spaces. For example, the title "File:Example_image.svg" will be returned as
-             *  "Example_image".
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getName
-             */
-            getName(): string;
-
-            /**
-             * Get the page name as if it is a file name, without extension or namespace prefix. Warning,
-             * this is usually not what you want! A title like "User:Dr._J._Fail" will be returned as
-             * "Dr. J"! Use #getMainText for the actual page name.
-             *
-             * @deprecated since 1.40, use #getFileNameTextWithoutExtension instead
-             * @return {string} File name without file extension, formatted with spaces instead of
-             *  underscores. For example, the title "File:Example_image.svg" will be returned as
-             *  "Example image".
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNameText
-             */
-            getNameText(): string;
-
-            /**
              * Whether this title exists on the wiki.
              *
-             * @static
-             * @param {string|mw.Title} title prefixed db-key name (string) or instance of Title
+             * @param {string|Title} title prefixed db-key name (string) or instance of Title
              * @return {boolean|null} Boolean if the information is available, otherwise null
              * @throws {Error} If title is not a string or mw.Title
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-exists
@@ -336,15 +301,25 @@ declare global {
             static exists(title: title): boolean | null;
 
             /**
+             * Check if a given namespace is a talk namespace
+             *
+             * See NamespaceInfo::isTalk in PHP
+             *
+             * @param {number} namespaceId Namespace ID
+             * @return {boolean} Namespace is a talk namespace
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkNamespace
+             */
+            static isTalkNamespace(namespaceId: number): boolean;
+
+            /**
              * Constructor for Title objects with predefined namespace.
              *
-             * Unlike #newFromText or #constructor, this function doesn't allow the given `namespace` to be
-             * overridden by a namespace prefix in `title`. See #constructor for details about this behavior.
+             * Unlike {@link newFromText} or {@link constructor}, this function doesn't allow the given `namespace` to be
+             * overridden by a namespace prefix in `title`. See {@link constructor} for details about this behavior.
              *
              * The single exception to this is when `namespace` is 0, indicating the main namespace. The
-             * function behaves like #newFromText in that case.
+             * function behaves like {@link newFromText} in that case.
              *
-             * @static
              * @param {number} namespace Namespace to use for the title
              * @param {string} title
              * @return {Title|null} A valid Title object or null if the title is invalid
@@ -357,7 +332,6 @@ declare global {
              * so it is most likely a valid MediaWiki title and file name after processing.
              * Returns null on fatal errors.
              *
-             * @static
              * @param {string} uncleanName The unclean file name including file extension but
              *   without namespace
              * @return {Title|null} A valid Title object or null if the title is invalid
@@ -368,9 +342,10 @@ declare global {
             /**
              * Get the file title from an image element
              *
-             *     var title = mw.Title.newFromImg( imageNode );
+             * ```js
+             * var title = mw.Title.newFromImg( imageNode );
+             * ```
              *
-             * @static
              * @param {HTMLElement|JQuery} img The image to use as a base
              * @return {Title|null} The file title or null if unsuccessful
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromImg
@@ -381,10 +356,9 @@ declare global {
              * Constructor for Title objects with a null return instead of an exception for invalid titles.
              *
              * Note that `namespace` is the **default** namespace only, and can be overridden by a namespace
-             * prefix in `title`. If you do not want this behavior, use #makeTitle. See #constructor for
+             * prefix in `title`. If you do not want this behavior, use {@link makeTitle}. See {@link constructor} for
              * details.
              *
-             * @static
              * @param {string} title
              * @param {number} [namespace=NS_MAIN] Default namespace
              * @return {Title|null} A valid Title object or null if the title is invalid
@@ -396,7 +370,6 @@ declare global {
              * Constructor for Title objects from user input altering that input to
              * produce a title that MediaWiki will accept as legal
              *
-             * @static
              * @param {string} title
              * @param {number} [defaultNamespace=NS_MAIN]
              *  If given, will used as default namespace for the given title.
@@ -413,6 +386,37 @@ declare global {
                 defaultNamespace?: number,
                 options?: { forUploading: boolean }
             ): Title;
+
+            /**
+             * Normalize a file extension to the common form, making it lowercase and checking some synonyms,
+             * and ensure it's clean. Extensions with non-alphanumeric characters will be discarded.
+             * Keep in sync with File::normalizeExtension() in PHP.
+             *
+             * @param {string} extension File extension (without the leading dot)
+             * @return {string} File extension in canonical form
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-normalizeExtension
+             */
+            static normalizeExtension(extension: string): string;
+
+            /**
+             * PHP's strtoupper differs from {@link String.toUpperCase} in a number of cases (T147646).
+             *
+             * @param {string} chr Unicode character
+             * @return {string} Unicode character, in upper case, according to the same rules as in PHP
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-phpCharToUpper
+             */
+            static phpCharToUpper(chr: string): string;
+
+            /**
+             * Check if signature buttons should be shown in a given namespace
+             *
+             * See NamespaceInfo::wantSignatures in PHP
+             *
+             * @param {number} namespaceId Namespace ID
+             * @return {boolean} Namespace is a signature namespace
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-wantSignaturesNamespace
+             */
+            static wantSignatureNamespace(namespaceId: number): boolean;
         }
     }
 }

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -1,3 +1,5 @@
+import { QueryParams } from "./Uri";
+
 type title = string | mw.Title;
 
 declare global {
@@ -260,7 +262,7 @@ declare global {
              * @return {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getUrl
              */
-            getUrl(params?: any): string;
+            getUrl(params?: QueryParams): string;
 
             /**
              * Check if the title is in a talk namespace
@@ -337,7 +339,7 @@ declare global {
              * @return {Title|null} A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromFileName
              */
-            static newFromFileName(uncleanName: string): Title;
+            static newFromFileName(uncleanName: string): Title | null;
 
             /**
              * Get the file title from an image element
@@ -385,7 +387,7 @@ declare global {
                 title: string,
                 defaultNamespace?: number,
                 options?: { forUploading: boolean }
-            ): Title;
+            ): Title | null;
 
             /**
              * Normalize a file extension to the common form, making it lowercase and checking some synonyms,

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -27,6 +27,7 @@ declare global {
          * mw.Title.makeTitle( NS_TEMPLATE, 'Template:Foo' ).getPrefixedText();   // => 'Template:Template:Foo'
          * ```
          *
+         * @since 1.18
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title
          */
         class Title {

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -1,6 +1,6 @@
 import { QueryParams } from "./Uri";
 
-type title = string | mw.Title;
+export type TitleLike = string | mw.Title;
 
 declare global {
     namespace mw {
@@ -33,7 +33,6 @@ declare global {
             /**
              * Store page existence
              *
-             * @property {Object} exist
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-property-exist
              */
             static exist: {
@@ -57,15 +56,14 @@ declare global {
                  * Title.exist.set( ['File:Foo_bar.jpg', ...], false );
                  * ```
                  *
-                 * @param {string|Array} titles Title(s) in strict prefixedDb title form
+                 * @param {string|string[]} titles Title(s) in strict prefixedDb title form
                  * @param {boolean} [state=true] State of the given titles
-                 * @return {boolean}
+                 * @returns {boolean}
                  */
                 set(titles: string | string[], state?: boolean): boolean;
             };
 
             /**
-             * @method constructor
              * @param {string} title Title of the page. If no second argument given,
              *  this will be searched for a namespace
              * @param {number} [namespace=NS_MAIN] If given, will used as default namespace for the given title
@@ -77,7 +75,7 @@ declare global {
             /**
              * Check the title can have an associated talk page
              *
-             * @return {boolean} The title can have an associated talk page
+             * @returns {boolean} The title can have an associated talk page
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-canHaveTalkPage
              */
             canHaveTalkPage(): boolean;
@@ -85,7 +83,7 @@ declare global {
             /**
              * Whether this title exists on the wiki.
              *
-             * @return {boolean|null} Boolean if the information is available, otherwise null
+             * @returns {boolean|null} Boolean if the information is available, otherwise null
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-exists
              */
             exists(): boolean | null;
@@ -93,7 +91,7 @@ declare global {
             /**
              * Get the extension of the page name (if any)
              *
-             * @return {string|null} Name extension or null if there is none
+             * @returns {string|null} Name extension or null if there is none
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getExtension
              */
             getExtension(): string | null;
@@ -106,7 +104,7 @@ declare global {
              * Note that this method will work for non-file titles but probably give nonsensical results.
              * A title like "User:Dr._J._Fail" will be returned as "Dr. J"! Use {@link getMainText} instead.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameTextWithoutExtension
              */
             getFileNameTextWithoutExtension(): string;
@@ -119,7 +117,7 @@ declare global {
              * Note that this method will work for non-file titles but probably give nonsensical results.
              * A title like "User:Dr._J._Fail" will be returned as "Dr._J"! Use {@link getMain} instead.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFileNameWithoutExtension
              */
             getFileNameWithoutExtension(): string;
@@ -130,7 +128,7 @@ declare global {
              * Note that this method (by design) does not include the hash character and
              * the value is not url encoded.
              *
-             * @return {string|null}
+             * @returns {string|null}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getFragment
              */
             getFragment(): string | null;
@@ -140,7 +138,7 @@ declare global {
              *
              * Example: "Example_image.svg" for "File:Example_image.svg".
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getMain
              */
             getMain(): string;
@@ -150,7 +148,7 @@ declare global {
              *
              * Example: "Example image.svg" for "File:Example_image.svg".
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getMainText
              */
             getMainText(): string;
@@ -161,7 +159,7 @@ declare global {
              * "Dr. J"! Use {@link getMain} or {@link getMainText} for the actual page name.
              *
              * @deprecated since 1.40, use {@link getFileNameWithoutExtension} instead
-             * @return {string} File name without file extension, in the canonical form with underscores
+             * @returns {string} File name without file extension, in the canonical form with underscores
              *  instead of spaces. For example, the title "File:Example_image.svg" will be returned as
              *  "Example_image".
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getName
@@ -173,7 +171,7 @@ declare global {
              *
              * Example: 6 for "File:Example_image.svg".
              *
-             * @return {number}
+             * @returns {number}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNamespaceId
              */
             getNamespaceId(): number;
@@ -184,7 +182,7 @@ declare global {
              * Example: "File:" for "File:Example_image.svg".
              * In #NS_MAIN this is '', otherwise namespace name plus ':'
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNamespacePrefix
              */
             getNamespacePrefix(): string;
@@ -195,7 +193,7 @@ declare global {
              * "Dr. J"! Use {@link getMainText} for the actual page name.
              *
              * @deprecated since 1.40, use {@link getFileNameTextWithoutExtension} instead
-             * @return {string} File name without file extension, formatted with spaces instead of
+             * @returns {string} File name without file extension, formatted with spaces instead of
              *  underscores. For example, the title "File:Example_image.svg" will be returned as
              *  "Example image".
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getNameText
@@ -208,7 +206,7 @@ declare global {
              * Example: "File:Example_image.svg".
              * Most useful for API calls, anything that must identify the "title".
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getPrefixedDb
              */
             getPrefixedDb(): string;
@@ -218,7 +216,7 @@ declare global {
              *
              * Example: "File:Example image.svg" for "File:Example_image.svg".
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getPrefixedText
              */
             getPrefixedText(): string;
@@ -233,7 +231,7 @@ declare global {
              * - "Foo:Bar" relative to any namespace other than Foo stays "Foo:Bar".
              *
              * @param {number} namespace The namespace to be relative to
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getRelativeText
              */
             getRelativeText(namespace: number): string;
@@ -241,7 +239,7 @@ declare global {
             /**
              * Get the title for the subject page of a talk page
              *
-             * @return {Title|null} The title for the subject page of a talk page, null if not available
+             * @returns {Title|null} The title for the subject page of a talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getSubjectPage
              */
             getSubjectPage(): Title | null;
@@ -249,7 +247,7 @@ declare global {
             /**
              * Get the title for the associated talk page
              *
-             * @return {Title|null} The title for the associated talk page, null if not available
+             * @returns {Title|null} The title for the associated talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getTalkPage
              */
             getTalkPage(): Title | null;
@@ -257,9 +255,9 @@ declare global {
             /**
              * Get the URL to this title
              *
-             * @param {Object} [params] A mapping of query parameter names to values,
+             * @param {QueryParams} [params] A mapping of query parameter names to values,
              *     e.g. `{ action: 'edit' }`.
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-getUrl
              */
             getUrl(params?: QueryParams): string;
@@ -267,27 +265,21 @@ declare global {
             /**
              * Check if the title is in a talk namespace
              *
-             * @return {boolean} The title is in a talk namespace
+             * @returns {boolean} The title is in a talk namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkPage
              */
             isTalkPage(): boolean;
 
             /**
-             * Alias of {@link mw.Title.getPrefixedDb}
+             * Alias of {@link getPrefixedDb}
              *
-             * TODO: Use @-alias when we switch to JSDoc
-             *
-             * @method
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-toString
              */
             toString(): string;
 
             /**
-             * Alias of {@link mw.Title.getPrefixedText}
+             * Alias of {@link getPrefixedText}
              *
-             * TODO: Use @-alias when we switch to JSDoc
-             *
-             * @method
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-toText
              */
             toText(): string;
@@ -296,11 +288,11 @@ declare global {
              * Whether this title exists on the wiki.
              *
              * @param {string|Title} title prefixed db-key name (string) or instance of Title
-             * @return {boolean|null} Boolean if the information is available, otherwise null
+             * @returns {boolean|null} Boolean if the information is available, otherwise null
              * @throws {Error} If title is not a string or mw.Title
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-exists
              */
-            static exists(title: title): boolean | null;
+            static exists(title: TitleLike): boolean | null;
 
             /**
              * Check if a given namespace is a talk namespace
@@ -308,7 +300,7 @@ declare global {
              * See NamespaceInfo::isTalk in PHP
              *
              * @param {number} namespaceId Namespace ID
-             * @return {boolean} Namespace is a talk namespace
+             * @returns {boolean} Namespace is a talk namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-isTalkNamespace
              */
             static isTalkNamespace(namespaceId: number): boolean;
@@ -324,7 +316,7 @@ declare global {
              *
              * @param {number} namespace Namespace to use for the title
              * @param {string} title
-             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @returns {Title|null} A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-makeTitle
              */
             static makeTitle(namespace: number, title: string): Title | null;
@@ -336,7 +328,7 @@ declare global {
              *
              * @param {string} uncleanName The unclean file name including file extension but
              *   without namespace
-             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @returns {Title|null} A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromFileName
              */
             static newFromFileName(uncleanName: string): Title | null;
@@ -349,7 +341,7 @@ declare global {
              * ```
              *
              * @param {HTMLElement|JQuery} img The image to use as a base
-             * @return {Title|null} The file title or null if unsuccessful
+             * @returns {Title|null} The file title or null if unsuccessful
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromImg
              */
             static newFromImg(img: HTMLElement | JQuery): Title;
@@ -363,7 +355,7 @@ declare global {
              *
              * @param {string} title
              * @param {number} [namespace=NS_MAIN] Default namespace
-             * @return {Title|null} A valid Title object or null if the title is invalid
+             * @returns {Title|null} A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromText
              */
             static newFromText(title: string, namespace?: number): Title | null;
@@ -380,7 +372,7 @@ declare global {
              *  Makes sure that a file is uploadable under the title returned.
              *  There are pages in the file namespace under which file upload is impossible.
              *  Automatically assumed if the title is created in the Media namespace.
-             * @return {Title|null} A valid Title object or null if the input cannot be turned into a valid title
+             * @returns {Title|null} A valid Title object or null if the input cannot be turned into a valid title
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromUserInput
              */
             static newFromUserInput(
@@ -395,7 +387,7 @@ declare global {
              * Keep in sync with File::normalizeExtension() in PHP.
              *
              * @param {string} extension File extension (without the leading dot)
-             * @return {string} File extension in canonical form
+             * @returns {string} File extension in canonical form
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-normalizeExtension
              */
             static normalizeExtension(extension: string): string;
@@ -404,7 +396,7 @@ declare global {
              * PHP's strtoupper differs from {@link String.toUpperCase} in a number of cases (T147646).
              *
              * @param {string} chr Unicode character
-             * @return {string} Unicode character, in upper case, according to the same rules as in PHP
+             * @returns {string} Unicode character, in upper case, according to the same rules as in PHP
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-phpCharToUpper
              */
             static phpCharToUpper(chr: string): string;
@@ -415,7 +407,7 @@ declare global {
              * See NamespaceInfo::wantSignatures in PHP
              *
              * @param {number} namespaceId Namespace ID
-             * @return {boolean} Namespace is a signature namespace
+             * @returns {boolean} Namespace is a signature namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-method-wantSignaturesNamespace
              */
             static wantSignatureNamespace(namespaceId: number): boolean;

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -344,7 +344,7 @@ declare global {
              * @returns {Title|null} The file title or null if unsuccessful
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Title-static-method-newFromImg
              */
-            static newFromImg(img: HTMLElement | JQuery): Title;
+            static newFromImg(img: HTMLElement | JQuery): Title | null;
 
             /**
              * Constructor for Title objects with a null return instead of an exception for invalid titles.
@@ -378,7 +378,7 @@ declare global {
             static newFromUserInput(
                 title: string,
                 defaultNamespace?: number,
-                options?: { forUploading: boolean }
+                options?: { forUploading?: boolean }
             ): Title | null;
 
             /**

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -21,6 +21,61 @@ declare global {
          */
         function UriRelative(documentLocation: string | ((...args: any[]) => string)): Uri;
 
+        /**
+         * Library for simple URI parsing and manipulation.
+         *
+         * Intended to be minimal, but featureful; do not expect full RFC 3986 compliance. The use cases we
+         * have in mind are constructing 'next page' or 'previous page' URLs, detecting whether we need to
+         * use cross-domain proxies for an API, constructing simple URL-based API calls, etc. Parsing here
+         * is regex-based, so may not work on all URIs, but is good enough for most.
+         *
+         * You can modify the properties directly, then use the {@link toString} method to extract the full URI
+         * string again. Example:
+         *
+         * ```js
+         * var uri = new mw.Uri( 'http://example.com/mysite/mypage.php?quux=2' );
+         *
+         * if ( uri.host == 'example.com' ) {
+         *     uri.host = 'foo.example.com';
+         *     uri.extend( { bar: 1 } );
+         *
+         *     $( 'a#id1' ).attr( 'href', uri );
+         *     // anchor with id 'id1' now links to http://foo.example.com/mysite/mypage.php?bar=1&quux=2
+         *
+         *     $( 'a#id2' ).attr( 'href', uri.clone().extend( { bar: 3, pif: 'paf' } ) );
+         *     // anchor with id 'id2' now links to http://foo.example.com/mysite/mypage.php?bar=3&quux=2&pif=paf
+         * }
+         * ```
+         *
+         * Given a URI like
+         * `http://usr:pwd@www.example.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=&test3=value+%28escaped%29&r=1&r=2#top`
+         * the returned object will have the following properties:
+         *
+         * ```js
+         * protocol  'http'
+         * user      'usr'
+         * password  'pwd'
+         * host      'www.example.com'
+         * port      '81'
+         * path      '/dir/dir.2/index.htm'
+         * query     {
+         *               q1: '0',
+         *               test1: null,
+         *               test2: '',
+         *               test3: 'value (escaped)'
+         *               r: ['1', '2']
+         *           }
+         * fragment  'top'
+         * ```
+         *
+         * (N.b., 'password' is technically not allowed for HTTP URIs, but it is possible with other kinds
+         * of URIs.)
+         *
+         * Parsing based on parseUri 1.2.2 (c) Steven Levithan <http://stevenlevithan.com>, MIT License.
+         * <http://stevenlevithan.com/demo/parseuri/js/>
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri
+         */
         class Uri {
             /**
              * @property {string|undefined} fragment For example `top`
@@ -71,7 +126,6 @@ declare global {
              * so the server-side strips these before delivering to the client.
              *
              * @private
-             * @static
              * @property {Object} parser
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-parser
              */
@@ -84,7 +138,6 @@ declare global {
              * The order here matches the order of captured matches in the `parser` property regexes.
              *
              * @private
-             * @static
              * @property {string[]} properties
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-properties
              */
@@ -103,8 +156,6 @@ declare global {
              * Construct a new URI object. Throws error if arguments are illegal/impossible, or
              * otherwise don't parse.
              *
-             * @class mw.Uri
-             * @constructor
              * @param {Object|string} [uri] URI string, or an Object with appropriate properties (especially
              *  another URI object to clone). Object must have non-blank `protocol`, `host`, and `path`
              *  properties. If omitted (or set to `undefined`, `null` or empty string), then an object
@@ -231,10 +282,9 @@ declare global {
             /**
              * Decode a url encoded value.
              *
-             * Reversed #encode. Standard decodeURIComponent, with addition of replacing
+             * Reversed {@link encode}. Standard decodeURIComponent, with addition of replacing
              * `+` with a space.
              *
-             * @static
              * @param {string} s String to decode
              * @return {string} Decoded string
              * @throws {Error} when the string contains an unknown % sequence
@@ -249,7 +299,6 @@ declare global {
              * compliant with RFC 3986. Similar to rawurlencode from PHP and our JS library
              * mw.util.rawurlencode, except this also replaces spaces with `+`.
              *
-             * @static
              * @param {string} s String to encode
              * @return {string} Encoded string for URI
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-method-encode

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -23,11 +23,9 @@ declare global {
          * A factory method to create an mw.Uri class with a default location to resolve relative URLs
          * against (including protocol-relative URLs).
          *
-         * @method
          * @param {string|Function} documentLocation A full url, or function returning one.
          *  If passed a function, the return value may change over time and this will be honoured. (T74334)
-         * @member mw
-         * @return {Function} An mw.Uri class constructor
+         * @returns {Function} An mw.Uri class constructor
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-UriRelative
          */
         function UriRelative(documentLocation: string | (() => string)): typeof Uri;
@@ -136,11 +134,10 @@ declare global {
              * file where they make use of named capture groups. That syntax isn't valid in JavaScript ES5,
              * so the server-side strips these before delivering to the client.
              *
-             * @private
              * @property {Object} parser
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-parser
              */
-            static parser: {
+            private static parser: {
                 strict: RegExp;
                 loose: RegExp;
             };
@@ -148,11 +145,10 @@ declare global {
             /**
              * The order here matches the order of captured matches in the `parser` property regexes.
              *
-             * @private
              * @property {string[]} properties
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-properties
              */
-            static properties: [
+            private static properties: [
                 "protocol",
                 "user",
                 "password",
@@ -185,7 +181,7 @@ declare global {
             /**
              * Clone this URI
              *
-             * @return {Uri} New URI object with same properties
+             * @returns {Uri} New URI object with same properties
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-clone
              */
             clone(): Uri;
@@ -193,9 +189,9 @@ declare global {
             /**
              * Extend the query section of the URI with new parameters.
              *
-             * @param {Object} parameters Query parameters to add to ours (or to override ours with) as an
+             * @param {QueryParams} parameters Query parameters to add to ours (or to override ours with) as an
              *  object
-             * @return {Uri} This URI object
+             * @returns {Uri} This URI object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-extend
              */
             extend(parameters: QueryParams): Uri;
@@ -205,7 +201,7 @@ declare global {
              *
              * In most real-world URLs this is simply the hostname, but the definition of 'authority' section is more general.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getAuthority
              */
             getAuthority(): string;
@@ -213,7 +209,7 @@ declare global {
             /**
              * Get host and port section of a URI.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getHostPort
              */
             getHostPort(): string;
@@ -223,7 +219,7 @@ declare global {
              *
              * Does not preserve the original order of arguments passed in the URI. Does handle escaping.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getQueryString
              */
             getQueryString(): string;
@@ -231,7 +227,7 @@ declare global {
             /**
              * Get everything after the authority section of the URI.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getRelativePath
              */
             getRelativePath(): string;
@@ -239,7 +235,7 @@ declare global {
             /**
              * Get user and password section of a URI.
              *
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-getUserInfo
              */
             getUserInfo(): string;
@@ -255,7 +251,7 @@ declare global {
              * web2017-polyfills, which loads a polyfill if needed) in contexts where the fragment
              * is important.
              *
-             * @return {string} The URI string
+             * @returns {string} The URI string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-toString
              */
             toString(): `${string}://${string}`;
@@ -263,13 +259,12 @@ declare global {
             /**
              * Parse a string and set our properties accordingly.
              *
-             * @private
              * @param {string} str URI, see constructor.
              * @param {Object} options See constructor.
              * @throws {Error} when the query string or fragment contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-parse
              */
-            parse(str: string, options: Partial<UriOptions>): void;
+            private parse(str: string, options: Partial<UriOptions>): void;
 
             /**
              * Decode a url encoded value.
@@ -278,7 +273,7 @@ declare global {
              * `+` with a space.
              *
              * @param {string} s String to decode
-             * @return {string} Decoded string
+             * @returns {string} Decoded string
              * @throws {Error} when the string contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-method-decode
              */
@@ -292,7 +287,7 @@ declare global {
              * mw.util.rawurlencode, except this also replaces spaces with `+`.
              *
              * @param {string} s String to encode
-             * @return {string} Encoded string for URI
+             * @returns {string} Encoded string for URI
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-method-encode
              */
             static encode(s: string): string;

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -92,42 +92,50 @@ declare global {
          */
         class Uri {
             /**
-             * @property {string|undefined} fragment For example `top`
+             * For example `top`
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-fragment
              */
             fragment: string | undefined;
             /**
-             * @property {string} host For example `www.example.com` (always present)
+             * For example `www.example.com` (always present)
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-host
              */
             host: string;
             /**
-             * @property {string|undefined} password For example `pwd`
+             * For example `pwd`
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-password
              */
             password: string | undefined;
             /**
-             * @property {string} path For example `/dir/dir.2/index.htm` (always present)
+             * For example `/dir/dir.2/index.htm` (always present)
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-path
              */
             path: string;
             /**
-             * @property {string|undefined} port For example `81`
+             * For example `81`
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-port
              */
             port: string | undefined;
             /**
-             * @property {string} protocol For example `http` (always present)
+             * For example `http` (always present)
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-protocol
              */
             protocol: string;
             /**
-             * @property {Object} query For example `{ a: '0', b: '', c: 'value' }` (always present)
+             * For example `{ a: '0', b: '', c: 'value' }` (always present)
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-query
              */
             query: QueryParams;
             /**
-             * @property {string|undefined} user For example `usr`
+             * For example `usr`
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-property-user
              */
             user: string | undefined;
@@ -146,7 +154,6 @@ declare global {
             /**
              * The order here matches the order of captured matches in the `parser` property regexes.
              *
-             * @property {string[]} properties
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-properties
              */
             private static properties: [
@@ -169,7 +176,7 @@ declare global {
              *  properties. If omitted (or set to `undefined`, `null` or empty string), then an object
              *  will be created for the default `uri` of this constructor (`location.href` for mw.Uri,
              *  other values for other instances -- see mw.UriRelative for details).
-             * @param {Object|boolean} [options] Object with options, or (backwards compatibility) a boolean
+             * @param {Partial<UriOptions>|boolean} [options] Object with options, or (backwards compatibility) a boolean
              *  for strictMode
              * @throws {Error} when the query string or fragment contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-constructor
@@ -261,7 +268,7 @@ declare global {
              * Parse a string and set our properties accordingly.
              *
              * @param {string} str URI, see constructor.
-             * @param {Object} options See constructor.
+             * @param {Partial<UriOptions>} options See constructor.
              * @throws {Error} when the query string or fragment contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-method-parse
              */

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -17,6 +17,11 @@ interface UriOptions {
     arrayParams: boolean;
 }
 
+interface UriParser {
+    strict: RegExp;
+    loose: RegExp;
+}
+
 declare global {
     namespace mw {
         /**
@@ -134,13 +139,9 @@ declare global {
              * file where they make use of named capture groups. That syntax isn't valid in JavaScript ES5,
              * so the server-side strips these before delivering to the client.
              *
-             * @property {Object} parser
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Uri-static-property-parser
              */
-            private static parser: {
-                strict: RegExp;
-                loose: RegExp;
-            };
+            private static parser: UriParser;
 
             /**
              * The order here matches the order of captured matches in the `parser` property regexes.

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -1,4 +1,4 @@
-export type QueryParams = Record<string, any>;
+export type QueryParams = Record<string, string | number | boolean | null | undefined>;
 
 interface UriOptions {
     /**

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -1,3 +1,5 @@
+import { ExtensibleMap } from "./Map";
+
 declare global {
     namespace mw {
         /**
@@ -11,7 +13,7 @@ declare global {
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-config
          */
-        const config: Map<{
+        const config: ExtensibleMap<{
             /**
              * Since MediaWiki 1.36+, 0 means debug mode is off, and a positive non-zero number means debug mode is on (e.g. 1 or 2).
              *
@@ -358,7 +360,6 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffNewId
              */
             wgDiffNewId?: number;
-            [key: string]: unknown; // more config keys can be added by extensions
         }>;
     }
 }

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -3,14 +3,15 @@ declare global {
         /**
          * Map of configuration values.
          *
-         * Check out [the complete list of configuration values](https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#mw.config)
+         * Check out {@link https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#mw.config the complete list of configuration values}
          * on mediawiki.org.
          *
          * If `$wgLegacyJavaScriptGlobals` is true, this Map will add its values to the
          * global `window` object.
+         *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-config
          */
-        const config: mw.Map<{
+        const config: Map<{
             debug: boolean;
             skin: string;
             stylepath: string;

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -32,6 +32,7 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#stylepath
              */
             stylepath: string;
+            wgActionPaths: Record<string, string>;
             /**
              * Local path, starting at the root, to reference articles, containing a "$1" placeholder that may be replaced by a page title to get a valid URL to that page. Given a valid page title title, a valid URL may be constructed using wgArticlePath.replace('$1', title). See also $wgArticlePath.
              *
@@ -44,6 +45,7 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCaseSensitiveNamespaces
              */
             wgCaseSensitiveNamespaces: number[];
+            wgCommentCodePointLimit: number;
             /**
              * The language code for the default content language of the wiki.
              *
@@ -68,12 +70,15 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgExtensionAssetsPath
              */
             wgExtensionAssetsPath: string;
+            wgExtraSignatureNamespaces: number[];
             /**
              * Gives a mapping from namespace IDs to localized namespace names. For each namespace, the object has one entry that has the stringified namespace number as the key and the namespace name as its value. Aliases or canonical names are not included.
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgFormattedNamespaces
              */
             wgFormattedNamespaces: Record<number, string>;
+            wgIllegalFileChars: string;
+            wgLegalTitleChars: string;
             /**
              * Gives a mapping from namespace names to namespace IDs. For each namespace name, including localized and canonical names as well as aliases, the object has one entry that has namespace name as the key and the namespace ID as its integer value. The keys are all lowercase, with spaces replaced by underscores.
              *
@@ -110,6 +115,7 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgSiteName
              */
             wgSiteName: string;
+            wgTranslateNumerals: boolean;
             wgUrlProtocols: string;
             /**
              * If a wiki has language variants (such as the Chinese and the Serbian Wikipedias), set to a path beginning at the root for language variants other than wgContentLanguage. The path contains two placeholders: "$1" is to be replaced by the page title, and "$2" is to be replaced by the language code of the language variant (e.g. "zh-tw"). If the wiki does not have language variants, set to false. See also $wgVariantArticlePath.
@@ -220,7 +226,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRedirectedFrom
              */
-            wgRedirectedFrom: string;
+            wgRedirectedFrom?: string;
             /**
              * The full name of the page to which content actions and navigation links (e.g. a skin's tabs) apply. The AJAX watch function uses this to work correctly on special pages such as Special:MovePage and Special:WhatLinksHere.
              *
@@ -232,7 +238,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRelevantUserName
              */
-            wgRelevantUserName: string;
+            wgRelevantUserName?: string;
             /**
              * Like wgIsProbablyEditable, but applied to the contextually relevant page name from wgRelevantPageName instead of strictly the current page being viewed. For example, when viewing a page "Special:MovePage/Example" this will indicate whether the subject page is editable.
              *
@@ -248,7 +254,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRestrictionEdit
              */
-            wgRestrictionEdit: string[];
+            wgRestrictionEdit?: string[];
             /**
              * If the page is movable at all (and is not a special page) and moving of the page is restricted to some user groups, the array contains the minimum user group a user must be in in order to move the page. For semi-moveprotected pages, it'd contain ["autoconfirmed"]; for fully moveprotected pages ["sysop"]. If there are no explicit restrictions, the value is [] (an array with no elements).
              *
@@ -268,7 +274,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgSearchType
              */
-            wgSearchType: string;
+            wgSearchType: string | null;
             /**
              * The page title, without the namespace. May contain spaces – does not contain underscores. To get the title including the namespace, use wgPageName.
              *
@@ -280,19 +286,19 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserEditCount
              */
-            wgUserEditCount: number;
+            wgUserEditCount?: number;
             /**
              * An array containing all the (local) user groups the current user is a member of, or null for non-logged-in users. User groups are identified by the internal user group names, e.g. "sysop", "autoconfirmed", "bureaucrat", and so on. The default user group is named "*".
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserGroups
              */
-            wgUserGroups: string[];
+            wgUserGroups: string[] | null;
             /**
              * The numeric ID of the current user (null if not logged in).
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserId
              */
-            wgUserId: number;
+            wgUserId?: number;
             /**
              * The language code for the user's interface language, as set in Special→Preferences (which may be overridden by a uselang= parameter in the URL).
              *
@@ -304,19 +310,19 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserName
              */
-            wgUserName: string;
+            wgUserName: string | null;
             /**
              * The time and date on which the current user registered, represented as milliseconds since epoch. Null if not logged in.
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserRegistration
              */
-            wgUserRegistration: number;
+            wgUserRegistration?: number;
             /**
              * true if the current page is the main page of the wiki. Omitted entirely otherwise (defaulting to null in mw.config).
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgIsMainPage
              */
-            wgIsMainPage: boolean;
+            wgIsMainPage?: true;
             /**
              * If the wiki has language variants, the language code of the user's preferred variant. If the wiki does not have variants, the variable is not configured (does not exist), i.e.:
              *
@@ -327,7 +333,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserVariant
              */
-            wgUserVariant: string;
+            wgUserVariant?: string;
             /**
              * "saved" if the user just saved this page. "created" if the user just created this page. "restored" if the user just restored this page by going to the history page, clicked on a timestamp link for an old revision, clicked on edit and then saved. null otherwise. Note that:
              *
@@ -339,19 +345,19 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPostEdit
              */
-            wgPostEdit: "created" | "restored" | "saved";
+            wgPostEdit?: "created" | "restored" | "saved";
             /**
              * Revision ID of the "old" revision when viewing a diff. Only available when viewing a revision comparison.
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffOldId
              */
-            wgDiffOldId: number;
+            wgDiffOldId?: number;
             /**
              * Revision ID of the "new" revision when viewing a diff. Only available when viewing a revision comparison.
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffNewId
              */
-            wgDiffNewId: number;
+            wgDiffNewId?: number;
             [key: string]: unknown; // more config keys can be added by extensions
         }>;
     }

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -19,7 +19,7 @@ declare global {
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#debug
              */
-            debug: number;
+            debug: boolean | number;
             /**
              * The internal name of the currently used skin.
              *

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -63,12 +63,6 @@ declare global {
              */
             wgDBname: string;
             /**
-             * The wiki identifier. Should be preferred over wgDBname.
-             *
-             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgWikiID
-             */
-            wgWikiID: string;
-            /**
              * Root path used for extension static assets (e.g. images). Append '/' then the name of the extension to get the root path for a given extension.
              *
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgExtensionAssetsPath
@@ -116,6 +110,7 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgSiteName
              */
             wgSiteName: string;
+            wgUrlProtocols: string;
             /**
              * If a wiki has language variants (such as the Chinese and the Serbian Wikipedias), set to a path beginning at the root for language variants other than wgContentLanguage. The path contains two placeholders: "$1" is to be replaced by the page title, and "$2" is to be replaced by the language code of the language variant (e.g. "zh-tw"). If the wiki does not have language variants, set to false. See also $wgVariantArticlePath.
              *
@@ -128,6 +123,12 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgVersion
              */
             wgVersion: string;
+            /**
+             * The wiki identifier. Should be preferred over wgDBname.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgWikiID
+             */
+            wgWikiID: string;
             /**
              * The action performed, e.g. "edit" for edit pages, or "view" for page views. See Manual:Parameters to index.php#Actions.
              *
@@ -351,7 +352,6 @@ declare global {
              * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffNewId
              */
             wgDiffNewId: number;
-            wgUrlProtocols: string;
             [key: string]: unknown; // more config keys can be added by extensions
         }>;
     }

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -12,63 +12,377 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-config
          */
         const config: Map<{
-            debug: boolean;
+            /**
+             * Since MediaWiki 1.36+, 0 means debug mode is off, and a positive non-zero number means debug mode is on (e.g. 1 or 2).
+             *
+             * In MediaWiki 1.35 and earlier, false and true were used (phab:T85805).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#debug
+             */
+            debug: number;
+            /**
+             * The internal name of the currently used skin.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#skin
+             */
             skin: string;
+            /**
+             * Full URL to the root directory for skins, containing stylesheets and skin-specific scripts. The path does not contain the skin subdirectory, and is not terminated by a "/".
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#stylepath
+             */
             stylepath: string;
+            /**
+             * Local path, starting at the root, to reference articles, containing a "$1" placeholder that may be replaced by a page title to get a valid URL to that page. Given a valid page title title, a valid URL may be constructed using wgArticlePath.replace('$1', title). See also $wgArticlePath.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgArticlePath
+             */
             wgArticlePath: string;
-            wgCaseSensitiveNamespaces: string[];
+            /**
+             * The IDs of the namespaces treated as case-sensitive by MediaWiki. Determined by the values of them $wgCapitalLinks and $wgCapitalLinksOverrides configuration variables.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCaseSensitiveNamespaces
+             */
+            wgCaseSensitiveNamespaces: number[];
+            /**
+             * The language code for the default content language of the wiki.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgContentLanguage
+             */
             wgContentLanguage: string;
+            /**
+             * The IDs of the namespaces considered "content namespaces" by MediaWiki. Equivalent to the value of the $wgContentNamespaces configuration variable, with 0 included if it is not already.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgContentNamespaces
+             */
             wgContentNamespaces: number[];
+            /**
+             * The name of the wiki's database.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDBname
+             */
             wgDBname: string;
-            wgEnableAPI: boolean;
-            wgEnableWriteAPI: boolean;
+            /**
+             * The wiki identifier. Should be preferred over wgDBname.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgWikiID
+             */
+            wgWikiID: string;
+            /**
+             * Root path used for extension static assets (e.g. images). Append '/' then the name of the extension to get the root path for a given extension.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgExtensionAssetsPath
+             */
             wgExtensionAssetsPath: string;
+            /**
+             * Gives a mapping from namespace IDs to localized namespace names. For each namespace, the object has one entry that has the stringified namespace number as the key and the namespace name as its value. Aliases or canonical names are not included.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgFormattedNamespaces
+             */
             wgFormattedNamespaces: Record<number, string>;
+            /**
+             * Gives a mapping from namespace names to namespace IDs. For each namespace name, including localized and canonical names as well as aliases, the object has one entry that has namespace name as the key and the namespace ID as its integer value. The keys are all lowercase, with spaces replaced by underscores.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgNamespaceIds
+             */
             wgNamespaceIds: Record<string, number>;
+            /**
+             * Full path to the main access point script, starting at the root, including the full script name with extension. On WMF wikis, normally "/w/index.php". See also $wgScript.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgScript
+             */
             wgScript: string;
+            /**
+             * The path part of wgScript, without trailing "/". This is the path to use for direct calls to the php access points such as index.php or api.php. See also $wgScriptPath.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgScriptPath
+             */
             wgScriptPath: string;
+            /**
+             * The server URL, not terminated by "/". The combination wgServer + wgScriptPath + "/api.php", for instance, results in a valid URL to the API access point script.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgServer
+             */
             wgServer: string;
+            /**
+             * The name of the server, without the protocol or trailing slash (e.g. "en.wikipedia.org").
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgServerName
+             */
             wgServerName: string;
+            /**
+             * The name of the site, as defined by $wgSitename.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgSiteName
+             */
             wgSiteName: string;
+            /**
+             * If a wiki has language variants (such as the Chinese and the Serbian Wikipedias), set to a path beginning at the root for language variants other than wgContentLanguage. The path contains two placeholders: "$1" is to be replaced by the page title, and "$2" is to be replaced by the language code of the language variant (e.g. "zh-tw"). If the wiki does not have language variants, set to false. See also $wgVariantArticlePath.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgVariantArticlePath
+             */
             wgVariantArticlePath: string | false;
+            /**
+             * Identifies the version of MediaWiki that served the page.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgVersion
+             */
             wgVersion: string;
+            /**
+             * The action performed, e.g. "edit" for edit pages, or "view" for page views. See Manual:Parameters to index.php#Actions.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgAction
+             */
             wgAction: string;
+            /**
+             * The internal ID (page ID) of the page. For non-existent pages and special pages, it is zero.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgArticleId
+             */
             wgArticleId: number;
+            /**
+             * The canonical (i.e., not localized or aliased) namespace name of the page.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCanonicalNamespace
+             */
             wgCanonicalNamespace: string;
+            /**
+             * On special pages, the canonical (i.e., not localized or aliased) name of the special page; otherwise it is not defined at all (up to and including MW 1.15) or is set to false (since MW 1.16).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCanonicalSpecialPageName
+             */
             wgCanonicalSpecialPageName: string | false;
+            /**
+             * The list of all the categories a page belongs to. This is essentially a JavaScript version of the category box shown on the page (grey box at bottom of page, in Monobook/Vector). If the category box is not shown on the current page (as is the case when editing/viewing history), wgCategories will be an empty array.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCategories
+             */
             wgCategories: string[];
+            /**
+             * The top revision ID of the currently viewed page at the time the page was served. Also set on diff and history pages; zero for special pages.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgCurRevisionId
+             */
             wgCurRevisionId: number;
+            /**
+             * true if the page displays the content of a wiki page, e.g. when viewing a page (regardless of namespace), or when viewing an old revision or diff with rendered content below it. It is false for anything else (edit form, history page, special pages, most generated pages, etc.).
+             *
+             * This variable is badly named – it is not related to a page being a main namespace "article".
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgIsArticle
+             */
             wgIsArticle: boolean;
+            /**
+             * True if the page is probably editable (based on Title::quickUserCan) by the current user. The 'probably' is necessary for performance reasons. An exact editability check is too costly here, due to cascading protection and hook-based extensions like TitleBlacklist that may be enabled. If this is true, it is likely to be editable. If it is false, it is definitely not editable.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgIsProbablyEditable
+             */
             wgIsProbablyEditable: boolean;
+            /**
+             * true if the page is a redirect to a wiki page using #REDIRECT [[Target page name]]. It is false for anything else (normal pages, special pages, most generated pages, etc.).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgIsRedirect
+             */
+            wgIsRedirect: boolean;
+            /**
+             * The number of the namespace the page is in.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgNamespaceNumber
+             */
             wgNamespaceNumber: number;
+            /**
+             * Language code of the page content language (according to $context->getTitle()->getPageLanguage())
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPageContentLanguage
+             */
             wgPageContentLanguage: string;
+            /**
+             * 'wikitext' on typical wiki pages, 'javascript' on pages interpreted as JavaScript, 'css' on pages interpreted as CSS, 'Scribunto' on pages interpreted as Scribunto (Lua).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPageContentModel
+             */
             wgPageContentModel: string;
+            /**
+             * The full name of the page, including the localized namespace name, if the namespace has a name (the main namespace (number 0) doesn't), and with spaces replaced by underscores. To get only the title without the namespace, use wgTitle.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPageName
+             */
             wgPageName: string;
+            /**
+             * Parser limit report for the page when parser data is available. Includes data about parset limits, Lua statistics when Scribunto extension is enabled and parser cache information.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPageParseReport
+             */
+            wgPageParseReport: PageParseReport;
+            /**
+             * When redirected contains the title of the page we were redirected from. If the page was not redirected, the value is omitted entirely (absent in mw.config). Uses the same format as wgPageName
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRedirectedFrom
+             */
             wgRedirectedFrom: string;
+            /**
+             * The full name of the page to which content actions and navigation links (e.g. a skin's tabs) apply. The AJAX watch function uses this to work correctly on special pages such as Special:MovePage and Special:WhatLinksHere.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRelevantPageName
+             */
             wgRelevantPageName: string;
+            /**
+             * The relevant name of the user to which content actions and some extra navigation links (e.g. link to user rights or user contributions) apply.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRelevantUserName
+             */
             wgRelevantUserName: string;
+            /**
+             * Like wgIsProbablyEditable, but applied to the contextually relevant page name from wgRelevantPageName instead of strictly the current page being viewed. For example, when viewing a page "Special:MovePage/Example" this will indicate whether the subject page is editable.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRelevantPageIsProbablyEditable
+             */
             wgRelevantPageIsProbablyEditable: boolean;
+            /**
+             * If the page is editable at all (and is not a special page) and editing of the page is restricted to some user groups, the array contains the minimum user group a user must be in in order to edit the page. For semi-protected pages, it'd contain ["autoconfirmed"]; for fully protected pages ["sysop"]. If there are no explicit restrictions, the value is [] (an array with no elements).
+             *
+             * This array contains only explicit protections. Namespace-wide protections (e.g. MediaWiki namespace, $wgNamespaceProtection), cascading protections, or "protections" brought about by the TitleBlacklist extension's "noedit" attribute, are ignored by this array. On such pages, the value is normally [], unless additional protections have been applied specifically to that page.
+             *
+             * If the page does not exist, the variable is not set.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRestrictionEdit
+             */
             wgRestrictionEdit: string[];
+            /**
+             * If the page is movable at all (and is not a special page) and moving of the page is restricted to some user groups, the array contains the minimum user group a user must be in in order to move the page. For semi-moveprotected pages, it'd contain ["autoconfirmed"]; for fully moveprotected pages ["sysop"]. If there are no explicit restrictions, the value is [] (an array with no elements).
+             *
+             * This array contains only explicit protections. Namespace-wide protections (e.g. MediaWiki namespace, $wgNamespaceProtection), cascading protections, or "protections" brought about by the TitleBlacklist extension's "moveonly" attribute, are ignored by this array. On such pages, the value is normally [], unless additional protections have been applied specifically to that page.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRestrictionMove
+             */
             wgRestrictionMove: string[];
+            /**
+             * The revision ID of the currently viewed revision, or the right revision for diff views (But 0 when diffonly=yes, task T231744). Also set on diff pages; zero for special pages, history pages, or anywhere else inapplicable.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgRevisionId
+             */
             wgRevisionId: number;
+            /**
+             * The name of the search backend used to execute search requests.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgSearchType
+             */
             wgSearchType: string;
+            /**
+             * The page title, without the namespace. May contain spaces – does not contain underscores. To get the title including the namespace, use wgPageName.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgTitle
+             */
             wgTitle: string;
+            /**
+             * The number of edits the current user made (null if not logged in).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserEditCount
+             */
             wgUserEditCount: number;
+            /**
+             * An array containing all the (local) user groups the current user is a member of, or null for non-logged-in users. User groups are identified by the internal user group names, e.g. "sysop", "autoconfirmed", "bureaucrat", and so on. The default user group is named "*".
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserGroups
+             */
             wgUserGroups: string[];
+            /**
+             * The numeric ID of the current user (null if not logged in).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserId
+             */
             wgUserId: number;
+            /**
+             * The language code for the user's interface language, as set in Special→Preferences (which may be overridden by a uselang= parameter in the URL).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserLanguage
+             */
             wgUserLanguage: string;
+            /**
+             * The user name of the user currently viewing the page, if it's a logged-in user. For non-logged-in users, it is null (not the user's IP address, unlike PHP $wgUser->getName() on the server).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserName
+             */
             wgUserName: string;
+            /**
+             * The time and date on which the current user registered, represented as milliseconds since epoch. Null if not logged in.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserRegistration
+             */
             wgUserRegistration: number;
+            /**
+             * true if the current page is the main page of the wiki. Omitted entirely otherwise (defaulting to null in mw.config).
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgIsMainPage
+             */
             wgIsMainPage: boolean;
+            /**
+             * If the wiki has language variants, the language code of the user's preferred variant. If the wiki does not have variants, the variable is not configured (does not exist), i.e.:
+             *
+             * ```js
+             * mw.config.exists( 'wgUserVariant' ); // false
+             * mw.config.get( 'wgUserVariant' ); // null.
+             * ```
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgUserVariant
+             */
             wgUserVariant: string;
-            wgPostEdit: string;
-            wgDiffOldId: number | false;
+            /**
+             * "saved" if the user just saved this page. "created" if the user just created this page. "restored" if the user just restored this page by going to the history page, clicked on a timestamp link for an old revision, clicked on edit and then saved. null otherwise. Note that:
+             *
+             * On null edits, this is null, not "saved"
+             *
+             * When using "undo", this is "saved"
+             *
+             * On rollback, this is null
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgPostEdit
+             */
+            wgPostEdit: "created" | "restored" | "saved";
+            /**
+             * Revision ID of the "old" revision when viewing a diff. Only available when viewing a revision comparison.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffOldId
+             */
+            wgDiffOldId: number;
+            /**
+             * Revision ID of the "new" revision when viewing a diff. Only available when viewing a revision comparison.
+             *
+             * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#wgDiffNewId
+             */
             wgDiffNewId: number;
-            wgWikibaseItemId: string;
             wgUrlProtocols: string;
             [key: string]: unknown; // more config keys can be added by extensions
         }>;
     }
+}
+
+interface PageParseReport {
+    cachereport: CacheReport;
+    limitreport: LimitReport;
+}
+
+interface CacheReport {
+    timestamp: `${number}`;
+    transientcontent: boolean;
+    ttl: number;
+}
+
+interface LimitReport {
+    "cputime": `${number}`;
+    "expansiondepth": LimitReportValue;
+    "expensivefunctioncount": LimitReportValue;
+    "postexpandincludesize": LimitReportValue;
+    "ppvisitednodes": LimitReportValue;
+    "templateargumentsize": LimitReportValue;
+    "timingprofile": string[];
+    "unstrip-depth": LimitReportValue;
+    "unstrip-size": LimitReportValue;
+}
+
+interface LimitReportValue {
+    value: number;
+    limit: number;
 }
 
 export {};

--- a/mw/cookie.d.ts
+++ b/mw/cookie.d.ts
@@ -9,6 +9,38 @@ declare global {
          */
         namespace cookie {
             /**
+             * Get the value of a cookie.
+             *
+             * @param {string} key The key for the cookie
+             * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
+             * @param {*} [defaultValue] A value to return if the cookie does not exist
+             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-get
+             */
+            function get<D>(
+                key: string,
+                prefix: string | undefined | null,
+                defaultValue: D
+            ): string | D;
+            function get(key: string, prefix?: string): string;
+
+            /**
+             * Get the value of a `SameSite` = `None` cookie, using the legacy `ss0-` prefix if needed.
+             *
+             * @param {string} key The key for the cookie
+             * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
+             * @param {*} defaultValue A value to return if the cookie does not exist
+             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-getCrossSite
+             */
+            function getCrossSite<D>(
+                key: string,
+                prefix: string | undefined | null,
+                defaultValue: D
+            ): string | D;
+            function getCrossSite(key: string, prefix?: string): string;
+
+            /**
              * Set or delete a cookie.
              *
              * **Note:** If explicitly passing `null` or `undefined` for an options key, that will override the default. This is natural in JavaScript, but noted here because it is contrary to MediaWiki's `WebResponse#setcookie()` method in PHP.
@@ -19,15 +51,16 @@ declare global {
              *
              * @param {string} key
              * @param {string | null} value Value of cookie. If `value` is `null` then this method will instead remove a cookie by name of `key`
-             * @param {(Object | Date | number)?} options Options object, or expiry date
-             * @param {(Date | number | null)?} options.expires The expiry date of the cookie or lifetime in seconds. If `options.expires` is null or 0, then a session cookie is set
-             * @param {string?} options.prefix The prefix of the key
-             * @param {string?} options.domain The domain attribute of the cookie
-             * @param {string?} options.path The path attribute of the cookie
-             * @param {boolean?} options.secure Whether or not to include the secure attribute (Does **not** use the wgCookieSecure configuration variable)
-             * @param {string?} options.sameSite The `SameSite` flag of the cookie (case-insensitive; default is to omit the flag, which results in `Lax` on modern browsers). Set to `None` *and* set `secure` to `true` if the cookie needs to be visible on cross-domain requests
-             * @param {boolean?} options.sameSiteLegacy If true, `SameSite` = `None` cookies will also be sent as non-`SameSite` cookies with an "ss0-" prefix, to work around old browsers interpreting the standard differently
+             * @param {Object | Date | number} [options] Options object, or expiry date
+             * @param {Date | number | null} [options.expires] The expiry date of the cookie or lifetime in seconds. If `options.expires` is null or 0, then a session cookie is set
+             * @param {string} [options.prefix] The prefix of the key
+             * @param {string} [options.domain] The domain attribute of the cookie
+             * @param {string} [options.path] The path attribute of the cookie
+             * @param {boolean} [options.secure] Whether or not to include the secure attribute (Does **not** use the wgCookieSecure configuration variable)
+             * @param {string} [options.sameSite] The `SameSite` flag of the cookie (case-insensitive; default is to omit the flag, which results in `Lax` on modern browsers). Set to `None` *and* set `secure` to `true` if the cookie needs to be visible on cross-domain requests
+             * @param {boolean} [options.sameSiteLegacy] If true, `SameSite` = `None` cookies will also be sent as non-`SameSite` cookies with an "ss0-" prefix, to work around old browsers interpreting the standard differently
              * @returns {void}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-set
              */
             // see https://stackoverflow.com/a/64932909 for <SS>
             function set<SS extends string = SameSite>(
@@ -45,36 +78,6 @@ declare global {
                           sameSite: Lowercase<SS> extends SameSite ? SS : SameSite;
                       }>
             ): void;
-
-            /**
-             * Get the value of a cookie.
-             *
-             * @param {string} key The key for the cookie
-             * @param {string?} prefix The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {*} defaultValue A value to return if the cookie does not exist
-             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
-             */
-            function get<D>(
-                key: string,
-                prefix: string | undefined | null,
-                defaultValue: D
-            ): string | D;
-            function get(key: string, prefix?: string): string;
-
-            /**
-             * Get the value of a `SameSite` = `None` cookie, using the legacy `ss0-` prefix if needed.
-             *
-             * @param {string} key The key for the cookie
-             * @param {string?} prefix The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {*} defaultValue A value to return if the cookie does not exist
-             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
-             */
-            function getCrossSite<D>(
-                key: string,
-                prefix: string | undefined | null,
-                defaultValue: D
-            ): string | D;
-            function getCrossSite(key: string, prefix?: string): string;
         }
     }
 }

--- a/mw/cookie.d.ts
+++ b/mw/cookie.d.ts
@@ -13,8 +13,8 @@ declare global {
              *
              * @param {string} key The key for the cookie
              * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {*} [defaultValue] A value to return if the cookie does not exist
-             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param {Mixed} [defaultValue] A value to return if the cookie does not exist
+             * @returns {Mixed} If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-get
              */
             function get<D>(
@@ -29,8 +29,8 @@ declare global {
              *
              * @param {string} key The key for the cookie
              * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {*} defaultValue A value to return if the cookie does not exist
-             * @returns {*} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param {Mixed} [defaultValue] A value to return if the cookie does not exist
+             * @returns {Mixed} If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-getCrossSite
              */
             function getCrossSite<D>(
@@ -59,7 +59,6 @@ declare global {
              * @param {boolean} [options.secure] Whether or not to include the secure attribute (Does **not** use the wgCookieSecure configuration variable)
              * @param {string} [options.sameSite] The `SameSite` flag of the cookie (case-insensitive; default is to omit the flag, which results in `Lax` on modern browsers). Set to `None` *and* set `secure` to `true` if the cookie needs to be visible on cross-domain requests
              * @param {boolean} [options.sameSiteLegacy] If true, `SameSite` = `None` cookies will also be sent as non-`SameSite` cookies with an "ss0-" prefix, to work around old browsers interpreting the standard differently
-             * @returns {void}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-set
              */
             // see https://stackoverflow.com/a/64932909 for <SS>
@@ -70,12 +69,12 @@ declare global {
                     | Date
                     | number
                     | Partial<{
-                          expires: Date | number;
-                          prefix: string;
                           domain: string;
+                          expires: Date | number;
                           path: string;
-                          secure: boolean;
+                          prefix: string;
                           sameSite: Lowercase<SS> extends SameSite ? SS : SameSite;
+                          secure: boolean;
                       }>
             ): void;
         }

--- a/mw/cookie.d.ts
+++ b/mw/cookie.d.ts
@@ -22,7 +22,7 @@ declare global {
                 prefix: string | undefined | null,
                 defaultValue: D
             ): string | D;
-            function get(key: string, prefix?: string): string;
+            function get(key: string, prefix?: string | null): string;
 
             /**
              * Get the value of a `SameSite` = `None` cookie, using the legacy `ss0-` prefix if needed.
@@ -38,7 +38,7 @@ declare global {
                 prefix: string | undefined | null,
                 defaultValue: D
             ): string | D;
-            function getCrossSite(key: string, prefix?: string): string;
+            function getCrossSite(key: string, prefix?: string | null): string;
 
             /**
              * Set or delete a cookie.
@@ -64,16 +64,17 @@ declare global {
             // see https://stackoverflow.com/a/64932909 for <SS>
             function set<SS extends string = SameSite>(
                 key: string,
-                value: any,
+                value: string | null,
                 options?:
                     | Date
                     | number
                     | Partial<{
                           domain: string;
-                          expires: Date | number;
+                          expires: Date | number | null;
                           path: string;
                           prefix: string;
                           sameSite: Lowercase<SS> extends SameSite ? SS : SameSite;
+                          sameSiteLegacy: boolean;
                           secure: boolean;
                       }>
             ): void;

--- a/mw/cookie.d.ts
+++ b/mw/cookie.d.ts
@@ -13,8 +13,8 @@ declare global {
              *
              * @param {string} key The key for the cookie
              * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {Mixed} [defaultValue] A value to return if the cookie does not exist
-             * @returns {Mixed} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param {any} [defaultValue] A value to return if the cookie does not exist
+             * @returns {any} If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-get
              */
             function get<D>(
@@ -22,15 +22,15 @@ declare global {
                 prefix: string | undefined | null,
                 defaultValue: D
             ): string | D;
-            function get(key: string, prefix?: string | null): string;
+            function get(key: string, prefix?: string | null): string | null;
 
             /**
              * Get the value of a `SameSite` = `None` cookie, using the legacy `ss0-` prefix if needed.
              *
              * @param {string} key The key for the cookie
              * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {Mixed} [defaultValue] A value to return if the cookie does not exist
-             * @returns {Mixed} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param {any} [defaultValue] A value to return if the cookie does not exist
+             * @returns {any} If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.cookie-method-getCrossSite
              */
             function getCrossSite<D>(
@@ -38,7 +38,7 @@ declare global {
                 prefix: string | undefined | null,
                 defaultValue: D
             ): string | D;
-            function getCrossSite(key: string, prefix?: string | null): string;
+            function getCrossSite(key: string, prefix?: string | null): string | undefined;
 
             /**
              * Set or delete a cookie.

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -31,13 +31,13 @@ declare global {
              * // the A or B bucket. If the experiment were disabled, then the user would always be
              * // assigned to the control bucket.
              * {
-             *   name: 'My first experiment',
-             *   enabled: true,
-             *   buckets: {
-             *     control: 0.5
-             *     A: 0.25,
-             *     B: 0.25
-             *   }
+             *     name: 'My first experiment',
+             *     enabled: true,
+             *     buckets: {
+             *         control: 0.5
+             *         A: 0.25,
+             *         B: 0.25
+             *     }
              * }
              * ```
              *
@@ -50,7 +50,7 @@ declare global {
              *  that the user will be assigned to that bucket
              * @param {string} token A token that uniquely identifies the user for the
              *  duration of the experiment
-             * @return {string|undefined} The bucket
+             * @returns {string|undefined} The bucket
              */
             function getBucket(experiment: Experiment, token: string): string | undefined;
         }

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -18,7 +18,7 @@ declare global {
         /**
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.experiments
          */
-        namespace experiment {
+        namespace experiments {
             /**
              * Gets the bucket for the experiment given the token.
              *

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -25,6 +25,7 @@ declare global {
              * The name of the experiment and the token are hashed. The hash is converted
              * to a number which is then used to get a bucket.
              *
+             * @example
              * ```js
              * // The experiment has three buckets: control, A, and B. The user has a 50% chance of
              * // being assigned to the control bucket, and a 25% chance of being assigned to either

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -41,16 +41,17 @@ declare global {
              * }
              * ```
              *
-             * @param {Object} experiment
+             * @param {Experiment} experiment
              * @param {string} experiment.name The name of the experiment
              * @param {boolean} experiment.enabled Whether or not the experiment is
              *  enabled. If the experiment is disabled, then the user is always assigned
              *  to the control bucket
-             * @param {Object} experiment.buckets A map of bucket name to probability
+             * @param {Object.<string, number>} experiment.buckets A map of bucket name to probability
              *  that the user will be assigned to that bucket
              * @param {string} token A token that uniquely identifies the user for the
              *  duration of the experiment
              * @returns {string|undefined} The bucket
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.experiments-method-getBucket
              */
             function getBucket(experiment: Experiment, token: string): string | undefined;
         }

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -25,7 +25,7 @@ declare global {
              * The name of the experiment and the token are hashed. The hash is converted
              * to a number which is then used to get a bucket.
              *
-             * @example
+             * ```js
              * // The experiment has three buckets: control, A, and B. The user has a 50% chance of
              * // being assigned to the control bucket, and a 25% chance of being assigned to either
              * // the A or B bucket. If the experiment were disabled, then the user would always be
@@ -39,6 +39,7 @@ declare global {
              *     B: 0.25
              *   }
              * }
+             * ```
              *
              * @param {Object} experiment
              * @param {string} experiment.name The name of the experiment

--- a/mw/global.d.ts
+++ b/mw/global.d.ts
@@ -13,7 +13,7 @@ declare global {
      * @param {Function} fn
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-addOnloadHook
      */
-    function addOnloadHook(fn: (...args: any[]) => any): void;
+    function addOnloadHook(fn: () => void): void;
 
     /**
      * Import a local JS content page, for use by user scripts and site-wide scripts.
@@ -48,7 +48,7 @@ declare global {
      * @return {HTMLLinkElement} Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheet
      */
-    function importStylesheet(title: string): HTMLLinkElement | null;
+    function importStylesheet(title: string): HTMLLinkElement;
 
     /**
      * @since 1.12.2
@@ -58,7 +58,7 @@ declare global {
      * @return {HTMLLinkElement} Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheetURI
      */
-    function importStylesheetURI(url: string, media: string): HTMLLinkElement | null;
+    function importStylesheetURI(url: string, media: string): HTMLLinkElement;
 }
 
 export {};

--- a/mw/global.d.ts
+++ b/mw/global.d.ts
@@ -9,7 +9,6 @@ declare global {
      * Schedule a function to run once the page is ready (DOM loaded).
      *
      * @since 1.5.8
-     * @member global
      * @param {Function} fn
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-addOnloadHook
      */
@@ -22,19 +21,16 @@ declare global {
      * be loaded and executed once.
      *
      * @since 1.12.2
-     * @member global
      * @param {string} title
-     * @return {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @returns {HTMLScriptElement|null} Script tag, or null if it was already imported before
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importScript
      */
     function importScript(title: string): HTMLScriptElement | null;
 
     /**
      * @since 1.12.2
-     * @method importScriptURI
-     * @member global
      * @param {string} url
-     * @return {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @returns {HTMLScriptElement|null} Script tag, or null if it was already imported before
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importScriptURI
      */
     function importScriptURI(url: string): HTMLScriptElement | null;
@@ -43,19 +39,17 @@ declare global {
      * Import a local CSS content page, for use by user scripts and site-wide scripts.
      *
      * @since 1.12.2
-     * @member global
      * @param {string} title
-     * @return {HTMLLinkElement} Link tag
+     * @returns {HTMLLinkElement} Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheet
      */
     function importStylesheet(title: string): HTMLLinkElement;
 
     /**
      * @since 1.12.2
-     * @member global
      * @param {string} url
      * @param {string} media
-     * @return {HTMLLinkElement} Link tag
+     * @returns {HTMLLinkElement} Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/global-method-importStylesheetURI
      */
     function importStylesheetURI(url: string, media: string): HTMLLinkElement;

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -17,7 +17,7 @@ import { User } from "./user";
  *
  * Example usage:
  *
- * ```
+ * ```js
  * mw.hook( 'wikipage.content' ).add( fn ).remove( fn );
  * mw.hook( 'wikipage.content' ).fire( $content );
  * ```
@@ -33,7 +33,7 @@ import { User } from "./user";
  * You can pass around the `add` and/or `fire` method to another piece of code
  * without it having to know the event name (or `mw.hook` for that matter).
  *
- * ```
+ * ```js
  * var h = mw.hook( 'bar.ready' );
  * new mw.Foo( .. ).fetch( { callback: h.fire } );
  * ```
@@ -49,6 +49,7 @@ interface Hook<T extends any[] = any[]> {
      *
      * @param {...Function} handler Function to bind.
      * @chainable
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-add
      */
     add(...handler: Array<(...data: T) => any>): this;
 
@@ -57,6 +58,7 @@ interface Hook<T extends any[] = any[]> {
      *
      * @param {*} data
      * @chainable
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-fire
      */
     fire(...data: T): this;
 
@@ -65,6 +67,7 @@ interface Hook<T extends any[] = any[]> {
      *
      * @param {...Function} handler Function to unbind.
      * @chainable
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-remove
      */
     remove(...handler: Array<(...data: T) => any>): this;
 }
@@ -140,7 +143,7 @@ declare global {
          *
          * Code that fires the postEdit hook should first set `wgRevisionId` and `wgCurRevisionId` to the revision associated with the edit that triggered the postEdit hook, then fire the postEdit hook, e.g.:
          *
-         * ```
+         * ```js
          * mw.config.set( {
          *    wgCurRevisionId: data.newrevid,
          *    wgRevisionId: data.newrevid
@@ -300,7 +303,8 @@ declare global {
          * Create an instance of mw.hook, fired when the page watch status has changed.
          *
          * Example usage:
-         * ```
+         *
+         * ```js
          * mw.hook( 'wikipage.watchlistChange' ).add( ( isWatched, expiry, expirySelected ) => {
          *     // Do things
          * } );
@@ -315,9 +319,9 @@ declare global {
         /**
          * Create an instance of mw.hook.
          *
-         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-hook
          */
-        function hook<T extends any[] = any[]>(name: string): Hook<T>;
+        function hook<T extends any[] = any[]>(event: string): Hook<T>;
     }
 }
 

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -48,7 +48,6 @@ interface Hook<T extends any[] = any[]> {
      * Register a hook handler.
      *
      * @param {...Function} handler Function to bind.
-     * @chainable
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-add
      */
     add(...handler: Array<(...data: T) => any>): this;
@@ -56,8 +55,7 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Call hook handlers with data.
      *
-     * @param {*} data
-     * @chainable
+     * @param {Mixed} data
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-fire
      */
     fire(...data: T): this;
@@ -66,7 +64,6 @@ interface Hook<T extends any[] = any[]> {
      * Unregister a hook handler.
      *
      * @param {...Function} handler Function to unbind.
-     * @chainable
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-remove
      */
     remove(...handler: Array<(...data: T) => any>): this;

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -55,7 +55,7 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Call hook handlers with data.
      *
-     * @param {Mixed} data
+     * @param {any} data
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.hook-method-fire
      */
     fire(...data: T): this;

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -20,7 +20,7 @@ declare global {
              * Create an HTML element string, with safe escaping.
              *
              * @param {string} name The tag name.
-             * @param {Object} [attrs] An object with members mapping element names to values
+             * @param {Object.<string, string|number|boolean>} [attrs] An object with members mapping element names to values
              * @param {string|Raw|null} [contents=null] The contents of the element.
              *
              *  - string: Text to be escaped.

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -31,7 +31,7 @@ declare global {
              */
             function element(
                 name: string,
-                attrs?: Record<string, string>,
+                attrs?: Record<string, string | number | boolean>,
                 contents?: string | Raw | null
             ): string;
 

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -1,6 +1,18 @@
 declare global {
     namespace mw {
         /**
+         * HTML construction helper functions
+         *
+         * ```js
+         * var Html, output;
+         *
+         * Html = mw.html;
+         * output = Html.element( 'div', {}, new Html.Raw(
+         *     Html.element( 'img', { src: '<' } )
+         * ) );
+         * mw.log( output ); // <div><img src="&lt;"/></div>
+         * ```
+         *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html
          */
         namespace html {
@@ -28,8 +40,10 @@ declare global {
              *
              * Converts special characters to HTML entities.
              *
-             *     mw.html.escape( '< > \' & "' );
-             *     // Returns &lt; &gt; &#039; &amp; &quot;
+             * ```js
+             * mw.html.escape( '< > \' & "' );
+             * // Returns &lt; &gt; &#039; &amp; &quot;
+             * ```
              *
              * @param {string} s The string to escape
              * @return {string} HTML
@@ -38,10 +52,8 @@ declare global {
             function escape(s: string): string;
 
             /**
-             * Wrapper object for raw HTML passed to mw.html.element().
+             * Wrapper object for raw HTML passed to {@link mw.html.element()}.
              *
-             * @class mw.html.Raw
-             * @constructor
              * @param {string} value
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html.Raw-method-constructor
              */

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -3,6 +3,7 @@ declare global {
         /**
          * HTML construction helper functions
          *
+         * @example
          * ```js
          * var Html, output;
          *

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -26,7 +26,7 @@ declare global {
              *  - string: Text to be escaped.
              *  - null: The element is treated as void with short closing form, e.g. `<br/>`.
              *  - this.Raw: The raw value is directly included.
-             * @return {string} HTML
+             * @returns {string} HTML
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html-method-element
              */
             function element(
@@ -46,7 +46,7 @@ declare global {
              * ```
              *
              * @param {string} s The string to escape
-             * @return {string} HTML
+             * @returns {string} HTML
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.html-method-escape
              */
             function escape(s: string): string;

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -61,6 +61,8 @@ declare global {
          * Empty object for third-party libraries, for cases where you don't
          * want to add a new global, or the global is bad and needs containment
          * or wrapping.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-libs
          */
         const libs: Record<string, any>;
 
@@ -80,11 +82,11 @@ declare global {
          *
          * @since 1.25
          * @param {string} formatString Format string
-         * @param {...Mixed} parameters Values for $N replacements
+         * @param {...string} parameters Values for $N replacements
          * @returns {string} Formatted string
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-format
          */
-        function format(formatString: string, ...parameters: unknown[]): string;
+        function format(formatString: string, ...parameters: string[]): string;
 
         /**
          * Get the current time, measured in milliseconds since January 1, 1970 (UTC).
@@ -126,8 +128,12 @@ declare global {
          * @param {number} [options.timeout] If set, the callback will be scheduled for
          *  immediate execution after this amount of time (in milliseconds) if it didn't run
          *  by that time.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-requestIdleCallback
          */
-        function requestIdleCallback(callback: (...args: any[]) => any): void;
+        function requestIdleCallback(
+            callback: (...args: any[]) => any,
+            options?: { timeout?: number }
+        ): void;
 
         /**
          * Track an analytic event.
@@ -143,7 +149,7 @@ declare global {
          * was subscribed.
          *
          * @param {string} topic Topic name
-         * @param {Object|number|string} [data] Data describing the event.
+         * @param {AnalyticEventData} [data] Data describing the event.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-track
          */
         function track(topic: string, data?: AnalyticEventData): void;
@@ -153,7 +159,7 @@ declare global {
          *
          * @private
          * @param {string} topic Topic name
-         * @param {Object} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
+         * @param {ErrorAnalyticEventData} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-trackError
          */
         function trackError(topic: string, data: ErrorAnalyticEventData): void;
@@ -179,16 +185,16 @@ declare global {
          * ```
          *
          * @param {string} topic Handle events whose name starts with this string prefix
-         * @param {Function} callback Handler to call for each matching tracked event
-         * @param {string} callback.topic
-         * @param {Object} [callback.data]
+         * @param {function(string, AnalyticEventData): void} callback Handler to call for each matching tracked event
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-trackSubscribe
          */
         function trackSubscribe(topic: string, callback: AnalyticEventCallback): void;
 
         /**
          * Stop handling events for a particular handler
          *
-         * @param {Function} callback
+         * @param {function(string, AnalyticEventData): void} callback
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-trackUnsubscribe
          */
         function trackUnsubscribe(callback: AnalyticEventCallback): void;
 

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -21,6 +21,24 @@ import "./Uri";
 import "./user";
 import "./util";
 
+type ObjectAnalyticEventData = Record<string, any>;
+type AnalyticEventData = ObjectAnalyticEventData | number | string | undefined;
+
+interface ErrorAnalyticEventData extends ObjectAnalyticEventData {
+    exception?: any;
+    module?: string;
+    source: string;
+}
+
+interface AnalyticEvent {
+    topic: string;
+    data: AnalyticEventData;
+}
+
+interface AnalyticEventCallback {
+    (topic: string, data: AnalyticEventData): void;
+}
+
 declare global {
     /**
      * Base library for MediaWiki.
@@ -128,7 +146,7 @@ declare global {
          * @param {Object|number|string} [data] Data describing the event.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-track
          */
-        function track(topic: string, data?: object | number | string): void;
+        function track(topic: string, data?: AnalyticEventData): void;
 
         /**
          * Track an early error event via mw.track and send it to the window console.
@@ -138,7 +156,7 @@ declare global {
          * @param {Object} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-trackError
          */
-        function trackError(topic: string, data: object): void;
+        function trackError(topic: string, data: ErrorAnalyticEventData): void;
 
         /**
          * Register a handler for subset of analytic events, specified by topic.
@@ -165,17 +183,14 @@ declare global {
          * @param {string} callback.topic
          * @param {Object} [callback.data]
          */
-        function trackSubscribe(
-            topic: string,
-            callback: (topic: string, data: object) => void
-        ): void;
+        function trackSubscribe(topic: string, callback: AnalyticEventCallback): void;
 
         /**
          * Stop handling events for a particular handler
          *
          * @param {Function} callback
          */
-        function trackUnsubscribe(callback: (topic: string, data: object) => void): void;
+        function trackUnsubscribe(callback: AnalyticEventCallback): void;
 
         /**
          * List of all analytic events emitted so far.
@@ -185,10 +200,7 @@ declare global {
          * @private
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-trackQueue
          */
-        const trackQueue: Array<{
-            topic: string;
-            data: Record<string, any> | number | string | undefined;
-        }>;
+        const trackQueue: AnalyticEvent[];
     }
 }
 

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -43,12 +43,16 @@ declare global {
          * Empty object for third-party libraries, for cases where you don't
          * want to add a new global, or the global is bad and needs containment
          * or wrapping.
-         *
-         * @property {Object}
          */
         const libs: any;
 
-        // types for mw.widgets are out of scope!
+        /**
+         * OOUI widgets specific to MediaWiki
+         *
+         * types for mw.widgets are out of scope!
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.base.html#mw-property-libs
+         */
         const widgets: any;
 
         /**
@@ -59,7 +63,7 @@ declare global {
          * @since 1.25
          * @param {string} formatString Format string
          * @param {...Mixed} parameters Values for $N replacements
-         * @return {string} Formatted string
+         * @returns {string} Formatted string
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-format
          */
         function format(formatString: string, ...parameters: unknown[]): string;
@@ -71,7 +75,8 @@ declare global {
          * floating-point values with microsecond precision that are guaranteed to be monotonic.
          * On all other browsers, it will fall back to using `Date`.
          *
-         * @return {number} Current time
+         * @returns {number} Current time
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-now
          */
         function now(): number;
 
@@ -98,7 +103,6 @@ declare global {
          * - <https://developers.google.com/web/updates/2015/08/using-requestidlecallback>
          * [RAIL]: https://developers.google.com/web/fundamentals/performance/rail
          *
-         * @member mw
          * @param {Function} callback
          * @param {Object} [options]
          * @param {number} [options.timeout] If set, the callback will be scheduled for
@@ -122,6 +126,7 @@ declare global {
          *
          * @param {string} topic Topic name
          * @param {Object|number|string} [data] Data describing the event.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-track
          */
         function track(topic: string, data?: object | number | string): void;
 
@@ -131,6 +136,7 @@ declare global {
          * @private
          * @param {string} topic Topic name
          * @param {Object} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-trackError
          */
         function trackError(topic: string, data: object): void;
 

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -44,7 +44,7 @@ declare global {
          * want to add a new global, or the global is bad and needs containment
          * or wrapping.
          */
-        const libs: any;
+        const libs: Record<string, any>;
 
         /**
          * OOUI widgets specific to MediaWiki
@@ -176,6 +176,19 @@ declare global {
          * @param {Function} callback
          */
         function trackUnsubscribe(callback: (topic: string, data: object) => void): void;
+
+        /**
+         * List of all analytic events emitted so far.
+         *
+         * Exposed only for use by mediawiki.base.
+         *
+         * @private
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-trackQueue
+         */
+        const trackQueue: Array<{
+            topic: string;
+            data: Record<string, any> | number | string | undefined;
+        }>;
     }
 }
 

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -29,10 +29,13 @@ declare global {
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw
      */
     namespace mw {
+        // types for mw.widgets are out of scope!
+        const widgets: any;
+
         /**
          * Format a string. Replace $1, $2 ... $N with positional arguments.
          *
-         * Used by Message#parser().
+         * Used by {@link Message.parser()}.
          *
          * @since 1.25
          * @param {string} formatString Format string
@@ -94,9 +97,9 @@ declare global {
          * arranged from most general to most specific. Each path component should have a clear and
          * well-defined purpose.
          *
-         * Data handlers are registered via `mw.trackSubscribe`, and receive the full set of
-         * events that match their subscription, including those that fired before the handler was
-         * bound.
+         * Data handlers are registered via {@link mw.trackSubscribe}, and receive the full set of
+         * events that match their subscription, including buffered events that fired before the handler
+         * was subscribed.
          *
          * @param {string} topic Topic name
          * @param {Object|number|string} [data] Data describing the event.
@@ -108,17 +111,29 @@ declare global {
          *
          * @private
          * @param {string} topic Topic name
-         * @param {Object} data Data describing the event, encoded as an object; see mw#logError
+         * @param {Object} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
          */
         function trackError(topic: string, data: object): void;
 
         /**
          * Register a handler for subset of analytic events, specified by topic.
          *
-         * Handlers will be called once for each tracked event, including any events that fired before the
-         * handler was registered; 'this' is set to a plain object with a topic' property naming the event, and a
-         * 'data' property which is an object of event-specific data. The event topic and event data are
-         * also passed to the callback as the first and second arguments, respectively.
+         * Handlers will be called once for each tracked event, including for any buffered events that
+         * fired before the handler was subscribed. The callback is passed a `topic` string, and optional
+         * `data` event object. The `this` value for the callback is a plain object with `topic` and
+         * `data` properties set to those same values.
+         *
+         * Example to monitor all topics for debugging:
+         *
+         * ```js
+         * mw.trackSubscribe( '', console.log );
+         * ```
+         *
+         * Example to subscribe to any of `foo.*`, e.g. both `foo.bar` and `foo.quux`:
+         *
+         * ```js
+         * mw.trackSubscribe( 'foo.', console.log );
+         * ```
          *
          * @param {string} topic Handle events whose name starts with this string prefix
          * @param {Function} callback Handler to call for each matching tracked event
@@ -136,9 +151,6 @@ declare global {
          * @param {Function} callback
          */
         function trackUnsubscribe(callback: (topic: string, data: object) => any): void;
-
-        // types for mw.widgets are out of scope!
-        const widgets: any;
     }
 }
 

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -26,9 +26,28 @@ declare global {
      * Base library for MediaWiki.
      *
      * Exposed globally as `mw`, with `mediaWiki` as alias.
+     *
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw
+     */
+    const mediaWiki: typeof mw;
+
+    /**
+     * Base library for MediaWiki.
+     *
+     * Exposed globally as `mw`, with `mediaWiki` as alias.
+     *
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw
      */
     namespace mw {
+        /**
+         * Empty object for third-party libraries, for cases where you don't
+         * want to add a new global, or the global is bad and needs containment
+         * or wrapping.
+         *
+         * @property {Object}
+         */
+        const libs: any;
+
         // types for mw.widgets are out of scope!
         const widgets: any;
 
@@ -142,7 +161,7 @@ declare global {
          */
         function trackSubscribe(
             topic: string,
-            callback: (topic: string, data: object) => any
+            callback: (topic: string, data: object) => void
         ): void;
 
         /**
@@ -150,7 +169,7 @@ declare global {
          *
          * @param {Function} callback
          */
-        function trackUnsubscribe(callback: (topic: string, data: object) => any): void;
+        function trackUnsubscribe(callback: (topic: string, data: object) => void): void;
     }
 }
 

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -46,7 +46,6 @@ declare global {
              * - `bcp47Map`
              * - `languageNames`
              *
-             * @property {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-data
              */
             const data: Record<string, Map>;
@@ -54,7 +53,6 @@ declare global {
             /**
              * Information about month names in current UI language.
              *
-             * @property {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
              */
             const months: {
@@ -68,11 +66,7 @@ declare global {
                  * Object containing zero-indexed arrays of message keys for appropriate messages
                  * which can be passed to {@link mw.msg}.
                  */
-                keys: {
-                    abbrev: string[];
-                    genitive: string[];
-                    names: string[];
-                };
+                keys: Record<"abbrev" | "genitive" | "names", string[]>;
 
                 /**
                  * Array of month names in genitive case, zero-indexed.
@@ -124,8 +118,8 @@ declare global {
              * Plural form transformations, needed for some languages.
              *
              * @param {number} count Non-localized quantifier
-             * @param {Array} forms List of plural forms
-             * @param {Object} [explicitPluralForms] List of explicit plural forms
+             * @param {string[]} forms List of plural forms
+             * @param {Object.<number, string>} [explicitPluralForms] List of explicit plural forms
              * @returns {string} Correct form for quantifier in this language
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertPlural
              */
@@ -138,8 +132,8 @@ declare global {
             /**
              * Helper function to flip transformation tables.
              *
-             * @param {...Object} tables Transformation tables
-             * @returns {Object}
+             * @param {...Object.<number|string, string>} tables Transformation tables
+             * @returns {Object.<string, number|string>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
              */
             function flipTransform<T extends Record<PropertyKey, PropertyKey>>(
@@ -155,7 +149,7 @@ declare global {
              * These details may be overridden per language.
              *
              * @param {string} gender 'male', 'female', or anything else for neutral.
-             * @param {Array} forms List of gender forms
+             * @param {string[]} forms List of gender forms
              * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-gender
              */
@@ -178,7 +172,7 @@ declare global {
             /**
              * Get the digit transform table for current UI language.
              *
-             * @returns {Object|Array}
+             * @returns {Object.<number|string, string>|string[]}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getDigitTransformTable
              */
             function getDigitTransformTable(): string[] | Record<number | string, string>;
@@ -202,7 +196,7 @@ declare global {
             /**
              * Get the separator transform table for current UI language.
              *
-             * @returns {Object|Array}
+             * @returns {Object.<number|string, string>|string[]}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getSeparatorTransformTable
              */
             function getSeparatorTransformTable(): string[] | Record<number | string, string>;
@@ -224,7 +218,7 @@ declare global {
              * Creates the data mw.Map if there isn't one for the specified language already.
              *
              * @param {string} langCode
-             * @param {string|Object} dataKey Key or object of key/values
+             * @param {string|Object.<string, Mixed>} dataKey Key or object of key/values
              * @param {Mixed} [value] Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
              */
@@ -277,9 +271,9 @@ declare global {
              * Pads an array to a specific length by copying the last one element.
              *
              * @private
-             * @param {Array} forms Number of forms given to convertPlural
+             * @param {string[]} forms Number of forms given to convertPlural
              * @param {number} count Number of forms required
-             * @returns {Array} Padded array of forms
+             * @returns {string[]} Padded array of forms
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-preConvertPlural
              */
             function preConvertPlural(forms: string[], count: number): string[];

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -1,5 +1,3 @@
-type FlipObject<T extends Record<PropertyKey, PropertyKey>> = { [K in keyof T as T[K]]: K };
-
 declare global {
     namespace mw {
         /**
@@ -112,6 +110,8 @@ declare global {
              * @returns {number|string} Formatted number
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertNumber
              */
+            function convertNumber(num: number, integer: true): number;
+            function convertNumber(num: number, integer?: false): string;
             function convertNumber(num: number, integer?: boolean): number | string;
 
             /**
@@ -142,7 +142,8 @@ declare global {
              * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-gender
              */
-            function gender<T extends string>(gender: string, forms: [T?, T?, T?]): T;
+            function gender<T extends string>(gender: string, forms: [T, T?, T?]): T;
+            function gender<T extends string = never>(gender: string, forms: [T?, T?, T?]): T | "";
 
             /**
              * Convenience method for retrieving language data.
@@ -152,7 +153,7 @@ declare global {
              *
              * @param {string} langCode
              * @param {string} dataKey
-             * @returns {Mixed} Value stored in the mw.Map (or `undefined` if there is no map for the
+             * @returns {any} Value stored in the mw.Map (or `undefined` if there is no map for the
              *  specified langCode)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getData
              */
@@ -208,7 +209,7 @@ declare global {
              *
              * @param {string} langCode
              * @param {string|Object.<string, any>} dataKey Key or object of key/values
-             * @param {Mixed} [value] Value for dataKey, omit if dataKey is an object
+             * @param {any} [value] Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
              */
             function setData(langCode: string, dataKey: string, value: any): void;
@@ -223,7 +224,10 @@ declare global {
              * @returns {string[]} Padded array of forms
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-preConvertPlural
              */
-            function preConvertPlural(forms: string[], count: number): string[];
+            function preConvertPlural<T extends string[]>(
+                forms: T,
+                count: number
+            ): [...T, ...string[]];
         }
     }
 }

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -4,12 +4,10 @@ declare global {
          * Base language object with methods related to language support, attempting to mirror some of the
          * functionality of the Language class in MediaWiki:
          *
-         *   - storing and retrieving language data
-         *   - transforming message syntax (`{{PLURAL:}}`, `{{GRAMMAR:}}`, `{{GENDER:}}`)
-         *   - formatting numbers
+         * - storing and retrieving language data
+         * - transforming message syntax (`{{PLURAL:}}`, `{{GRAMMAR:}}`, `{{GENDER:}}`)
+         * - formatting numbers
          *
-         * @class
-         * @singleton
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language
          */
         namespace language {
@@ -20,27 +18,31 @@ declare global {
              *
              * To set data:
              *
-             *     // Override, extend or create the language data object of 'nl'
-             *     mw.language.setData( 'nl', 'myKey', 'My value' );
+             * ```js
+             * // Override, extend or create the language data object of 'nl'
+             * mw.language.setData( 'nl', 'myKey', 'My value' );
              *
-             *     // Set multiple key/values pairs at once
-             *     mw.language.setData( 'nl', { foo: 'X', bar: 'Y' } );
+             * // Set multiple key/values pairs at once
+             * mw.language.setData( 'nl', { foo: 'X', bar: 'Y' } );
+             * ```
              *
              * To get GrammarForms data for language 'nl':
              *
-             *     var grammarForms = mw.language.getData( 'nl', 'grammarForms' );
+             * ```js
+             * var grammarForms = mw.language.getData( 'nl', 'grammarForms' );
+             * ```
              *
              * Possible data keys:
              *
-             *  - `digitTransformTable`
-             *  - `separatorTransformTable`
-             *  - `minimumGroupingDigits`
-             *  - `grammarForms`
-             *  - `pluralRules`
-             *  - `digitGroupingPattern`
-             *  - `fallbackLanguages`
-             *  - `bcp47Map`
-             *  - `languageNames`
+             * - `digitTransformTable`
+             * - `separatorTransformTable`
+             * - `minimumGroupingDigits`
+             * - `grammarForms`
+             * - `pluralRules`
+             * - `digitGroupingPattern`
+             * - `fallbackLanguages`
+             * - `bcp47Map`
+             * - `languageNames`
              *
              * @property {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-data
@@ -90,7 +92,7 @@ declare global {
             function convertGrammar(word: string, form: string): string;
 
             /**
-             * Converts a number using #getDigitTransformTable.
+             * Converts a number using {@link getDigitTransformTable}.
              *
              * @param {number} num Value to be converted
              * @param {boolean} [integer=false] Whether to convert the return value to an integer
@@ -117,13 +119,11 @@ declare global {
             /**
              * Helper function to flip transformation tables.
              *
-             * @param {...Object} Transformation tables
+             * @param {...Object} tables Transformation tables
              * @return {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
              */
-            function flipTransform(
-                ...Transformation: Array<Record<string, any>>
-            ): Record<string, any>;
+            function flipTransform(...tables: Array<Record<string, any>>): Record<string, any>;
 
             /**
              * Provides an alternative text depending on specified gender.
@@ -238,7 +238,9 @@ declare global {
              *
              * Example: Fill the string to length 10 with '+' characters on the right.
              *
-             *     pad( 'blah', 10, '+', true ); // => 'blah++++++'
+             * ```js
+             * pad( 'blah', 10, '+', true ); // => 'blah++++++'
+             * ```
              *
              * @private
              * @param {string} text The string to pad

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -218,7 +218,7 @@ declare global {
              * Creates the data mw.Map if there isn't one for the specified language already.
              *
              * @param {string} langCode
-             * @param {string|Object.<string, Mixed>} dataKey Key or object of key/values
+             * @param {string|Object.<string, any>} dataKey Key or object of key/values
              * @param {Mixed} [value] Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
              */

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -55,7 +55,6 @@ declare global {
              * Information about month names in current UI language.
              *
              * @property {Object}
-             * @member mw.language
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
              */
             const months: {
@@ -92,7 +91,7 @@ declare global {
              * See LanguageCode::bcp47 for the PHP implementation.
              *
              * @param {string} languageTag Well-formed language tag
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-bcp47
              */
             function bcp47(languageTag: string): string;
@@ -106,7 +105,7 @@ declare global {
              *
              * @param {string} word
              * @param {string} form
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertGrammar
              */
             function convertGrammar(word: string, form: string): string;
@@ -116,7 +115,7 @@ declare global {
              *
              * @param {number} num Value to be converted
              * @param {boolean} [integer=false] Whether to convert the return value to an integer
-             * @return {number|string} Formatted number
+             * @returns {number|string} Formatted number
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertNumber
              */
             function convertNumber(num: number, integer?: boolean): number | string;
@@ -127,7 +126,7 @@ declare global {
              * @param {number} count Non-localized quantifier
              * @param {Array} forms List of plural forms
              * @param {Object} [explicitPluralForms] List of explicit plural forms
-             * @return {string} Correct form for quantifier in this language
+             * @returns {string} Correct form for quantifier in this language
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-convertPlural
              */
             function convertPlural(
@@ -140,7 +139,7 @@ declare global {
              * Helper function to flip transformation tables.
              *
              * @param {...Object} tables Transformation tables
-             * @return {Object}
+             * @returns {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
              */
             function flipTransform<T extends Record<PropertyKey, PropertyKey>>(
@@ -157,7 +156,7 @@ declare global {
              *
              * @param {string} gender 'male', 'female', or anything else for neutral.
              * @param {Array} forms List of gender forms
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-gender
              */
             function gender<T extends string>(gender: string, forms: [T?, T?, T?]): T;
@@ -170,7 +169,7 @@ declare global {
              *
              * @param {string} langCode
              * @param {string} dataKey
-             * @return {any} Value stored in the mw.Map (or `undefined` if there is no map for the
+             * @returns {Mixed} Value stored in the mw.Map (or `undefined` if there is no map for the
              *  specified langCode)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getData
              */
@@ -179,7 +178,7 @@ declare global {
             /**
              * Get the digit transform table for current UI language.
              *
-             * @return {Object|Array}
+             * @returns {Object|Array}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getDigitTransformTable
              */
             function getDigitTransformTable(): string[] | Record<number | string, string>;
@@ -187,7 +186,7 @@ declare global {
             /**
              * Get the language fallback chain for current UI language, including the language itself.
              *
-             * @return {string[]} List of language keys, e.g. `['pfl', de', 'en']`
+             * @returns {string[]} List of language keys, e.g. `['pfl', de', 'en']`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getFallbackLanguageChain
              */
             function getFallbackLanguageChain(): string[];
@@ -195,7 +194,7 @@ declare global {
             /**
              * Get the language fallback chain for current UI language (not including the language itself).
              *
-             * @return {string[]} List of language keys, e.g. `['de', 'en']`
+             * @returns {string[]} List of language keys, e.g. `['de', 'en']`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getFallbackLanguages
              */
             function getFallbackLanguages(): string[];
@@ -203,7 +202,7 @@ declare global {
             /**
              * Get the separator transform table for current UI language.
              *
-             * @return {Object|Array}
+             * @returns {Object|Array}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getSeparatorTransformTable
              */
             function getSeparatorTransformTable(): string[] | Record<number | string, string>;
@@ -214,7 +213,7 @@ declare global {
              * See Language::listToText in languages/Language.php
              *
              * @param {string[]} list
-             * @return {string}
+             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-listToText
              */
             function listToText(list: string[]): string;
@@ -226,7 +225,7 @@ declare global {
              *
              * @param {string} langCode
              * @param {string|Object} dataKey Key or object of key/values
-             * @param {any} [value] Value for dataKey, omit if dataKey is an object
+             * @param {Mixed} [value] Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
              */
             function setData(langCode: string, dataKey: string, value: any): void;
@@ -246,7 +245,7 @@ declare global {
              * @param {string} options.decimal The decimal separator. Defaults to: `'.'`.
              * @param {string} options.group The group separator. Defaults to: `','`.
              * @param {number|null} options.minimumGroupingDigits
-             * @return {string}
+             * @returns {string}
              */
             function commafyNumber(
                 value: number,
@@ -270,7 +269,7 @@ declare global {
              * @param {number} size The length to pad to
              * @param {string} [ch='0'] Character to pad with
              * @param {boolean} [end=false] Adds padding at the end if true, otherwise pads at start
-             * @return {string}
+             * @returns {string}
              */
             function pad(text: string, size: number, ch?: string, end?: boolean): string;
 
@@ -280,7 +279,7 @@ declare global {
              * @private
              * @param {Array} forms Number of forms given to convertPlural
              * @param {number} count Number of forms required
-             * @return {Array} Padded array of forms
+             * @returns {Array} Padded array of forms
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-preConvertPlural
              */
             function preConvertPlural(forms: string[], count: number): string[];
@@ -291,7 +290,7 @@ declare global {
              * @private
              * @param {string} str The string to replicate
              * @param {number} num Number of times to replicate the string
-             * @return {string}
+             * @returns {string}
              */
             function replicate(str: string, num: number): string;
         }

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -130,17 +130,6 @@ declare global {
             ): string;
 
             /**
-             * Helper function to flip transformation tables.
-             *
-             * @param {...Object.<number|string, string>} tables Transformation tables
-             * @returns {Object.<string, number|string>}
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
-             */
-            function flipTransform<T extends Record<PropertyKey, PropertyKey>>(
-                ...tables: T[]
-            ): FlipObject<T>;
-
-            /**
              * Provides an alternative text depending on specified gender.
              *
              * Usage in message text: `{{gender:[gender|user object]|masculine|feminine|neutral}}`.
@@ -226,48 +215,6 @@ declare global {
             function setData(langCode: string, dataKey: Record<string, any>): void;
 
             /**
-             * Apply numeric pattern to absolute value using options. Gives no
-             * consideration to local customs.
-             *
-             * Adapted from dojo/number library with thanks
-             * <http://dojotoolkit.org/reference-guide/1.8/dojo/number.html>
-             *
-             * @private
-             * @param {number} value the number to be formatted, ignores sign
-             * @param {string} pattern the number portion of a pattern (e.g. `#,##0.00`)
-             * @param {Object} [options] If provided, all option keys must be present:
-             * @param {string} options.decimal The decimal separator. Defaults to: `'.'`.
-             * @param {string} options.group The group separator. Defaults to: `','`.
-             * @param {number|null} options.minimumGroupingDigits
-             * @returns {string}
-             */
-            function commafyNumber(
-                value: number,
-                pattern: string,
-                options?: { decimal: string; group: string; minimumGroupingDigits: number | null }
-            ): string;
-
-            /**
-             * Pad a string to guarantee that it is at least `size` length by
-             * filling with the character `ch` at either the start or end of the
-             * string. Pads at the start, by default.
-             *
-             * Example: Fill the string to length 10 with '+' characters on the right.
-             *
-             * ```js
-             * pad( 'blah', 10, '+', true ); // => 'blah++++++'
-             * ```
-             *
-             * @private
-             * @param {string} text The string to pad
-             * @param {number} size The length to pad to
-             * @param {string} [ch='0'] Character to pad with
-             * @param {boolean} [end=false] Adds padding at the end if true, otherwise pads at start
-             * @returns {string}
-             */
-            function pad(text: string, size: number, ch?: string, end?: boolean): string;
-
-            /**
              * Pads an array to a specific length by copying the last one element.
              *
              * @private
@@ -277,16 +224,6 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-preConvertPlural
              */
             function preConvertPlural(forms: string[], count: number): string[];
-
-            /**
-             * Replicate a string 'n' times.
-             *
-             * @private
-             * @param {string} str The string to replicate
-             * @param {number} num Number of times to replicate the string
-             * @returns {string}
-             */
-            function replicate(str: string, num: number): string;
         }
     }
 }

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -49,36 +49,6 @@ declare global {
             const data: Record<string, Map>;
 
             /**
-             * Information about month names in current UI language.
-             *
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
-             */
-            const months: {
-                /**
-                 * Array of month names (in nominative case in languages which have the distinction),
-                 * zero-indexed.
-                 */
-                abbrev: string[];
-
-                /**
-                 * Object containing zero-indexed arrays of message keys for appropriate messages
-                 * which can be passed to {@link mw.msg}.
-                 */
-                keys: Record<"abbrev" | "genitive" | "names", string[]>;
-
-                /**
-                 * Array of month names in genitive case, zero-indexed.
-                 */
-                genitive: string[];
-
-                /**
-                 * Array of month names (in nominative case in languages which have the distinction),
-                 * zero-indexed.
-                 */
-                names: string[];
-            };
-
-            /**
              * Formats language tags according the BCP 47 standard.
              * See LanguageCode::bcp47 for the PHP implementation.
              *
@@ -228,6 +198,36 @@ declare global {
                 forms: T,
                 count: number
             ): [...T, ...string[]];
+
+            /**
+             * Information about month names in current UI language.
+             *
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
+             */
+            namespace months {
+                /**
+                 * Array of month names (in nominative case in languages which have the distinction),
+                 * zero-indexed.
+                 */
+                const abbrev: string[];
+
+                /**
+                 * Object containing zero-indexed arrays of message keys for appropriate messages
+                 * which can be passed to {@link mw.msg}.
+                 */
+                const keys: Record<"abbrev" | "genitive" | "names", string[]>;
+
+                /**
+                 * Array of month names in genitive case, zero-indexed.
+                 */
+                const genitive: string[];
+
+                /**
+                 * Array of month names (in nominative case in languages which have the distinction),
+                 * zero-indexed.
+                 */
+                const names: string[];
+            }
         }
     }
 }

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -1,3 +1,5 @@
+type FlipObject<T extends Record<PropertyKey, PropertyKey>> = { [K in keyof T as T[K]]: K };
+
 declare global {
     namespace mw {
         /**
@@ -47,25 +49,43 @@ declare global {
              * @property {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-data
              */
-            const data: Record<string, any>;
+            const data: Record<string, Map>;
 
             /**
              * Information about month names in current UI language.
-             *
-             * Object keys:
-             *
-             * - `names`: array of month names (in nominative case in languages which have the distinction),
-             *   zero-indexed
-             * - `genitive`: array of month names in genitive case, zero-indexed
-             * - `abbrev`: array of three-letter-long abbreviated month names, zero-indexed
-             * - `keys`: object with three keys like the above, containing zero-indexed arrays of message keys
-             *   for appropriate messages which can be passed to mw.msg.
              *
              * @property {Object}
              * @member mw.language
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-property-months
              */
-            const months: Record<string, any>;
+            const months: {
+                /**
+                 * Array of month names (in nominative case in languages which have the distinction),
+                 * zero-indexed.
+                 */
+                abbrev: string[];
+
+                /**
+                 * Object containing zero-indexed arrays of message keys for appropriate messages
+                 * which can be passed to {@link mw.msg}.
+                 */
+                keys: {
+                    abbrev: string[];
+                    genitive: string[];
+                    names: string[];
+                };
+
+                /**
+                 * Array of month names in genitive case, zero-indexed.
+                 */
+                genitive: string[];
+
+                /**
+                 * Array of month names (in nominative case in languages which have the distinction),
+                 * zero-indexed.
+                 */
+                names: string[];
+            };
 
             /**
              * Formats language tags according the BCP 47 standard.
@@ -113,7 +133,7 @@ declare global {
             function convertPlural(
                 count: number,
                 forms: string[],
-                explicitPluralForms?: Record<string, any>
+                explicitPluralForms?: Record<number, string>
             ): string;
 
             /**
@@ -123,7 +143,9 @@ declare global {
              * @return {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-flipTransform
              */
-            function flipTransform(...tables: Array<Record<string, any>>): Record<string, any>;
+            function flipTransform<T extends Record<PropertyKey, PropertyKey>>(
+                ...tables: T[]
+            ): FlipObject<T>;
 
             /**
              * Provides an alternative text depending on specified gender.
@@ -138,7 +160,7 @@ declare global {
              * @return {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-gender
              */
-            function gender(gender: string, forms: string[]): string;
+            function gender<T extends string>(gender: string, forms: [T?, T?, T?]): T;
 
             /**
              * Convenience method for retrieving language data.
@@ -160,7 +182,7 @@ declare global {
              * @return {Object|Array}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getDigitTransformTable
              */
-            function getDigitTransformTable(): any;
+            function getDigitTransformTable(): string[] | Record<number | string, string>;
 
             /**
              * Get the language fallback chain for current UI language, including the language itself.
@@ -184,7 +206,7 @@ declare global {
              * @return {Object|Array}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-getSeparatorTransformTable
              */
-            function getSeparatorTransformTable(): any;
+            function getSeparatorTransformTable(): string[] | Record<number | string, string>;
 
             /**
              * Turn a list of string into a simple list using commas and 'and'.
@@ -207,7 +229,8 @@ declare global {
              * @param {any} [value] Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.language-method-setData
              */
-            function setData(langCode: string, dataKey: any, value?: any): void;
+            function setData(langCode: string, dataKey: string, value: any): void;
+            function setData(langCode: string, dataKey: Record<string, any>): void;
 
             /**
              * Apply numeric pattern to absolute value using options. Gives no

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -433,7 +433,7 @@ declare global {
              * @throws {Error} If an unregistered module or a dependency loop is encountered
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-resolve
              */
-            function resolve<T extends string, U extends T>(modules: U[]): T[];
+            function resolve<T extends string, U extends T = T>(modules: U[]): T[];
 
             /**
              * Start loading of all queued module dependencies.

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -433,6 +433,7 @@ declare global {
              * @throws {Error} If an unregistered module or a dependency loop is encountered
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-resolve
              */
+            // note: U is required so T is not inferred from the "modules" argument
             function resolve<T extends string, U extends T = T>(modules: U[]): T[];
 
             /**

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -31,7 +31,7 @@ interface ModuleRequire {
      * Get the exported value of a module.
      *
      * @param moduleName Module name
-     * @return Exported value
+     * @returns Exported value
      */
     (moduleName: string): any;
 }
@@ -87,7 +87,7 @@ declare global {
              * @param {string} text CSS text
              * @param {Node|null} [nextNode] The element where the style tag
              *  should be inserted before
-             * @return {HTMLStyleElement} Reference to the created style element
+             * @returns {HTMLStyleElement} Reference to the created style element
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-addStyleTag
              */
             function addStyleTag(text: string, nextNode?: Node | null): HTMLStyleElement;
@@ -95,8 +95,7 @@ declare global {
             /**
              * Get the names of all registered ResourceLoader modules.
              *
-             * @member mw.loader
-             * @return {string[]}
+             * @returns {string[]}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getModuleNames
              */
             function getModuleNames(): string[];
@@ -119,9 +118,8 @@ declare global {
              * } );
              * ```
              *
-             * @member mw.loader
              * @param {string} url Script URL
-             * @return {JQuery.Promise} Resolved when the script is loaded
+             * @returns {JQuery.Promise} Resolved when the script is loaded
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getScript
              */
             function getScript(url: string): JQuery.Promise<any>;
@@ -139,7 +137,7 @@ declare global {
              * - `missing`: The module was requested but is not defined according to the server.
              *
              * @param {string} module Name of module
-             * @return {string|null} The state, or null if the module (or its state) is not
+             * @returns {string|null} The state, or null if the module (or its state) is not
              *  in the registry.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-getState
              */
@@ -156,7 +154,7 @@ declare global {
              *   as '`[name]@[version]`". This version should match the requested version
              *   (from #batchRequest and #registry). This avoids race conditions (T117587).
              *
-             * - 1. {Function|Array|string|Object} [script] Module code. This can be a function,
+             * - 1. {ModuleScript} [script] Module code. This can be a function,
              *   a list of URLs to load via `<script src>`, a string for `globalEval()`, or an
              *   object like {"files": {"foo.js":function, "bar.js": function, ...}, "main": "foo.js"}.
              *   If an object is provided, the main file will be executed immediately, and the other
@@ -164,7 +162,7 @@ declare global {
              *   provided, it will be executed/evaluated immediately. If an array is provided, all
              *   URLs in the array will be loaded immediately, and executed as soon as they arrive.
              *
-             * - 2. {Object} [style] Should follow one of the following patterns:
+             * - 2. {ModuleStyle} [style] Should follow one of the following patterns:
              *
              *   ```js
              *   { "css": [css, ..] }
@@ -174,8 +172,8 @@ declare global {
              *   The reason css strings are not concatenated anymore is T33676. We now check
              *   whether it's safe to extend the stylesheet.
              *
-             * - 3. {Object} [messages] List of key/value pairs to be added to {@link mw.messages}.
-             * - 4. {Object} [templates] List of key/value pairs to be added to {@link mw.templates}.
+             * - 3. {ModuleMessages} [messages] List of key/value pairs to be added to {@link mw.messages}.
+             * - 4. {ModuleTemplates} [templates] List of key/value pairs to be added to {@link mw.templates}.
              * - 5. {String|null} [deprecationWarning] Deprecation warning if any
              *
              * The declarator must not use any scope variables, since it will be serialized with
@@ -196,14 +194,14 @@ declare global {
              * Does not support mw.loader.store caching.
              *
              * @param {string} module
-             * @param {Function|Array|string|Object} [script] Module code. This can be a function,
+             * @param {ModuleScript} [script] Module code. This can be a function,
              *  a list of URLs to load via `<script src>`, a string for `domEval()`, or an
              *  object like {"files": {"foo.js":function, "bar.js": function, ...}, "main": "foo.js"}.
              *  If an object is provided, the main file will be executed immediately, and the other
              *  files will only be executed if loaded via require(). If a function or string is
              *  provided, it will be executed/evaluated immediately. If an array is provided, all
              *  URLs in the array will be loaded immediately, and executed as soon as they arrive.
-             * @param {Object} [style] Should follow one of the following patterns:
+             * @param {ModuleStyle} [style] Should follow one of the following patterns:
              *
              * ```js
              * { "css": [css, ..] }
@@ -212,8 +210,8 @@ declare global {
              *
              * The reason css strings are not concatenated anymore is T33676. We now check
              * whether it's safe to extend the stylesheet.
-             * @param {Object} [messages] List of key/value pairs to be added to {@link mw.messages}.
-             * @param {Object} [templates] List of key/value pairs to be added to {@link mw.templates}.
+             * @param {ModuleMessages} [messages] List of key/value pairs to be added to {@link mw.messages}.
+             * @param {ModuleTemplates} [templates] List of key/value pairs to be added to {@link mw.templates}.
              * @param {string|null} [deprecationWarning] Deprecation warning if any
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-implement
              */
@@ -330,12 +328,11 @@ declare global {
              *
              * Since MediaWiki 1.28 the promise is resolved with a `require` function.
              *
-             * @member mw.loader
              * @param {string|Array} dependencies Module name or array of modules names the
              *  callback depends on to be ready before executing
              * @param {Function} [ready] Callback to execute when all dependencies are ready
              * @param {Function} [error] Callback to execute if one or more dependencies failed
-             * @return {JQuery.Promise} With a `require` function
+             * @returns {JQuery.Promise} With a `require` function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-using
              */
             function using(
@@ -370,7 +367,7 @@ declare global {
              * @param {string} url URL
              * @param {string} [media] Media attribute
              * @param {Node|null} [nextNode]
-             * @return {HTMLLinkElement}
+             * @returns {HTMLLinkElement}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html#global-method-addLinkTag
              */
             function addLinkTag(
@@ -387,7 +384,7 @@ declare global {
              * @param {Function} [callback] Callback to run after request resolution
              * @param {string[]} [modules] List of modules being requested, for state to be marked as error
              * in case the script fails to load
-             * @return {HTMLScriptElement}
+             * @returns {HTMLScriptElement}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/source/mediawiki.loader.html#mw-loader-method-addScriptTag
              */
             function addScriptTag(
@@ -434,7 +431,7 @@ declare global {
              *
              * @private
              * @param {string[]} modules Array of string module names
-             * @return {Array} List of dependencies, including 'module'.
+             * @returns {Array} List of dependencies, including 'module'.
              * @throws {Error} If an unregistered module or a dependency loop is encountered
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-resolve
              */
@@ -491,7 +488,7 @@ declare global {
                  * Retrieve a module from the store and update cache hit stats.
                  *
                  * @param {string} module Module name
-                 * @return {string|boolean} Module implementation or false if unavailable
+                 * @returns {string|boolean} Module implementation or false if unavailable
                  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-get
                  */
                 function get(module: string): string | false;
@@ -524,7 +521,7 @@ declare global {
                 /**
                  * Construct a JSON-serializable object representing the content of the store.
                  *
-                 * @return {Object} Module store contents.
+                 * @returns {Object} Module store contents.
                  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-toJSON
                  */
                 function toJSON(): { items: string; vary: string; asOf: number };
@@ -602,7 +599,6 @@ declare global {
                  * be called if the store is enabled.
                  *
                  * @private
-                 * @method
                  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader.store-method-requestUpdate
                  */
                 function requestUpdate(): void;

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -236,7 +236,7 @@ declare global {
              * - This method is used for preloading, which must not throw. Later code that
              *   calls {@link using()} will handle the error.
              *
-             * @param {string|Array} modules Either the name of a module, array of modules,
+             * @param {string|string[]} modules Either the name of a module, array of modules,
              *  or a URL of an external script or style
              * @param {string} [type='text/javascript'] MIME type to use if calling with a URL of an
              *  external script or style; acceptable values are "text/css" and
@@ -289,7 +289,7 @@ declare global {
             /**
              * Change the state of one or more modules.
              *
-             * @param {Object} states Object of module name/state pairs
+             * @param {Object.<string, ModuleState>} states Object of module name/state pairs
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-state
              */
             function state(states: Record<string, ModuleState>): void;
@@ -328,11 +328,11 @@ declare global {
              *
              * Since MediaWiki 1.28 the promise is resolved with a `require` function.
              *
-             * @param {string|Array} dependencies Module name or array of modules names the
+             * @param {string|string[]} dependencies Module name or array of modules names the
              *  callback depends on to be ready before executing
              * @param {Function} [ready] Callback to execute when all dependencies are ready
              * @param {Function} [error] Callback to execute if one or more dependencies failed
-             * @returns {JQuery.Promise} With a `require` function
+             * @returns {JQuery.Promise<ModuleRequire>} With a `require` function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-using
              */
             function using(
@@ -345,7 +345,6 @@ declare global {
              * Exposed for testing and debugging only.
              *
              * @private
-             * @property {number}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-property-maxQueryLength
              */
             const maxQueryLength: number;
@@ -355,7 +354,6 @@ declare global {
              * state; it is not a public interface for modifying the registry.
              *
              * @private
-             * @property {Object}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-property-moduleRegistry
              */
             const moduleRegistry: Record<string, ModuleRegistryEntry>;
@@ -431,7 +429,7 @@ declare global {
              *
              * @private
              * @param {string[]} modules Array of string module names
-             * @returns {Array} List of dependencies, including 'module'.
+             * @returns {string[]} List of dependencies, including 'module'.
              * @throws {Error} If an unregistered module or a dependency loop is encountered
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.loader-method-resolve
              */

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -217,7 +217,7 @@ declare global {
              */
             function implement(
                 module: string,
-                script?: any,
+                script?: ModuleScript,
                 style?: ModuleStyle,
                 messages?: ModuleMessages,
                 templates?: ModuleTemplates,

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -29,7 +29,6 @@ declare global {
              *
              * See {@link mw.log} for other logging methods.
              *
-             * @member mw
              * @param {...string} msg Messages to output to console.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
              */
@@ -98,7 +97,7 @@ declare global {
              * @param {string|null} key Name of the feature for deprecation tracker,
              *  or null for a console-only deprecation.
              * @param {string} msg Deprecation warning.
-             * @return {Function}
+             * @returns {Function}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-makeDeprecated
              */
             makeDeprecated(key: string | null, msg: string): () => void;

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -29,7 +29,7 @@ declare global {
              *
              * See {@link mw.log} for other logging methods.
              *
-             * @param {...string} msg Messages to output to console.
+             * @param {...Mixed} msg Messages to output to console.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
              */
             (...msg: any[]): void;
@@ -105,7 +105,7 @@ declare global {
             /**
              * Write a message to the browser console's warning channel.
              *
-             * @param {...string} msg Messages to output to console
+             * @param {...Mixed} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log-method-warn
              */
             warn(...msg: any[]): void;

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -1,11 +1,40 @@
 declare global {
     namespace mw {
+        namespace errorLogger {
+            /**
+             * Logs an error by notifying subscribers to the given {@link mw.track()} topic
+             * (by default `error.caught`) that an event has occurred.
+             *
+             * @param {Error} error
+             * @param {string} [topic='error.caught'] Error topic. Conventionally in the form
+             *   'error.?component?' (where ?component? identifies the code logging the error at a
+             *   high level; e.g. an extension name).
+             * @fires error_caught
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log
+             */
+            function logError(error: Error, topic?: `error.${string}`): void;
+        }
+
         /**
          * Collection of methods to help log messages to the console.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log
          */
-        namespace log {
+        const log: {
+            /**
+             * Write a verbose message to the browser's console in debug mode.
+             *
+             * This method is mainly intended for verbose logging. It is a no-op in production mode.
+             * In ResourceLoader debug mode, it will use the browser's console.
+             *
+             * See {@link mw.log} for other logging methods.
+             *
+             * @member mw
+             * @param {...string} msg Messages to output to console.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
+             */
+            (...msg: any[]): void;
+
             /**
              * Create a property on a host object that, when accessed, will log
              * a deprecation warning to the console.
@@ -26,10 +55,10 @@ declare global {
              *  Tracking is disabled by default, except for global variables on `window`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-deprecate
              */
-            function deprecate(
-                obj: any,
-                key: string,
-                val: any,
+            deprecate<T, K extends string & keyof T>(
+                obj: T,
+                key: K,
+                val: T[K],
                 msg?: string,
                 logName?: string
             ): void;
@@ -44,7 +73,35 @@ declare global {
              * @param {...Mixed} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-error
              */
-            function error(...msg: any[]): void;
+            error(...msg: any[]): void;
+
+            /**
+             * Create a function that logs a deprecation warning when called.
+             *
+             * Usage:
+             *
+             * ```js
+             * var deprecatedNoB = mw.log.makeDeprecated( 'hello_without_b', 'Use of hello without b is deprecated.' );
+             *
+             * function hello( a, b ) {
+             *     if ( b === undefined ) {
+             *         deprecatedNoB();
+             *         b = 0;
+             *     }
+             *     return a + b;
+             * }
+             *
+             * hello( 1 );
+             * ```
+             *
+             * @since 1.38
+             * @param {string|null} key Name of the feature for deprecation tracker,
+             *  or null for a console-only deprecation.
+             * @param {string} msg Deprecation warning.
+             * @return {Function}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-makeDeprecated
+             */
+            makeDeprecated(key: string | null, msg: string): () => void;
 
             /**
              * Write a message to the browser console's warning channel.
@@ -52,8 +109,8 @@ declare global {
              * @param {...string} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log-method-warn
              */
-            function warn(...msg: any[]): void;
-        }
+            warn(...msg: any[]): void;
+        };
     }
 }
 

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -9,7 +9,6 @@ declare global {
              * @param {string} [topic='error.caught'] Error topic. Conventionally in the form
              *   'error.?component?' (where ?component? identifies the code logging the error at a
              *   high level; e.g. an extension name).
-             * @fires error_caught
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log
              */
             function logError(error: Error, topic?: `error.${string}`): void;

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -16,24 +16,24 @@ declare global {
         }
 
         /**
+         * Write a verbose message to the browser's console in debug mode.
+         *
+         * This method is mainly intended for verbose logging. It is a no-op in production mode.
+         * In ResourceLoader debug mode, it will use the browser's console.
+         *
+         * See {@link mw.log} for other logging methods.
+         *
+         * @param {...Mixed} msg Messages to output to console.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
+         */
+        function log(...msg: any[]): void;
+
+        /**
          * Collection of methods to help log messages to the console.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log
          */
-        const log: {
-            /**
-             * Write a verbose message to the browser's console in debug mode.
-             *
-             * This method is mainly intended for verbose logging. It is a no-op in production mode.
-             * In ResourceLoader debug mode, it will use the browser's console.
-             *
-             * See {@link mw.log} for other logging methods.
-             *
-             * @param {...Mixed} msg Messages to output to console.
-             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
-             */
-            (...msg: any[]): void;
-
+        namespace log {
             /**
              * Create a property on a host object that, when accessed, will log
              * a deprecation warning to the console.
@@ -54,7 +54,7 @@ declare global {
              *  Tracking is disabled by default, except for global variables on `window`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-deprecate
              */
-            deprecate<T, K extends string & keyof T>(
+            function deprecate<T, K extends string & keyof T>(
                 obj: T,
                 key: K,
                 val: T[K],
@@ -72,7 +72,7 @@ declare global {
              * @param {...Mixed} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-error
              */
-            error(...msg: any[]): void;
+            function error(...msg: any[]): void;
 
             /**
              * Create a function that logs a deprecation warning when called.
@@ -100,7 +100,7 @@ declare global {
              * @returns {Function}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-makeDeprecated
              */
-            makeDeprecated(key: string | null, msg: string): () => void;
+            function makeDeprecated(key: string | null, msg: string): () => void;
 
             /**
              * Write a message to the browser console's warning channel.
@@ -108,8 +108,8 @@ declare global {
              * @param {...Mixed} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log-method-warn
              */
-            warn(...msg: any[]): void;
-        };
+            function warn(...msg: any[]): void;
+        }
     }
 }
 

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -23,7 +23,7 @@ declare global {
          *
          * See {@link mw.log} for other logging methods.
          *
-         * @param {...Mixed} msg Messages to output to console.
+         * @param {...any} msg Messages to output to console.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-log
          */
         function log(...msg: any[]): void;
@@ -48,7 +48,7 @@ declare global {
              *
              * @param {Object} obj Host object of deprecated property
              * @param {string} key Name of property to create in `obj`
-             * @param {Mixed} val The value this property should return when accessed
+             * @param {any} val The value this property should return when accessed
              * @param {string} [msg] Optional extra text to add to the deprecation warning
              * @param {string} [logName] Name of the feature for deprecation tracker.
              *  Tracking is disabled by default, except for global variables on `window`.
@@ -69,7 +69,7 @@ declare global {
              * argument is an Error object.
              *
              * @since 1.26
-             * @param {...Mixed} msg Messages to output to console
+             * @param {...any} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-error
              */
             function error(...msg: any[]): void;
@@ -105,7 +105,7 @@ declare global {
             /**
              * Write a message to the browser console's warning channel.
              *
-             * @param {...Mixed} msg Messages to output to console
+             * @param {...any} msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log-method-warn
              */
             function warn(...msg: any[]): void;

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -1,14 +1,30 @@
 declare global {
     namespace mw {
+        /**
+         * Collection of methods to help log messages to the console.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log
+         */
         namespace log {
             /**
-             * Create a property on a host object that, when accessed, will produce a deprecation warning in the console.
-             * @param {*} obj Host object of deprecated property
+             * Create a property on a host object that, when accessed, will log
+             * a deprecation warning to the console.
+             *
+             * Usage:
+             *
+             * ```js
+             * mw.log.deprecate( window, 'myGlobalFn', myGlobalFn );
+             *
+             * mw.log.deprecate( Thing, 'old', old, 'Use Other.thing instead', 'Thing.old'  );
+             * ```
+             *
+             * @param {Object} obj Host object of deprecated property
              * @param {string} key Name of property to create in `obj`
-             * @param {*} val The value this property should return when accessed
-             * @param {string?} msg Optional text to include in the deprecation message
-             * @param {string?} logName Name for the feature for logging and tracking purposes. Except for properties of the window object, tracking is only enabled if logName is set
-             * @returns {void}
+             * @param {Mixed} val The value this property should return when accessed
+             * @param {string} [msg] Optional extra text to add to the deprecation warning
+             * @param {string} [logName] Name of the feature for deprecation tracker.
+             *  Tracking is disabled by default, except for global variables on `window`.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-deprecate
              */
             function deprecate(
                 obj: any,
@@ -21,20 +37,20 @@ declare global {
             /**
              * Write a message to the browser console's error channel.
              *
-             * Most browsers also print a stacktrace when calling this method if the argument is an Error object.
+             * Most browsers also print a stacktrace when calling this method if the
+             * argument is an Error object.
              *
-             * This method is a no-op in browsers that don't implement the Console API.
-             * @param {Array<*>} msg Messages to output to console
-             * @returns {void}
+             * @since 1.26
+             * @param {...Mixed} msg Messages to output to console
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-error
              */
             function error(...msg: any[]): void;
 
             /**
              * Write a message to the browser console's warning channel.
              *
-             * This method is a no-op in browsers that don't implement the Console API.
-             * @param msg Messages to output to console
-             * @returns {void}
+             * @param {...string} msg Messages to output to console
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.log-method-warn
              */
             function warn(...msg: any[]): void;
         }

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -6,7 +6,7 @@ declare global {
          * Shortcut for `new mw.Message( mw.messages, key, parameters )`.
          *
          * @param {string} key Key of message to get
-         * @param {...Mixed} parameters Values for $N replacements
+         * @param {...any} parameters Values for $N replacements
          * @returns {Message}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-message
          */
@@ -232,7 +232,7 @@ declare global {
          * Shortcut for `mw.message( key, parameters... ).text()`.
          *
          * @param {string} key Key of message to get
-         * @param {...Mixed} parameters Values for $N replacements
+         * @param {...any} parameters Values for $N replacements
          * @returns {string}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-msg
          */

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -131,6 +131,17 @@ declare global {
             exists(): boolean;
 
             /**
+             * Check whether the message contains only syntax supported by jqueryMsg.
+             *
+             * This method is only available when jqueryMsg is loaded.
+             *
+             * @since 1.41
+             * @return {boolean}
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-isParseable
+             */
+            isParseable(): boolean;
+
+            /**
              * Add (does not replace) parameters for `$N` placeholder values.
              *
              * @param {Array} parameters
@@ -138,7 +149,7 @@ declare global {
              * @chainable
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-params
              */
-            params(parameters: any[]): Message;
+            params(parameters: any[]): this;
 
             /**
              * Parse message as wikitext and return HTML.
@@ -176,7 +187,7 @@ declare global {
              * @return {string} Parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parser
              */
-            parser(): string;
+            parser(format: string): string;
 
             /**
              * Return message plainly.
@@ -215,7 +226,7 @@ declare global {
              *  does not exist.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-toString
              */
-            toString(): string;
+            toString(format?: "escaped" | "parse" | "plain" | "text"): string;
         }
 
         /**

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -1,15 +1,66 @@
 declare global {
     namespace mw {
-        function message(key: string, ...parameters: any[]): mw.Message;
+        /**
+         * Get a message object.
+         *
+         * Shortcut for `new mw.Message( mw.messages, key, parameters )`.
+         *
+         * @param {string} key Key of message to get
+         * @param {...Mixed} parameters Values for $N replacements
+         * @return {Message}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-message
+         */
+        function message(key: string, ...parameters: any[]): Message;
 
-        const messages: mw.Map<{ [key: string]: string }>;
+        /**
+         * Store for messages.
+         *
+         * @property {Map}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-messages
+         */
+        const messages: Map<{ [key: string]: string }>;
 
         /**
          * Object constructor for messages.
          *
          * Similar to the Message class in MediaWiki PHP.
          *
-         * Format defaults to 'text'.
+         * ```js
+         * var obj, str;
+         * mw.messages.set( {
+         *     'hello': 'Hello world',
+         *     'hello-user': 'Hello, $1!',
+         *     'welcome-user': 'Welcome back to $2, $1! Last visit by $1: $3',
+         *     'so-unusual': 'You will find: $1'
+         * } );
+         *
+         * obj = mw.message( 'hello' );
+         * mw.log( obj.text() );
+         * // Hello world
+         *
+         * obj = mw.message( 'hello-user', 'John Doe' );
+         * mw.log( obj.text() );
+         * // Hello, John Doe!
+         *
+         * obj = mw.message( 'welcome-user', 'John Doe', 'Wikipedia', '2 hours ago' );
+         * mw.log( obj.text() );
+         * // Welcome back to Wikipedia, John Doe! Last visit by John Doe: 2 hours ago
+         *
+         * // Using mw.msg shortcut, always in "text' format.
+         * str = mw.msg( 'hello-user', 'John Doe' );
+         * mw.log( str );
+         * // Hello, John Doe!
+         *
+         * // Different formats
+         * obj = mw.message( 'so-unusual', 'Time "after" <time>' );
+         *
+         * mw.log( obj.text() );
+         * // You will find: Time "after" <time>
+         *
+         * mw.log( obj.escaped() );
+         * // You will find: Time &quot;after&quot; &lt;time&gt;
+         * ```
+         *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message
          */
         class Message {
@@ -18,48 +69,95 @@ declare global {
              *
              * Similar to the Message class in MediaWiki PHP.
              *
-             * Format defaults to 'text'.
-             * @param map Message store
-             * @param key
-             * @param parameters
+             * ```js
+             * var obj, str;
+             * mw.messages.set( {
+             *     'hello': 'Hello world',
+             *     'hello-user': 'Hello, $1!',
+             *     'welcome-user': 'Welcome back to $2, $1! Last visit by $1: $3',
+             *     'so-unusual': 'You will find: $1'
+             * } );
+             *
+             * obj = mw.message( 'hello' );
+             * mw.log( obj.text() );
+             * // Hello world
+             *
+             * obj = mw.message( 'hello-user', 'John Doe' );
+             * mw.log( obj.text() );
+             * // Hello, John Doe!
+             *
+             * obj = mw.message( 'welcome-user', 'John Doe', 'Wikipedia', '2 hours ago' );
+             * mw.log( obj.text() );
+             * // Welcome back to Wikipedia, John Doe! Last visit by John Doe: 2 hours ago
+             *
+             * // Using mw.msg shortcut, always in "text' format.
+             * str = mw.msg( 'hello-user', 'John Doe' );
+             * mw.log( str );
+             * // Hello, John Doe!
+             *
+             * // Different formats
+             * obj = mw.message( 'so-unusual', 'Time "after" <time>' );
+             *
+             * mw.log( obj.text() );
+             * // You will find: Time "after" <time>
+             *
+             * mw.log( obj.escaped() );
+             * // You will find: Time &quot;after&quot; &lt;time&gt;
+             * ```
+             *
+             * @param {Map} map Message store
+             * @param {string} key
+             * @param {Array} [parameters]
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-constructor
              */
-            constructor(map: mw.Map<Record<string, string>>, key: string, parameters?: any[]);
+            constructor(map: Map<Record<string, string>>, key: string, parameters?: any[]);
 
             /**
-             * Change the format to 'escaped' and convert message to string
+             * Format message and return as escaped text in HTML.
              *
-             * This is equivalent to using the 'text' format (see text), then HTML-escaping the output.
+             * This is equivalent to the {@link text} format, which is then HTML-escaped.
+             *
+             * @return {string} String form of html escaped message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-escaped
              */
             escaped(): string;
 
             /**
              * Check if a message exists
+             *
+             * @return {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-exists
              */
             exists(): boolean;
 
             /**
-             * Add (does not replace) parameters for $N placeholder values.
+             * Add (does not replace) parameters for `$N` placeholder values.
+             *
+             * @param {Array} parameters
+             * @return {Message}
+             * @chainable
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-params
              */
-            params(parameters: any[]): mw.Message;
+            params(parameters: any[]): Message;
 
             /**
-             * Change format to 'parse' and convert message to string
+             * Parse message as wikitext and return HTML.
              *
-             * If `jqueryMsg` is loaded, this parses the message text from wikitext (where supported) to HTML
+             * If jqueryMsg is loaded, this transforms text and parses a subset of supported wikitext
+             * into HTML. Without jqueryMsg, it is equivalent to {@link escaped}.
              *
-             * Otherwise, it is equivalent to plain.
+             * @return {string} String form of parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parse
              */
             parse(): string;
 
             /**
-             * Parse the message to DOM nodes, rather than HTML string like parse.
+             * Parse the message to DOM nodes, rather than HTML string like {@link parse}.
              *
              * This method is only available when jqueryMsg is loaded.
+             *
              * @since 1.27
+             * @return {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parseDom
              */
             parseDom(): JQuery;
@@ -67,40 +165,69 @@ declare global {
             /**
              * Get parsed contents of the message.
              *
-             * The default parser does simple $N replacements and nothing else. This may be overridden to
-             * provide a more complex message parser. The primary override is in the mediawiki.jqueryMsg module.
+             * The default parser does simple $N replacements and nothing else.
+             * This may be overridden to provide a more complex message parser.
+             * The primary override is in the mediawiki.jqueryMsg module.
              *
              * This function will not be called for nonexistent messages.
+             *
+             * @private For internal use by mediawiki.jqueryMsg only
+             * @param {string} format
+             * @return {string} Parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parser
              */
             parser(): string;
 
             /**
-             * Change format to 'plain' and convert message to string
+             * Return message plainly.
              *
-             * This substitutes parameters, but otherwise does not change the message text.
+             * This substitutes parameters, but otherwise does not transform the
+             * message content.
+             *
+             * @return {string} String form of plain message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-plain
              */
             plain(): string;
 
             /**
-             * Change format to 'text' and convert message to string
+             * Format message with text transformations applied.
              *
-             * If jqueryMsg is loaded, {{-transformation is done where supported (such as {{plural:}},
-             * {{gender:}}, {{int:}}).
+             * If jqueryMsg is loaded, `{{`-transformation is done for supported
+             * magic words such as `{{plural:}}`, `{{gender:}}`, and `{{int:}}`.
+             * Without jqueryMsg, it is equivalent to {@link plain}.
              *
-             * Otherwise, it is equivalent to plain
+             * @return {string} String form of text message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-text
              */
             text(): string;
 
             /**
-             * Convert message object to its string form based on current format.
+             * Convert message object to a string using the "text"-format .
+             *
+             * This exists for implicit string type casting only.
+             * Do not call this directly. Use {@link mw.Message.text()} instead, one of the
+             * other format methods.
+             *
+             * @private
+             * @param {string} [format="text"] Internal parameter. Uses "text" if called
+             *  implicitly through string casting.
+             * @return {string} Message in the given format, or `⧼key⧽` if the key
+             *  does not exist.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-toString
              */
             toString(): string;
         }
 
+        /**
+         * Get a message string using the (default) 'text' format.
+         *
+         * Shortcut for `mw.message( key, parameters... ).text()`.
+         *
+         * @param {string} key Key of message to get
+         * @param {...Mixed} parameters Values for $N replacements
+         * @return {string}
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-msg
+         */
         function msg(key: string, ...parameters: any[]): string;
     }
 }

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -24,6 +24,7 @@ declare global {
          *
          * Similar to the Message class in MediaWiki PHP.
          *
+         * @example
          * ```js
          * var obj, str;
          * mw.messages.set( {
@@ -68,6 +69,7 @@ declare global {
              *
              * Similar to the Message class in MediaWiki PHP.
              *
+             * @example
              * ```js
              * var obj, str;
              * mw.messages.set( {

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -7,7 +7,7 @@ declare global {
          *
          * @param {string} key Key of message to get
          * @param {...Mixed} parameters Values for $N replacements
-         * @return {Message}
+         * @returns {Message}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-message
          */
         function message(key: string, ...parameters: any[]): Message;
@@ -15,7 +15,6 @@ declare global {
         /**
          * Store for messages.
          *
-         * @property {Map}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-property-messages
          */
         const messages: Map<{ [key: string]: string }>;
@@ -117,7 +116,7 @@ declare global {
              *
              * This is equivalent to the {@link text} format, which is then HTML-escaped.
              *
-             * @return {string} String form of html escaped message
+             * @returns {string} String form of html escaped message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-escaped
              */
             escaped(): string;
@@ -125,7 +124,7 @@ declare global {
             /**
              * Check if a message exists
              *
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-exists
              */
             exists(): boolean;
@@ -136,7 +135,7 @@ declare global {
              * This method is only available when jqueryMsg is loaded.
              *
              * @since 1.41
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-isParseable
              */
             isParseable(): boolean;
@@ -145,8 +144,7 @@ declare global {
              * Add (does not replace) parameters for `$N` placeholder values.
              *
              * @param {Array} parameters
-             * @return {Message}
-             * @chainable
+             * @returns {Message}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-params
              */
             params(parameters: any[]): this;
@@ -157,7 +155,7 @@ declare global {
              * If jqueryMsg is loaded, this transforms text and parses a subset of supported wikitext
              * into HTML. Without jqueryMsg, it is equivalent to {@link escaped}.
              *
-             * @return {string} String form of parsed message
+             * @returns {string} String form of parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parse
              */
             parse(): string;
@@ -168,7 +166,7 @@ declare global {
              * This method is only available when jqueryMsg is loaded.
              *
              * @since 1.27
-             * @return {JQuery}
+             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parseDom
              */
             parseDom(): JQuery;
@@ -184,10 +182,10 @@ declare global {
              *
              * @private For internal use by mediawiki.jqueryMsg only
              * @param {string} format
-             * @return {string} Parsed message
+             * @returns {string} Parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-parser
              */
-            parser(format: string): string;
+            private parser(format: string): string;
 
             /**
              * Return message plainly.
@@ -195,7 +193,7 @@ declare global {
              * This substitutes parameters, but otherwise does not transform the
              * message content.
              *
-             * @return {string} String form of plain message
+             * @returns {string} String form of plain message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-plain
              */
             plain(): string;
@@ -207,7 +205,7 @@ declare global {
              * magic words such as `{{plural:}}`, `{{gender:}}`, and `{{int:}}`.
              * Without jqueryMsg, it is equivalent to {@link plain}.
              *
-             * @return {string} String form of text message
+             * @returns {string} String form of text message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-text
              */
             text(): string;
@@ -219,14 +217,13 @@ declare global {
              * Do not call this directly. Use {@link mw.Message.text()} instead, one of the
              * other format methods.
              *
-             * @private
              * @param {string} [format="text"] Internal parameter. Uses "text" if called
              *  implicitly through string casting.
-             * @return {string} Message in the given format, or `⧼key⧽` if the key
+             * @returns {string} Message in the given format, or `⧼key⧽` if the key
              *  does not exist.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.Message-method-toString
              */
-            toString(format?: "escaped" | "parse" | "plain" | "text"): string;
+            private toString(format?: "escaped" | "parse" | "plain" | "text"): string;
         }
 
         /**
@@ -236,7 +233,7 @@ declare global {
          *
          * @param {string} key Key of message to get
          * @param {...Mixed} parameters Values for $N replacements
-         * @return {string}
+         * @returns {string}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-msg
          */
         function msg(key: string, ...parameters: any[]): string;

--- a/mw/notification.d.ts
+++ b/mw/notification.d.ts
@@ -111,9 +111,9 @@ declare global {
          * Display a notification message to the user.
          *
          * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
-         * @param {Object} [options] The options to use for the notification.
+         * @param {Partial<NotificationOptions>} [options] The options to use for the notification.
          *  See {@link NotificationOptions defaults} for details.
-         * @returns {JQuery.Promise} Notification object
+         * @returns {JQuery.Promise<Notification>} Notification object
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-notify
          */
         function notify(
@@ -138,6 +138,10 @@ declare global {
              */
             const autoHideLimit: number;
 
+            /**
+             * @private
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.notification-property-autoHideSeconds
+             */
             const autoHideSeconds: {
                 short: number;
                 long: number;
@@ -170,7 +174,7 @@ declare global {
              * Display a notification message to the user.
              *
              * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
-             * @param {Object} [options] The options to use for the notification.
+             * @param {Partial<NotificationOptions>} [options] The options to use for the notification.
              *  See {@link NotificationOptions defaults} for details.
              * @returns {Notification} Notification object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.notification-method-notify

--- a/mw/notification.d.ts
+++ b/mw/notification.d.ts
@@ -1,3 +1,55 @@
+interface NotificationOptions {
+    /**
+     * A boolean indicating whether the notification should automatically
+     * be hidden after shown. Or if it should persist.
+     */
+    autoHide: boolean;
+
+    /**
+     * Key to {@link mw.notification.autoHideSeconds} for number of seconds for timeout of auto-hide
+     * notifications.
+     */
+    autoHideSeconds: "long" | "short";
+
+    /**
+     * An optional string. When a notification is tagged only one message
+     * with that tag will be displayed. Trying to display a new notification
+     * with the same tag as one already being displayed will cause the other
+     * notification to be closed and this new notification to open up inside
+     * the same place as the previous notification.
+     */
+    tag: string | null;
+
+    /**
+     * An optional title for the notification. Will be displayed above the
+     * content. Usually in bold.
+     */
+    title: string | null;
+
+    /**
+     * An optional string for the type of the message used for styling:
+     * Examples: 'info', 'warn', 'error', 'success'.
+     */
+    type: "error" | "info" | "success" | "warn" | null;
+
+    /**
+     * A boolean indicating if the autoHide timeout should be based on
+     * time the page was visible to user. Or if it should use wall clock time.
+     */
+    visibleTimeout: boolean;
+
+    /**
+     * HTML ID to set on the notification element.
+     */
+    id: string | false;
+
+    /**
+     * CSS class names in the form of a single string or
+     * array of strings, to be set on the notification element.
+     */
+    classes: string | string[] | false;
+}
+
 /**
  * A Notification object for 1 message.
  *
@@ -11,7 +63,7 @@ interface Notification {
     autoHideSeconds: number;
     isOpen: boolean;
     isPaused: boolean;
-    options: Partial<typeof mw.notification.defaults>;
+    options: Partial<NotificationOptions>;
     timeout: {
         set: typeof setTimeout;
         clear: typeof clearTimeout;
@@ -61,27 +113,12 @@ declare global {
          * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
          * @param {Object} [options] The options to use for the notification.
          *  See {@link NotificationOptions defaults} for details.
-         * @param options.autoHide A boolean indicating whether the notification should automatically
-         * be hidden after shown. Or if it should persist.
-         * @param options.autoHideSeconds Key to autoHideSeconds for number of seconds for timeout of
-         * auto-hide notifications.
-         * @param options.tag An optional string. When a notification is tagged only one message with that
-         * tag will be displayed. Trying to display a new notification with the same tag as one
-         * already being displayed will cause the other notification to be closed and this new
-         * notification to open up inside the same place as the previous notification.
-         * @param options.title An optional title for the notification. Will be displayed above the
-         * content. Usually in bold.
-         * @param options.type An optional string for the type of the message used for styling:
-         * Examples: 'info', 'warn', 'error', 'success'.
-         * @param options.visibleTimeout A boolean indicating if the autoHide timeout should be based on
-         * time the page was visible to user. Or if it should use wall clock time.
-         * @param options.id HTML ID to set on the notification element.
          * @return {JQuery.Promise} Notification object
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-notify
          */
         function notify(
-            message: string | JQuery | HTMLElement | HTMLElement[],
-            options?: Partial<typeof notification.defaults>
+            message: string | Message | JQuery | HTMLElement | HTMLElement[],
+            options?: Partial<NotificationOptions>
         ): JQuery.Promise<Notification>;
 
         /**
@@ -108,33 +145,10 @@ declare global {
 
             /**
              * The defaults for notify options parameter.
-             * @param autoHide A boolean indicating whether the notification should automatically
-             * be hidden after shown. Or if it should persist.
-             * @param autoHideSeconds Key to autoHideSeconds for number of seconds for timeout of
-             * auto-hide notifications.
-             * @param tag An optional string. When a notification is tagged only one message with that
-             * tag will be displayed. Trying to display a new notification with the same tag as one
-             * already being displayed will cause the other notification to be closed and this new
-             * notification to open up inside the same place as the previous notification.
-             * @param title An optional title for the notification. Will be displayed above the
-             * content. Usually in bold.
-             * @param type An optional string for the type of the message used for styling:
-             * Examples: 'info', 'warn', 'error', 'success'.
-             * @param visibleTimeout A boolean indicating if the autoHide timeout should be based on
-             * time the page was visible to user. Or if it should use wall clock time.
-             * @param id HTML ID to set on the notification element.
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.notification-property-defaults
              */
-            const defaults: {
-                autoHide: boolean;
-                autoHideSeconds: "short" | "long";
-                tag: string | null;
-                title: string | null;
-                type: "info" | "warn" | "error" | "success";
-                visibleTimeout: boolean;
-                id: string;
-                classes: string | string[];
-            };
+            const defaults: NotificationOptions;
 
             /**
              * Pause auto-hide timers for all notifications.
@@ -158,27 +172,12 @@ declare global {
              * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
              * @param {Object} [options] The options to use for the notification.
              *  See {@link NotificationOptions defaults} for details.
-             * @param options.autoHide A boolean indicating whether the notification should automatically
-             * be hidden after shown. Or if it should persist.
-             * @param options.autoHideSeconds Key to autoHideSeconds for number of seconds for timeout of
-             * auto-hide notifications.
-             * @param options.tag An optional string. When a notification is tagged only one message with that
-             * tag will be displayed. Trying to display a new notification with the same tag as one
-             * already being displayed will cause the other notification to be closed and this new
-             * notification to open up inside the same place as the previous notification.
-             * @param options.title An optional title for the notification. Will be displayed above the
-             * content. Usually in bold.
-             * @param options.type An optional string for the type of the message used for styling:
-             * Examples: 'info', 'warn', 'error', 'success'.
-             * @param options.visibleTimeout A boolean indicating if the autoHide timeout should be based on
-             * time the page was visible to user. Or if it should use wall clock time.
-             * @param options.id HTML ID to set on the notification element.
              * @return {Notification} Notification object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.notification-method-notify
              */
             function notify(
-                message: string | JQuery | HTMLElement | HTMLElement[],
-                options?: Partial<typeof notification.defaults>
+                message: string | Message | JQuery | HTMLElement | HTMLElement[],
+                options?: Partial<NotificationOptions>
             ): Notification;
         }
     }

--- a/mw/notification.d.ts
+++ b/mw/notification.d.ts
@@ -113,7 +113,7 @@ declare global {
          * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
          * @param {Object} [options] The options to use for the notification.
          *  See {@link NotificationOptions defaults} for details.
-         * @return {JQuery.Promise} Notification object
+         * @returns {JQuery.Promise} Notification object
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw-method-notify
          */
         function notify(
@@ -172,7 +172,7 @@ declare global {
              * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
              * @param {Object} [options] The options to use for the notification.
              *  See {@link NotificationOptions defaults} for details.
-             * @return {Notification} Notification object
+             * @returns {Notification} Notification object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.notification-method-notify
              */
             function notify(

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -11,7 +11,7 @@ interface SafeStorage {
      * Retrieve value from device storage.
      *
      * @param {string} key Key of item to retrieve
-     * @return {string|null|boolean} String value, null if no value exists, or false
+     * @returns {string|null|boolean} String value, null if no value exists, or false
      *  if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-get
      */
@@ -21,7 +21,7 @@ interface SafeStorage {
      * Retrieve JSON object from device storage.
      *
      * @param {string} key Key of item to retrieve
-     * @return {Object|null|boolean} Object, null if no value exists or value
+     * @returns {Object|null|boolean} Object, null if no value exists or value
      *  is not JSON-parseable, or false if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getObject
      */
@@ -31,7 +31,7 @@ interface SafeStorage {
      * Remove a value from device storage.
      *
      * @param {string} key Key of item to remove
-     * @return {boolean} Whether the key was removed
+     * @returns {boolean} Whether the key was removed
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-remove
      */
     remove(key: string): boolean;
@@ -42,7 +42,7 @@ interface SafeStorage {
      * @param {string} key Key name to store under
      * @param {string} value Value to be stored
      * @param {number} [expiry] Number of seconds after which this item can be deleted
-     * @return {boolean} The value was set
+     * @returns {boolean} The value was set
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-set
      */
     set(key: string, value: string, expiry?: number): boolean;
@@ -54,7 +54,7 @@ interface SafeStorage {
      * @param {number} [expiry] Number of seconds after which this item can be deleted,
      *  omit to clear the expiry (either making the item never expire, or to clean up
      *  when deleting a key).
-     * @return {boolean} The expiry was set (or cleared) [since 1.41]
+     * @returns {boolean} The expiry was set (or cleared) [since 1.41]
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-setExpires
      */
     setExpires(key: string, expiry?: number): boolean;
@@ -65,7 +65,7 @@ interface SafeStorage {
      * @param {string} key Key name to store under
      * @param {Object} value Object value to be stored
      * @param {number} [expiry] Number of seconds after which this item can be deleted
-     * @return {boolean} The value was set
+     * @returns {boolean} The value was set
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-setObject
      */
     setObject(key: string, value: any, expiry?: number): boolean;
@@ -74,7 +74,7 @@ interface SafeStorage {
      * Clear any expired items from the store
      *
      * @private
-     * @return {JQuery.Promise} Resolves when items have been expired
+     * @returns {JQuery.Promise} Resolves when items have been expired
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-clearExpired
      */
     clearExpired(): JQuery.Promise<undefined>;
@@ -83,7 +83,7 @@ interface SafeStorage {
      * Get all keys with expiry values
      *
      * @private
-     * @return {JQuery.Promise} Promise resolving with all the keys which have
+     * @returns {JQuery.Promise} Promise resolving with all the keys which have
      *  expiry values (unprefixed), or as many could be retrieved in the allocated time.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getExpiryKeys
      */
@@ -94,7 +94,7 @@ interface SafeStorage {
      *
      * @private
      * @param {string} key Key name
-     * @return {boolean} Whether key is expired
+     * @returns {boolean} Whether key is expired
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-isExpired
      */
     isExpired(key: string): boolean;

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -3,7 +3,6 @@
  * that is safe to call in all browsers.
  *
  * @private
- * @param {Object|undefined} store The Storage instance to wrap around
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage
  */
 interface SafeStorage {
@@ -11,7 +10,7 @@ interface SafeStorage {
      * Retrieve value from device storage.
      *
      * @param {string} key Key of item to retrieve
-     * @returns {string|null|boolean} String value, null if no value exists, or false
+     * @returns {string|null|false} String value, null if no value exists, or false
      *  if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-get
      */
@@ -83,7 +82,7 @@ interface SafeStorage {
      * Get all keys with expiry values
      *
      * @private
-     * @returns {JQuery.Promise} Promise resolving with all the keys which have
+     * @returns {JQuery.Promise<string[]>} Promise resolving with all the keys which have
      *  expiry values (unprefixed), or as many could be retrieved in the allocated time.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getExpiryKeys
      */

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -2,7 +2,6 @@
  * A wrapper for the HTML5 Storage interface (`localStorage` or `sessionStorage`)
  * that is safe to call in all browsers.
  *
- * @class mw.SafeStorage
  * @private
  * @param {Object|undefined} store The Storage instance to wrap around
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage
@@ -102,6 +101,33 @@ interface SafeStorage {
 }
 
 interface MwStorage extends SafeStorage {
+    /**
+     * A safe interface to HTML5 `sessionStorage`.
+     *
+     * This normalises differences across browsers and silences any and all
+     * exceptions that may occur.
+     *
+     * **Note**: Data persisted via `sessionStorage` will persist for the lifetime
+     * of the browser *tab*, not the browser *window*.
+     * For longer-lasting persistence across tabs, refer to {@link mw.storage} or {@link mw.cookie} instead.
+     *
+     * Example:
+     *
+     * ```js
+     * mw.storage.session.set( key, value );
+     * mw.storage.session.get( key );
+     * ```
+     *
+     * Example:
+     *
+     * ```js
+     * var session = require( 'mediawiki.storage' ).session;
+     * session.set( key, value );
+     * session.get( key );
+     * ```
+     *
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.storage.session
+     */
     session: SafeStorage;
 }
 
@@ -133,19 +159,20 @@ declare global {
          *
          * Example:
          *
-         *     mw.storage.set( key, value, expiry );
-         *     mw.storage.set( key, value ); // stored indefinitely
-         *     mw.storage.get( key );
+         * ```js
+         * mw.storage.set( key, value, expiry );
+         * mw.storage.set( key, value ); // stored indefinitely
+         * mw.storage.get( key );
+         * ```
          *
          * Example:
          *
-         *     var local = require( 'mediawiki.storage' ).local;
-         *     local.set( key, value, expiry );
-         *     local.get( key );
+         * ```js
+         * var local = require( 'mediawiki.storage' ).local;
+         * local.set( key, value, expiry );
+         * local.get( key );
+         * ```
          *
-         * @class
-         * @singleton
-         * @extends mw.SafeStorage
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.storage
          */
         const storage: MwStorage;

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -15,7 +15,7 @@ interface SafeStorage {
      *  if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-get
      */
-    get(key: string): string | null | boolean;
+    get(key: string): string | null | false;
 
     /**
      * Retrieve JSON object from device storage.
@@ -57,7 +57,7 @@ interface SafeStorage {
      * @return {boolean} The expiry was set (or cleared) [since 1.41]
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-setExpires
      */
-    setExpires(key: string, expiry?: number): void;
+    setExpires(key: string, expiry?: number): boolean;
 
     /**
      * Set an object value in device storage by JSON encoding
@@ -77,7 +77,7 @@ interface SafeStorage {
      * @return {JQuery.Promise} Resolves when items have been expired
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-clearExpired
      */
-    clearExpired(): JQuery.Promise<any>;
+    clearExpired(): JQuery.Promise<undefined>;
 
     /**
      * Get all keys with expiry values
@@ -87,7 +87,7 @@ interface SafeStorage {
      *  expiry values (unprefixed), or as many could be retrieved in the allocated time.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.SafeStorage-method-getExpiryKeys
      */
-    getExpiryKeys(): JQuery.Promise<any>;
+    getExpiryKeys(): JQuery.Promise<string[]>;
 
     /**
      * Check if a given key has expired

--- a/mw/template.d.ts
+++ b/mw/template.d.ts
@@ -8,6 +8,8 @@ declare global {
     namespace mw {
         /**
          * Requires mediawiki.template ResourceLoader module
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template
          */
         namespace template {
             /**
@@ -20,6 +22,7 @@ declare global {
              *
              * @param {string} name Compiler name
              * @param {Object} compiler
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-registerCompiler
              */
             function registerCompiler(name: string, compiler: Compiler): void;
 
@@ -28,6 +31,7 @@ declare global {
              *
              * @param {string} templateName Name of a template (including suffix)
              * @return {string} Name of a compiler
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-getCompilerName
              */
             function getCompilerName(templateName: string): string;
 
@@ -36,6 +40,7 @@ declare global {
              *
              * @param {string} name Name of a compiler
              * @return {Object} The compiler
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-getCompiler
              */
             function getCompiler(name: string): Compiler;
 
@@ -48,6 +53,7 @@ declare global {
              * @param {string} templateName Name of the template (including suffix)
              * @param {string} templateBody Contents of the template (e.g. html markup)
              * @return {Object} Compiled template
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-add
              */
             function add(
                 moduleName: string,
@@ -61,6 +67,7 @@ declare global {
              * @param {string} moduleName Name of the module to retrieve the template from
              * @param {string} templateName Name of template to be retrieved
              * @return {Object} Compiled template
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-get
              */
             function get(moduleName: string, templateName: string): CompiledTemplate;
 
@@ -70,6 +77,7 @@ declare global {
              * @param {string} templateBody Template body
              * @param {string} compilerName The name of a registered compiler
              * @return {Object} Compiled template
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-compile
              */
             function compile(templateBody: string, compilerName: string): CompiledTemplate;
         }

--- a/mw/template.d.ts
+++ b/mw/template.d.ts
@@ -1,7 +1,7 @@
 type CompiledTemplate = any; // Can this be made more specific?
 
 interface Compiler {
-    compile: (src: string) => CompiledTemplate;
+    compile(src: string): CompiledTemplate;
 }
 
 declare global {
@@ -21,7 +21,7 @@ declare global {
              * The compiler name must correspond with the name suffix of templates that use this compiler.
              *
              * @param {string} name Compiler name
-             * @param {Object} compiler
+             * @param {Compiler} compiler
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-registerCompiler
              */
             function registerCompiler(name: string, compiler: Compiler): void;
@@ -30,7 +30,7 @@ declare global {
              * Get the name of the associated compiler based on a template name.
              *
              * @param {string} templateName Name of a template (including suffix)
-             * @return {string} Name of a compiler
+             * @returns {string} Name of a compiler
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-getCompilerName
              */
             function getCompilerName(templateName: string): string;
@@ -39,7 +39,7 @@ declare global {
              * Get a compiler via its name.
              *
              * @param {string} name Name of a compiler
-             * @return {Object} The compiler
+             * @returns {Compiler} The compiler
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-getCompiler
              */
             function getCompiler(name: string): Compiler;
@@ -52,7 +52,7 @@ declare global {
              * @param {string} moduleName Name of the ResourceLoader module the template is associated with
              * @param {string} templateName Name of the template (including suffix)
              * @param {string} templateBody Contents of the template (e.g. html markup)
-             * @return {Object} Compiled template
+             * @returns {CompiledTemplate} Compiled template
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-add
              */
             function add(
@@ -66,7 +66,7 @@ declare global {
              *
              * @param {string} moduleName Name of the module to retrieve the template from
              * @param {string} templateName Name of template to be retrieved
-             * @return {Object} Compiled template
+             * @returns {CompiledTemplate} Compiled template
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-get
              */
             function get(moduleName: string, templateName: string): CompiledTemplate;
@@ -76,7 +76,7 @@ declare global {
              *
              * @param {string} templateBody Template body
              * @param {string} compilerName The name of a registered compiler
-             * @return {Object} Compiled template
+             * @returns {CompiledTemplate} Compiled template
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.template-method-compile
              */
             function compile(templateBody: string, compilerName: string): CompiledTemplate;

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -1,14 +1,12 @@
 export interface User {
     /**
-     * @property {Map}
-     * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
      */
     // TODO: add types for items in the options map
     options: mw.Map;
 
     /**
-     * @property {mw.Map}
-     * @see: https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
      */
     tokens: mw.Map<{
         csrfToken: string;
@@ -36,7 +34,7 @@ export interface User {
      * See https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
      * n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))
      *
-     * @return {string} 80 bit integer in hex format, padded
+     * @return {string} 80 bit integer (20 characters) in hex format, padded
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-generateRandomSessionId
      */
     generateRandomSessionId(): string;
@@ -53,7 +51,7 @@ export interface User {
     /**
      * Get the current user's database id
      *
-     * Not to be confused with #id.
+     * Not to be confused with {@link id}.
      *
      * @return {number} Current user's id, or 0 if user is anonymous
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getId
@@ -99,7 +97,7 @@ export interface User {
     /**
      * Get the current user's name or the session ID
      *
-     * Not to be confused with #getId.
+     * Not to be confused with {@link getId}.
      *
      * @return {string} User name or random session ID
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-id
@@ -139,7 +137,7 @@ export interface User {
      *
      * **Note:** Server-side code must never interpret or modify this value.
      *
-     * @return {string} Random session ID
+     * @return {string} Random session ID (20 hex characters)
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-sessionId
      */
     sessionId(): string;

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -1,3 +1,14 @@
+export interface UserInfo {
+    /**
+     * User groups that the user belongs to
+     */
+    groups: string[];
+    /**
+     * User's rights
+     */
+    rights: string[];
+}
+
 export interface User {
     /**
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
@@ -13,6 +24,21 @@ export interface User {
         patrolToken: string;
         watchToken: string;
     }>;
+
+    /**
+     * Acquire a temporary user username and stash it in the current session, if temp account creation
+     * is enabled and the current user is logged out. If a name has already been stashed, returns the
+     * same name.
+     *
+     * If the user later performs an action that results in temp account creation, the stashed username
+     * will be used for their account. It may also be used in previews. However, the account is not
+     * created yet, and the name is not visible to other users.
+     *
+     * @return {JQuery.Promise} Promise resolved with the username if we succeeded,
+     *   or resolved with `null` if we failed
+     * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-acquireTempUserName
+     */
+    acquireTempUserName(): JQuery.Promise<string>;
 
     /**
      * Generate a random user session ID.
@@ -46,7 +72,8 @@ export interface User {
      * @return {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
      */
-    getGroups(callback?: (groups: string[]) => any): JQuery.Promise<string[]>;
+    getGroups(callback: (groups: string[]) => any): JQuery.Promise<undefined>;
+    getGroups(): JQuery.Promise<string[]>;
 
     /**
      * Get the current user's database id
@@ -83,7 +110,7 @@ export interface User {
      *  unavailable, or Date for when the user registered.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRegistration
      */
-    getRegistration(): boolean | null | Date;
+    getRegistration(): false | null | Date;
 
     /**
      * Get the current user's rights
@@ -92,7 +119,8 @@ export interface User {
      * @return {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
      */
-    getRights(callback?: (rights: string[]) => any): JQuery.Promise<string[]>;
+    getRights(callback: (rights: string[]) => any): JQuery.Promise<undefined>;
+    getRights(): JQuery.Promise<string[]>;
 
     /**
      * Get the current user's name or the session ID
@@ -149,10 +177,7 @@ export interface User {
      * @return {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
      */
-    getUserInfo(): JQuery.Promise<{
-        groups: string[];
-        rights: string[];
-    }>;
+    getUserInfo(): JQuery.Promise<UserInfo>;
 }
 
 declare global {

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -17,6 +17,50 @@ interface UserTokens extends Record<string, string> {
 
 export interface User {
     /**
+     * Manage client preferences
+     *
+     * For skins that enable the `clientPrefEnabled` option (see Skin class in PHP),
+     * this feature allows you to store preferences in the browser session that will
+     * switch one or more the classes on the HTML document.
+     *
+     * This is only supported for unregistered users. For registered users, skins
+     * and extensions must use user preferences (e.g. hidden or API-only options)
+     * and swap class names server-side through the Skin interface.
+     *
+     * This feature is limited to page views by unregistered users. For logged-in requests,
+     * store preferences in the database instead, via UserOptionsManager or mw.Api#saveOption
+     * (may be hidden or API-only to exclude from Special:Preferences), and then include the
+     * desired classes directly in Skin::getHtmlElementAttributes.
+     *
+     * Classes toggled by this feature must be named as `<feature>-clientpref-<value>`,
+     * where `value` contains only alphanumerical characters (a-zA-Z0-9), and `feature`
+     * can also include hyphens.
+     */
+    clientPrefs: {
+        /**
+         * Retrieve the current value of the feature from the HTML document element
+         *
+         * @param {string} feature
+         * @return {false|string} returns false if the feature is not recognized.
+         *   returns string if a feature was found.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user.clientPrefs-method-get
+         */
+        get(feature: string): false | string;
+
+        /**
+         * Change the class on the HTML document element, and save the value in a cookie
+         *
+         * @param {string} feature
+         * @param {string} value
+         * @return {boolean} True if feature was stored successfully, false if the value
+         *   uses a forbidden character or the feature is not recognised
+         *   e.g. a matching class was not defined on the HTML document element.
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user.clientPrefs-method-set
+         */
+        set(feature: string, value: string): boolean;
+    };
+
+    /**
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
      */
     // TODO: add types for items in the options map

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -34,7 +34,7 @@ export interface User {
      * will be used for their account. It may also be used in previews. However, the account is not
      * created yet, and the name is not visible to other users.
      *
-     * @return {JQuery.Promise} Promise resolved with the username if we succeeded,
+     * @returns {JQuery.Promise} Promise resolved with the username if we succeeded,
      *   or resolved with `null` if we failed
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-acquireTempUserName
      */
@@ -60,7 +60,7 @@ export interface User {
      * See https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
      * n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))
      *
-     * @return {string} 80 bit integer (20 characters) in hex format, padded
+     * @returns {string} 80 bit integer (20 characters) in hex format, padded
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-generateRandomSessionId
      */
     generateRandomSessionId(): string;
@@ -69,7 +69,7 @@ export interface User {
      * Get the current user's groups
      *
      * @param {Function} [callback]
-     * @return {JQuery.Promise}
+     * @returns {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
      */
     getGroups(callback: (groups: string[]) => any): JQuery.Promise<undefined>;
@@ -80,7 +80,7 @@ export interface User {
      *
      * Not to be confused with {@link id}.
      *
-     * @return {number} Current user's id, or 0 if user is anonymous
+     * @returns {number} Current user's id, or 0 if user is anonymous
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getId
      */
     getId(): number;
@@ -88,7 +88,7 @@ export interface User {
     /**
      * Get the current user's name
      *
-     * @return {string|null} User name string or null if user is anonymous
+     * @returns {string|null} User name string or null if user is anonymous
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getName
      */
     getName(): string | null;
@@ -98,7 +98,7 @@ export interface User {
      * cached within this class (also known as a page view token).
      *
      * @since 1.32
-     * @return {string} 80 bit integer in hex format, padded
+     * @returns {string} 80 bit integer in hex format, padded
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getPageviewToken
      */
     getPageviewToken(): string;
@@ -106,7 +106,7 @@ export interface User {
     /**
      * Get date user registered, if available
      *
-     * @return {boolean|null|Date} False for anonymous users, null if data is
+     * @returns {false|null|Date} False for anonymous users, null if data is
      *  unavailable, or Date for when the user registered.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRegistration
      */
@@ -116,7 +116,7 @@ export interface User {
      * Get the current user's rights
      *
      * @param {Function} [callback]
-     * @return {JQuery.Promise}
+     * @returns {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
      */
     getRights(callback: (rights: string[]) => any): JQuery.Promise<undefined>;
@@ -127,7 +127,7 @@ export interface User {
      *
      * Not to be confused with {@link getId}.
      *
-     * @return {string} User name or random session ID
+     * @returns {string} User name or random session ID
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-id
      */
     id(): string;
@@ -135,7 +135,7 @@ export interface User {
     /**
      * Whether the current user is anonymous
      *
-     * @return {boolean}
+     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isAnon
      */
     isAnon(): boolean;
@@ -143,7 +143,7 @@ export interface User {
     /**
      * Is the user a normal non-temporary registered user?
      *
-     * @return {boolean}
+     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isNamed
      */
     isNamed(): boolean;
@@ -151,7 +151,7 @@ export interface User {
     /**
      * Is the user an autocreated temporary user?
      *
-     * @return {boolean}
+     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-isTemp
      */
     isTemp(): boolean;
@@ -165,7 +165,7 @@ export interface User {
      *
      * **Note:** Server-side code must never interpret or modify this value.
      *
-     * @return {string} Random session ID (20 hex characters)
+     * @returns {string} Random session ID (20 hex characters)
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-sessionId
      */
     sessionId(): string;
@@ -174,7 +174,7 @@ export interface User {
      * Get the current user's groups or rights
      *
      * @private
-     * @return {JQuery.Promise}
+     * @returns {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
      */
     getUserInfo(): JQuery.Promise<UserInfo>;

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -9,6 +9,12 @@ export interface UserInfo {
     rights: string[];
 }
 
+interface UserTokens extends Record<string, string> {
+    csrfToken: string;
+    patrolToken: string;
+    watchToken: string;
+}
+
 export interface User {
     /**
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-options
@@ -19,11 +25,7 @@ export interface User {
     /**
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-property-tokens
      */
-    tokens: mw.Map<{
-        csrfToken: string;
-        patrolToken: string;
-        watchToken: string;
-    }>;
+    tokens: mw.Map<UserTokens>;
 
     /**
      * Acquire a temporary user username and stash it in the current session, if temp account creation

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -72,7 +72,7 @@ export interface User {
      * @returns {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
      */
-    getGroups(callback: (groups: string[]) => any): JQuery.Promise<undefined>;
+    getGroups<T>(callback: (groups: string[]) => T): JQuery.Promise<T>;
     getGroups(): JQuery.Promise<string[]>;
 
     /**
@@ -119,7 +119,7 @@ export interface User {
      * @returns {JQuery.Promise}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
      */
-    getRights(callback: (rights: string[]) => any): JQuery.Promise<undefined>;
+    getRights<T>(callback: (rights: string[]) => T): JQuery.Promise<T>;
     getRights(): JQuery.Promise<string[]>;
 
     /**

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -36,7 +36,7 @@ export interface User {
      * will be used for their account. It may also be used in previews. However, the account is not
      * created yet, and the name is not visible to other users.
      *
-     * @returns {JQuery.Promise} Promise resolved with the username if we succeeded,
+     * @returns {JQuery.Promise<string>} Promise resolved with the username if we succeeded,
      *   or resolved with `null` if we failed
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-acquireTempUserName
      */
@@ -71,7 +71,7 @@ export interface User {
      * Get the current user's groups
      *
      * @param {Function} [callback]
-     * @returns {JQuery.Promise}
+     * @returns {JQuery.Promise<string[]>}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getGroups
      */
     getGroups<T>(callback: (groups: string[]) => T): JQuery.Promise<T>;
@@ -118,7 +118,7 @@ export interface User {
      * Get the current user's rights
      *
      * @param {Function} [callback]
-     * @returns {JQuery.Promise}
+     * @returns {JQuery.Promise<string[]>}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getRights
      */
     getRights<T>(callback: (rights: string[]) => T): JQuery.Promise<T>;
@@ -176,7 +176,7 @@ export interface User {
      * Get the current user's groups or rights
      *
      * @private
-     * @returns {JQuery.Promise}
+     * @returns {JQuery.Promise<UserInfo>}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.user-method-getUserInfo
      */
     getUserInfo(): JQuery.Promise<UserInfo>;

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -9,6 +9,28 @@ type NoReturn<T extends (...args: any[]) => any> = T extends (
         : (this: U, ...args: V) => void
     : never;
 
+interface ImageUrlData {
+    /**
+     * File name (same format as {@link mw.Title.getMainText()}).
+     */
+    name: string;
+
+    /**
+     * Thumbnail width, in pixels. Null when the file is not a thumbnail.
+     */
+    width: number | null;
+
+    /**
+     * @param w Width, which must be smaller than the width of the original image (or equal to it; that
+     *   only works if `MediaHandler::mustRender` returns true for the file). Null when the
+     *   file in the original URL is not a thumbnail.
+     *   On wikis with `$wgGenerateThumbnailOnParse` set to true, this will fall back to using
+     *   `Special:Redirect` which is less efficient. Otherwise, it is a direct thumbnail URL.
+     * @returns A thumbnail URL (URL-encoded) with that width.
+     */
+    resizeUrl: (w: number) => string | null;
+}
+
 declare global {
     namespace mw {
         /**
@@ -403,27 +425,11 @@ declare global {
              * the image.
              *
              * @param {string} url URL to parse (URL-encoded)
-             * @returns {Object|null} URL data, or null if the URL is not a valid MediaWiki
+             * @returns {ImageUrlData|null} URL data, or null if the URL is not a valid MediaWiki
              *   image/thumbnail URL.
-             * @returns {string} return.name File name (same format as Title.getMainText()).
-             * @returns {number} [return.width] Thumbnail width, in pixels. Null when the file is not
-             *   a thumbnail.
-             * @returns {function(number):string} [return.resizeUrl] A function that takes a width
-             *   parameter and returns a thumbnail URL (URL-encoded) with that width. The width
-             *   parameter must be smaller than the width of the original image (or equal to it; that
-             *   only works if MediaHandler::mustRender returns true for the file). Null when the
-             *   file in the original URL is not a thumbnail.
-             *   On wikis with $wgGenerateThumbnailOnParse set to true, this will fall back to using
-             *   Special:Redirect which is less efficient. Otherwise, it is a direct thumbnail URL.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-parseImageUrl
              */
-            function parseImageUrl(
-                url: string
-            ): {
-                name: string;
-                width?: number | null;
-                resizeUrl(w: number): string;
-            } | null;
+            function parseImageUrl(url: string): ImageUrlData | null;
 
             /**
              * Percent-decode a string, as found in a URL hash fragment

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -163,7 +163,6 @@ declare global {
              * @param {HTMLElement|JQuery|string} [nextnode] Element that the new item should be added before.
              *  Must be another item in the same list, it will be ignored otherwise.
              *  Can be specified as DOM reference, as jQuery object, or as CSS selector string.
-             * @fires util_addPortletLink
              * @returns {HTMLLIElement|null} The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addPortletLink
              */

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -57,7 +57,7 @@ declare global {
              * See also [MDN: CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
              *
              * @param {string} text CSS to be appended
-             * @return {CSSStyleSheet} The sheet object
+             * @returns {CSSStyleSheet} The sheet object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addCSS
              */
             function addCSS(text: string): CSSStyleSheet;
@@ -69,7 +69,7 @@ declare global {
              * @param {string} [label] of the new portlet.
              * @param {string} [before] selector of the element preceding the new portlet. If not passed
              *  the caller is responsible for appending the element to the DOM before using addPortletLink.
-             * @return {HTMLElement|null} will be null if it was not possible to create an portlet with
+             * @returns {HTMLElement|null} will be null if it was not possible to create an portlet with
              *  the required information e.g. the selector given in before parameter could not be resolved
              *  to an existing element in the page.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addPortlet
@@ -140,7 +140,7 @@ declare global {
              *  Must be another item in the same list, it will be ignored otherwise.
              *  Can be specified as DOM reference, as jQuery object, or as CSS selector string.
              * @fires util_addPortletLink
-             * @return {HTMLLIElement|null} The added list item, or null if no element was added.
+             * @returns {HTMLLIElement|null} The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-addPortletLink
              */
             function addPortletLink(
@@ -183,7 +183,7 @@ declare global {
              * @param {Function} func Function to debounce
              * @param {number} [wait=0] Wait period in milliseconds
              * @param {boolean} [immediate] Trigger on leading edge
-             * @return {Function} Debounced function
+             * @returns {Function} Debounced function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-debounce
              */
             function debounce<T extends (...args: any[]) => any>(
@@ -203,7 +203,7 @@ declare global {
              *
              * @since 1.30
              * @param {string} str String to encode
-             * @return {string} Encoded string
+             * @returns {string} Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeIdForAttribute
              */
             function escapeIdForAttribute(str: string): string;
@@ -215,7 +215,7 @@ declare global {
              *
              * @since 1.30
              * @param {string} str String to encode
-             * @return {string} Encoded string
+             * @returns {string} Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeIdForLink
              */
             function escapeIdForLink(str: string): string;
@@ -225,11 +225,13 @@ declare global {
              *
              * The following characters are escaped:
              *
-             *     \ { } ( ) | . ? * + - ^ $ [ ]
+             * ```text
+             * \ { } ( ) | . ? * + - ^ $ [ ]
+             * ```
              *
-             * @since 1.26; moved to mw.util in 1.34
+             * @since 1.26; moved to {@link mw.util} in 1.34
              * @param {string} str String to escape
-             * @return {string} Escaped string
+             * @returns {string} Escaped string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-escapeRegExp
              */
             function escapeRegExp(str: string): string;
@@ -247,7 +249,7 @@ declare global {
              *
              * @param {string} param The parameter name.
              * @param {URLSearchParams} [params] Parsed URL parameters to search through, defaulting to the current browsing location.
-             * @return {string[]|null} Parameter value, or null if parameter was not found.
+             * @returns {string[]|null} Parameter value, or null if parameter was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getArrayParam
              */
             function getArrayParam(param: string, params?: URLSearchParams): string[] | null;
@@ -263,7 +265,7 @@ declare global {
              *
              * @param {string} param The parameter name.
              * @param {string} [url=location.href] URL to search through, defaulting to the current browsing location.
-             * @return {string|null} Parameter value, or null if parameter was not found.
+             * @returns {string|null} Parameter value, or null if parameter was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getParamValue
              */
             function getParamValue(param: string, url?: string): string | null;
@@ -272,7 +274,7 @@ declare global {
              * Get the target element from a link hash
              *
              * This is the same element as you would get from
-             * document.querySelectorAll(':target'), but can be used on
+             * `document.querySelectorAll(':target')`, but can be used on
              * an arbitrary hash fragment, or after pushState/replaceState
              * has been used.
              *
@@ -285,7 +287,7 @@ declare global {
              *
              * @param {string} [hash] Hash fragment, without the leading '#'.
              *  Taken from location.hash if omitted.
-             * @return {HTMLElement|null} Element, if found
+             * @returns {HTMLElement|null} Element, if found
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getTargetFromFragment
              */
             function getTargetFromFragment(hash?: string): HTMLElement | null;
@@ -296,7 +298,7 @@ declare global {
              * @param {string|null} [pageName=wgPageName] Page name
              * @param {Object} [params] A mapping of query parameter names to values,
              *  e.g. `{ action: 'edit' }`
-             * @return {string} URL, relative to `wgServer`.
+             * @returns {string} URL, relative to `wgServer`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getUrl
              */
             // params are handled by $.param, which converts any value to a string. However, instead of using toString(),
@@ -320,7 +322,7 @@ declare global {
              * @since 1.25
              * @param {string} address String to check
              * @param {boolean} [allowBlock=false] If a block of IPs should be allowed
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPAddress
              */
             function isIPAddress(address: string, allowBlock?: boolean): boolean;
@@ -342,7 +344,7 @@ declare global {
              *
              * @param {string} address
              * @param {boolean} [allowBlock=false]
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPv4Address
              */
             function isIPv4Address(
@@ -371,7 +373,7 @@ declare global {
              *
              * @param {string} address
              * @param {boolean} [allowBlock=false]
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isIPv6Address
              */
             function isIPv6Address(address: string, allowBlock?: boolean): boolean;
@@ -380,7 +382,7 @@ declare global {
              * Is a portlet visible?
              *
              * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isPortletVisible
              */
             function isPortletVisible(portletId: string): boolean;
@@ -388,10 +390,10 @@ declare global {
             /**
              * Does given username match $wgAutoCreateTempUser?
              *
-             * This functionality has been adapted from MediaWiki\User\TempUser\Pattern::isMatch()
+             * This functionality has been adapted from `MediaWiki\User\TempUser\Pattern::isMatch()`
              *
              * @param {string} username
-             * @return {boolean}
+             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-isTemporaryUser
              */
             function isTemporaryUser(username: string): boolean;
@@ -402,12 +404,12 @@ declare global {
              * the image.
              *
              * @param {string} url URL to parse (URL-encoded)
-             * @return {Object|null} URL data, or null if the URL is not a valid MediaWiki
+             * @returns {Object|null} URL data, or null if the URL is not a valid MediaWiki
              *   image/thumbnail URL.
-             * @return {string} return.name File name (same format as Title.getMainText()).
-             * @return {number} [return.width] Thumbnail width, in pixels. Null when the file is not
+             * @returns {string} return.name File name (same format as Title.getMainText()).
+             * @returns {number} [return.width] Thumbnail width, in pixels. Null when the file is not
              *   a thumbnail.
-             * @return {function(number):string} [return.resizeUrl] A function that takes a width
+             * @returns {function(number):string} [return.resizeUrl] A function that takes a width
              *   parameter and returns a thumbnail URL (URL-encoded) with that width. The width
              *   parameter must be smaller than the width of the original image (or equal to it; that
              *   only works if MediaHandler::mustRender returns true for the file). Null when the
@@ -428,16 +430,16 @@ declare global {
              * Percent-decode a string, as found in a URL hash fragment
              *
              * Implements the percent-decode method as defined in
-             * https://url.spec.whatwg.org/#percent-decode.
+             * {@link https://url.spec.whatwg.org/#percent-decode}.
              *
-             * URLSearchParams implements https://url.spec.whatwg.org/#concept-urlencoded-parser
+             * URLSearchParams implements {@link https://url.spec.whatwg.org/#concept-urlencoded-parser}
              * which performs a '+' to ' ' substitution before running percent-decode.
              *
              * To get the desired behaviour we percent-encode any '+' in the fragment
              * to effectively expose the percent-decode implementation.
              *
              * @param {string} text Text to decode
-             * @return {string|null} Decoded text, null if decoding failed
+             * @returns {string|null} Decoded text, null if decoding failed
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-percentDecodeFragment
              */
             function percentDecodeFragment(text: string): string | null;
@@ -447,10 +449,10 @@ declare global {
              *
              * This will make it more compact and lower-case.
              *
-             * This functionality has been adapted from \Wikimedia\IPUtils::prettifyIP()
+             * This functionality has been adapted from `\Wikimedia\IPUtils::prettifyIP()`
              *
              * @param {string} ip IP address in quad or octet form (CIDR or not).
-             * @return {string|null}
+             * @returns {string|null}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-prettifyIP
              */
             function prettifyIP(ip: string): string | null;
@@ -459,7 +461,7 @@ declare global {
              * Encode the string like PHP's rawurlencode
              *
              * @param {string} str String to be encoded.
-             * @return {string} Encoded string
+             * @returns {string} Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-rawurlencode
              */
             function rawurlencode(str: string): string;
@@ -471,10 +473,10 @@ declare global {
              * IPv6 addresses in octet notation are expanded to 8 words;
              * IPv4 addresses have leading zeros, in each octet, removed.
              *
-             * This functionality has been adapted from \Wikimedia\IPUtils::sanitizeIP()
+             * This functionality has been adapted from `\Wikimedia\IPUtils::sanitizeIP()`
              *
              * @param {string} ip IP address in quad or octet form (CIDR or not).
-             * @return {string|null}
+             * @returns {string|null}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-sanitizeIP
              */
             function sanitizeIP(ip: string): string | null;
@@ -500,7 +502,7 @@ declare global {
              *
              * @param {Function} func Function to throttle
              * @param {number} wait Throttle window length, in milliseconds
-             * @return {Function} Throttled function
+             * @returns {Function} Throttled function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-throttle
              */
             function throttle<T extends (...args: any[]) => any>(
@@ -518,7 +520,7 @@ declare global {
              * ```
              *
              * @param {string} email E-mail address
-             * @return {boolean|null} True if valid, false if invalid, null if `email` was empty.
+             * @returns {boolean|null} True if valid, false if invalid, null if `email` was empty.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-validateEmail
              */
             function validateEmail(email: string): boolean | null;
@@ -530,7 +532,7 @@ declare global {
              *
              * @since 1.18
              * @param {string} [str="index"] Name of entry point (e.g. 'index' or 'api')
-             * @return {string} URL to the script file (e.g. `/w/api.php`)
+             * @returns {string} URL to the script file (e.g. `/w/api.php`)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-wikiScript
              */
             function wikiScript(str?: string): string;
@@ -545,7 +547,7 @@ declare global {
              * non-canonical URL.
              *
              * @param {string} str String to be encoded.
-             * @return {string} Encoded string
+             * @returns {string} Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-wikiUrlencode
              */
             function wikiUrlencode(str: string): string;

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -3,8 +3,6 @@ declare global {
         /**
          * Utility library provided by the `mediawiki.util` module.
          *
-         * @class mw.util
-         * @singleton
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util
          */
         namespace util {
@@ -21,7 +19,7 @@ declare global {
              *
              * If you need just the wikipage content (not any of the
              * extra elements output by the skin), use `$( '#mw-content-text' )`
-             * instead. Or listen to mw.hook#wikipage_content which will
+             * instead. Or listen to {@link mw.hook mw.hook("wikipage.content")} which will
              * allow your code to re-run when the page changes (e.g. live preview
              * or re-render after ajax save).
              *
@@ -34,16 +32,18 @@ declare global {
              * Append a new style block to the head and return the CSSStyleSheet object.
              *
              * To access the `<style>` element, reference `sheet.ownerNode`, or call
-             * the mw.loader#addStyleTag method directly.
+             * the {@link mw.loader.addStyleTag} method directly.
              *
              * This function returns the CSSStyleSheet object for convience with features
              * that are managed at that level, such as toggling of styles:
              *
-             *     var sheet = util.addCSS( '.foobar { display: none; }' );
-             *     $( '#myButton' ).click( function () {
-             *         // Toggle the sheet on and off
-             *         sheet.disabled = !sheet.disabled;
-             *     } );
+             * ```js
+             * var sheet = util.addCSS( '.foobar { display: none; }' );
+             * $( '#myButton' ).click( function () {
+             *     // Toggle the sheet on and off
+             *     sheet.disabled = !sheet.disabled;
+             * } );
+             * ```
              *
              * See also [MDN: CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
              *
@@ -64,7 +64,10 @@ declare global {
              * - p-namespaces (For namespaces on legacy skins)
              *
              * Additional menus can be discovered through the following code:
-             * ```$('.mw-portlet').toArray().map((el) => el.id);```
+             *
+             * ```js
+             * $('.mw-portlet').toArray().map((el) => el.id);
+             * ```
              *
              * Menu availability varies by skin, wiki, and current page.
              *
@@ -75,27 +78,31 @@ declare global {
              * add the link before an existing item, pass the DOM node or a CSS selector
              * for that item, e.g. `'#foobar'` or `document.getElementById( 'foobar' )`.
              *
-             *     mw.util.addPortletLink(
-             *         'p-tb', 'https://www.mediawiki.org/',
-             *         'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
-             *     );
+             * ```js
+             * mw.util.addPortletLink(
+             *     'p-tb', 'https://www.mediawiki.org/',
+             *     'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
+             * );
              *
-             *     var node = mw.util.addPortletLink(
-             *         'p-tb',
-             *         new mw.Title( 'Special:Example' ).getUrl(),
-             *         'Example'
-             *     );
-             *     $( node ).on( 'click', function ( e ) {
-             *         console.log( 'Example' );
-             *         e.preventDefault();
-             *     } );
+             * var node = mw.util.addPortletLink(
+             *     'p-tb',
+             *     mw.util.getUrl( 'Special:Example' ),
+             *     'Example'
+             * );
+             * $( node ).on( 'click', function ( e ) {
+             *     console.log( 'Example' );
+             *     e.preventDefault();
+             * } );
+             * ```
              *
              * Remember that to call this inside a user script, you may have to ensure the
              * `mediawiki.util` is loaded first:
              *
-             *     $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
-             *          mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
-             *     } );
+             * ```js
+             * $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
+             *      mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
+             * } );
+             * ```
              *
              * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
              * @param {string} href Link URL
@@ -207,9 +214,11 @@ declare global {
             /**
              * Get the value for a given URL query parameter.
              *
-             *     mw.util.getParamValue( 'foo', '/?foo=x' ); // "x"
-             *     mw.util.getParamValue( 'foo', '/?foo=' ); // ""
-             *     mw.util.getParamValue( 'foo', '/' ); // null
+             * ```js
+             * mw.util.getParamValue( 'foo', '/?foo=x' ); // "x"
+             * mw.util.getParamValue( 'foo', '/?foo=' ); // ""
+             * mw.util.getParamValue( 'foo', '/' ); // null
+             * ```
              *
              * @param {string} param The parameter name.
              * @param {string} [url=location.href] URL to search through, defaulting to the current browsing location.
@@ -275,13 +284,15 @@ declare global {
              *
              * Based on \Wikimedia\IPUtils::isIPv4 in PHP.
              *
-             *     // Valid
-             *     mw.util.isIPv4Address( '80.100.20.101' );
-             *     mw.util.isIPv4Address( '192.168.1.101' );
+             * ```js
+             * // Valid
+             * mw.util.isIPv4Address( '80.100.20.101' );
+             * mw.util.isIPv4Address( '192.168.1.101' );
              *
-             *     // Invalid
-             *     mw.util.isIPv4Address( '192.0.2.0/24' );
-             *     mw.util.isIPv4Address( 'hello' );
+             * // Invalid
+             * mw.util.isIPv4Address( '192.0.2.0/24' );
+             * mw.util.isIPv4Address( 'hello' );
+             * ```
              *
              * @param {string} address
              * @param {boolean} [allowBlock=false]
@@ -295,13 +306,15 @@ declare global {
              *
              * Based on \Wikimedia\IPUtils::isIPv6 in PHP.
              *
-             *     // Valid
-             *     mw.util.isIPv6Address( '2001:db8:a:0:0:0:0:0' );
-             *     mw.util.isIPv6Address( '2001:db8:a::' );
+             * ```js
+             * // Valid
+             * mw.util.isIPv6Address( '2001:db8:a:0:0:0:0:0' );
+             * mw.util.isIPv6Address( '2001:db8:a::' );
              *
-             *     // Invalid
-             *     mw.util.isIPv6Address( '2001:db8:a::/32' );
-             *     mw.util.isIPv6Address( 'hello' );
+             * // Invalid
+             * mw.util.isIPv6Address( '2001:db8:a::/32' );
+             * mw.util.isIPv6Address( 'hello' );
+             * ```
              *
              * @param {string} address
              * @param {boolean} [allowBlock=false]
@@ -320,9 +333,9 @@ declare global {
             function isPortletVisible(portletId: string): boolean;
 
             /**
-             * This functionality has been adapted from MediaWiki\User\TempUser\Pattern::isMatch()
+             * Does given username match $wgAutoCreateTempUser?
              *
-             * Checks if the pattern matches the given username
+             * This functionality has been adapted from MediaWiki\User\TempUser\Pattern::isMatch()
              *
              * @param {string} username
              * @return {boolean}
@@ -377,10 +390,11 @@ declare global {
             function percentDecodeFragment(text: string): string | null;
 
             /**
-             * This functionality has been adapted from \Wikimedia\IPUtils::prettifyIP()
-             *
              * Prettify an IP for display to end users.
+             *
              * This will make it more compact and lower-case.
+             *
+             * This functionality has been adapted from \Wikimedia\IPUtils::prettifyIP()
              *
              * @param {string} ip IP address in quad or octet form (CIDR or not).
              * @return {string|null}
@@ -398,12 +412,13 @@ declare global {
             function rawurlencode(str: string): string;
 
             /**
-             * This functionality has been adapted from \Wikimedia\IPUtils::sanitizeIP()
-             *
              * Convert an IP into a verbose, uppercase, normalized form.
+             *
              * Both IPv4 and IPv6 addresses are trimmed. Additionally,
              * IPv6 addresses in octet notation are expanded to 8 words;
              * IPv4 addresses have leading zeros, in each octet, removed.
+             *
+             * This functionality has been adapted from \Wikimedia\IPUtils::sanitizeIP()
              *
              * @param {string} ip IP address in quad or octet form (CIDR or not).
              * @return {string|null}
@@ -442,7 +457,9 @@ declare global {
              *
              * This validation is based on the HTML5 specification.
              *
-             *     mw.util.validateEmail( "me@example.org" ) === true;
+             * ```js
+             * mw.util.validateEmail( "me@example.org" ) === true;
+             * ```
              *
              * @param {string} email E-mail address
              * @return {boolean|null} True if valid, false if invalid, null if `email` was empty.
@@ -451,7 +468,7 @@ declare global {
             function validateEmail(email: string): boolean | null;
 
             /**
-             * Get URL to a MediaWiki server entry point.
+             * Get URL to a MediaWiki entry point.
              *
              * Similar to `wfScript()` in PHP.
              *

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -1,3 +1,5 @@
+import { QueryParams } from "./Uri";
+
 type NoReturn<T extends (...args: any[]) => any> = T extends (
     this: infer U,
     ...args: infer V
@@ -296,17 +298,14 @@ declare global {
              * Get the URL to a given local wiki page name,
              *
              * @param {string|null} [pageName=wgPageName] Page name
-             * @param {Object} [params] A mapping of query parameter names to values,
+             * @param {QueryParams} [params] A mapping of query parameter names to values,
              *  e.g. `{ action: 'edit' }`
              * @returns {string} URL, relative to `wgServer`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/#!/api/mw.util-method-getUrl
              */
             // params are handled by $.param, which converts any value to a string. However, instead of using toString(),
             // object are serialized (deep ones recursively), so only simple values are allowed to prevent mistakes.
-            function getUrl(
-                pageName?: string | null,
-                params?: { [param: string]: string | number | boolean | null | undefined }
-            ): string;
+            function getUrl(pageName?: string | null, params?: QueryParams): string;
 
             /**
              * Hide a portlet.
@@ -349,12 +348,12 @@ declare global {
              */
             function isIPv4Address(
                 address: string,
-                allowBlock: true
-            ): address is `${number}.${number}.${number}.${number}${`/${number}` | ""}`;
-            function isIPv4Address(
-                address: string,
                 allowBlock?: false
             ): address is `${number}.${number}.${number}.${number}`;
+            function isIPv4Address(
+                address: string,
+                allowBlock: boolean
+            ): address is `${number}.${number}.${number}.${number}${`/${number}` | ""}`;
 
             /**
              * Whether a string is a valid IPv6 address or not.
@@ -423,7 +422,7 @@ declare global {
             ): {
                 name: string;
                 width?: number | null;
-                resizeUrl: (w: number) => string;
+                resizeUrl(w: number): string;
             } | null;
 
             /**

--- a/scripts/api-types-generator.js
+++ b/scripts/api-types-generator.js
@@ -15,7 +15,7 @@ const queryApiData = await new mw.Api().get({
     formatversion: "2",
 });
 
-function processParamInfo(type, name, multi) {
+function processParamInfo(type, prefix, name, multi) {
     if (Array.isArray(type)) {
         type = type.map((e) => `'${e}'`).join(" | ");
         if (multi) {
@@ -42,8 +42,11 @@ function processParamInfo(type, name, multi) {
         name === "site" // gusite used by ApiQueryGlobalUsage
     ) {
         type = "string | string[]";
-    } else if (name.includes(`-`)) {
-        name = `'${name}'`;
+    }
+
+    name = prefix + name;
+    if (name.includes("-")) {
+        name = `"${name}"`;
     }
     return { name, type };
 }
@@ -61,12 +64,17 @@ const actionsTypes = data.paraminfo.modules
             `export interface ${getInterfaceName(module)}Params extends ApiParams {\n` +
             module.parameters
                 .map((param) => {
-                    const { name, type } = processParamInfo(param.type, param.name, param.multi);
+                    const { name, type } = processParamInfo(
+                        param.type,
+                        module.prefix,
+                        param.name,
+                        param.multi
+                    );
                     return `${name}?: ${type}`;
                 })
                 .join("\n")
                 .replace(/^/gm, "\t") +
-            `\n}`
+            "\n}"
         );
     })
     .join("\n\n");
@@ -77,12 +85,17 @@ const queryTypes = queryApiData.paraminfo.modules
             `export interface ${getInterfaceName(module)}Params extends ApiQueryParams {\n` +
             module.parameters
                 .map((param) => {
-                    const { name, type } = processParamInfo(param.type, param.name, param.multi);
-                    return `${module.prefix}${name}?: ${type}`;
+                    const { name, type } = processParamInfo(
+                        param.type,
+                        module.prefix,
+                        param.name,
+                        param.multi
+                    );
+                    return `${name}?: ${type}`;
                 })
                 .join("\n")
                 .replace(/^/gm, "\t") +
-            `\n}`
+            "\n}"
         );
     })
     .join("\n\n");

--- a/scripts/config-types-scraper.js
+++ b/scripts/config-types-scraper.js
@@ -25,9 +25,27 @@ for (const table of tables) {
         if (!cells.length) continue;
         const name = cells[0].innerText.trim();
         const type = processType(cells[1].innerText);
-        types[name] = type;
+        const description = cells[2].innerText;
+        types[name] = [type, description];
     }
 }
 
-const entries = Object.entries(types).map(([k, v]) => `${" ".repeat(12)}${k}: ${v};`);
-console.log(`{\n${entries.join("\n")}${" ".repeat(8)}\n}`);
+function formatEntry(name, type, description) {
+    return [
+        "/**",
+        ...description.split("\n").map((e) => ` * ${e.trim()}`),
+        " *",
+        ` * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#${k}`,
+        " */",
+        `${name}: ${type};`,
+    ];
+}
+
+function formatCode(lines, level = 0) {
+    return `{\n${lines.map((e) => `${" ".repeat(4 * (level + 1))}${e}`).join("\n")}${" ".repeat(
+        4 * level
+    )}\n}`;
+}
+
+const lines = Object.entries(types).flatMap(([n, [t, d]]) => formatEntry(n, t, d));
+console.log(formatCode(lines, 2));

--- a/scripts/config-types-scraper.js
+++ b/scripts/config-types-scraper.js
@@ -2,10 +2,15 @@
 // paste this into the browser console, and copy the log output
 
 function processType(type) {
+    const data = {};
     type = type.toLowerCase();
-    type = type.replace(/or (unset|not defined)/, "");
+    type = type.replace("not defined", "unset");
     type = type.replace("integer", "number");
     type = type.replace(/ or /g, " | ");
+    if (type.includes("unset")) {
+        data.optional = true;
+        type = type.replace(/ \| unset/g, "");
+    }
     if (type.startsWith("array of")) {
         const element = type.replace(/array of (.*)s(\s|$)/, "$1");
         type = `${element}[]`;
@@ -13,7 +18,8 @@ function processType(type) {
     if (type === "array") type = "string[]";
     if (type === "object") type = "Record<string, string>";
 
-    return type.trim();
+    data.type = type.trim();
+    return data;
 }
 
 const types = {};
@@ -24,20 +30,21 @@ for (const table of tables) {
         const cells = row.querySelectorAll("td");
         if (!cells.length) continue;
         const name = cells[0].innerText.trim();
-        const type = processType(cells[1].innerText);
-        const description = cells[2].innerText;
-        types[name] = [type, description];
+        types[name] = {
+            ...processType(cells[1].innerText),
+            description: cells[2].innerText,
+        };
     }
 }
 
-function formatEntry(name, type, description) {
+function formatEntry(name, data) {
     return [
         "/**",
-        ...description.split("\n").map((e) => ` * ${e.trim()}`),
+        ...data.description.split("\n").map((e) => ` * ${e.trim()}`),
         " *",
-        ` * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#${k}`,
+        ` * @see https://www.mediawiki.org/wiki/Manual:Interface/JavaScript#${name}`,
         " */",
-        `${name}: ${type};`,
+        `${name}${data.optional ? "?" : ""}: ${data.type};`,
     ];
 }
 
@@ -47,5 +54,5 @@ function formatCode(lines, level = 0) {
     )}\n}`;
 }
 
-const lines = Object.entries(types).flatMap(([n, [t, d]]) => formatEntry(n, t, d));
+const lines = Object.entries(types).flatMap((e) => formatEntry(...e));
 console.log(formatCode(lines, 2));

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,6 @@
     "extends": ["dtslint/dtslint.json", "tslint-config-prettier"],
     "rules": {
         "no-padding": false,
-        "no-unnecessary-qualifier": false,
         "unified-signatures": false,
         "no-redundant-jsdoc": false,
         "no-unnecessary-generics": false

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,5 @@
 {
     "extends": ["dtslint/dtslint.json", "tslint-config-prettier"],
-    "linterOptions": {
-        "exclude": ["api_params/index.d.ts"]
-    },
     "rules": {
         "no-padding": false,
         "no-unnecessary-qualifier": false,


### PR DESCRIPTION
This merge request contains various type and documentation changes, mostly to add MediaWiki 1.41 declarations and to fix various JSdoc inconsistencies and type issues.

Below is a (non exhaustive) list of proposed changes:

## JSDoc changes

- Update comments to 1.41:
  - add missing comments to `$.client`, `$.textSelection`, `mw.html`, `mw.loader.store.stats`, `mw.message`, `mw.notification`, `mw.storage.session`, `mw.Uri`, and `mw.widgets`.
  - update comments of `mw.Api` and `mw.util.isTemporaryUser`.
  - scrap `mw.config` comments, along with property types.
- Synchronize JSDoc types with TypeScript types.
- Add missing `@link` (instead of `@see`, for referencing other members), `@see`, and `@since` annotations.
- Unify annotation conventions:
  - use ```` ``` ```` code blocks, and specify language name as much as possible.
  - replace `@return` with `@returns`.
  - replace `*`, `Mixed` with `any`.
  - replace `{T?} x` with `{T} [x]` to match expected behavior.
- Move `@property` and `@param` annotations to inner objects when sub-property referencing is used.
- Remove redundant annotations:
  - `@class`, `@constructor`, `@extends`, `@fires`, `@member`, `@method`, `@property`, `@returns {void}`, `@singleton`, and `@static`.
  - `@private` and `@protected` where corresponding TS keywords can be used.
  - `@chainable` where `this` can be used.

## Type changes

- Add missing declarations from 1.41:
  - update `api_params.d.ts` generated list from Wikipedia API (1.42.0-wmf.18).
  - add global `mediaWiki`.
  - add `libs`, `log`, and `trackQueue` to `mw`.
  - add missing `mw.config` properties.
  - add `mw.errorLogger`.
  - add OOJS static properties to `mw.ForeignApi` and `mw.ForeignRest`.
  - make `mw.language.months` a namespace and specify properties.
  - add `impl` to `mw.loader` and missing `mw.loader.moduleRegistry` properties.
  - add `makeDeprecated` to `mw.log`.
  - add `isParseable` to `mw.Message`.
  - add `acquireTempUserName` and `clientPrefs` to `mw.user`.
  - add `addPortlet` and `getArrayParam` to `mw.util`.
- Use more shared interfaces for similar or complex types.
- Stricten some types:
  - replace `any` values of `$.client.test`, `$.colorUtil.getColorBrightness`, `mw.cookie.set`, `mw.language.data`, `mw.language.getDigitTransformTable`, `mw.language.getSeparatorTransformTable`, `mw.language.setData`, `mw.loader.implement`, `mw.loader.require`, `mw.loader.store.items`, `mw.storage.clearExpired`, `mw.storage.getExpiryKeys`, `mw.Title.getUrl`, `mw.track`, `mw.trackError`, `mw.Uri.query`, and `mw.Uri.extend`.
  - specify callback arguments of `addOnloadHook`, `mw.loader.addScriptTag`, `mw.loader.enqueue`, `mw.loader.using`, `mw.trackSubscribe`, `mw.trackUnsubscribe`, and `mw.UriRelative`.
  - specify query parameters and promise results of various `mw.Api` methods.
  - use fixed-size arrays with `$.colorUtil` color arrays.
  - infer argument type from boolean result with `mw.util.isIPv4Address` and `mw.util.isIPv4Address`.
  - use `false` literal instead of `boolean` with return type of `mw.loader.store.get`, `mw.storage.get`, and `mw.user.getRegistration`.
  - use string enumeration with type argument of `mw.loader.load` and module state argument of `mw.loader.state`.
  - use template strings with return type of `mw.ForeignApi.getOrigin` and `mw.Uri.toString`.
- Improve type inference based on function arguments:
  - add type variables to `$.colorUtil.getRGB`, `mw.language.gender`, `mw.language.preConvertPlural`, and `mw.log.deprecate`.
  - add alternative declarations to `mw.language.convertNumber` and `mw.language.gender`.
- Add optional type variables to help manually improving type checking when desired:
  - to specify loaded modules of `mw.loader.resolve`.
  - to specify allowed keys of `mw.Map.exists` and `mw.Map.set`.
- Add autocompletion to common parameter values:
  - base and legacy token types of `mw.Api.badToken`, `mw.Api.getToken`, and `mw.Api.postWithToken` methods.
  - known properties of `mw.Map` methods, by using another `ExtensibleMap` interface (see https://github.com/wikimedia-gadgets/types-mediawiki/issues/37).

## Specific type fixes

- Fix some functions not specifying some "error" return values:
  - `null` for `mw.cookie.get`, `mw.language.gender`, `mw.notification.defaults.type`, `mw.Title.newFromFileName`, `mw.Title.newFromImg`, and `mw.Title.newFromUserInput`.
  - `false` for `mw.cookie.getCrossSite`, `mw.notification.defaults.classes` and `mw.notification.defaults.id`.
- Add missing command options argument to `$.textSelection()` when called with `setContents` and `replaceSelection`.
- Fix `$.textSelection("getCaretPosition", { startAndEnd: x })` not allowing `x: boolean`.
- Prevent calling `$.textSelection("setSelection")` without any options, as `start` is required.
- Add a default definition of `$.textSelection` for custom commands, registered via `$.textSelection("register")`.
- Add missing prefix to properties of some `api_params.d.ts` interfaces.
- Fix `importStylesheet` and `importStylesheetURI` eventually returning `null`, which actually never appens.
- Fix `defaults` of `mw.Api`, `mw.ForeignApi`, `mw.ForeignRest`, and `mw.Rest` having all properties optional. Some are optional, but some are always defined.
- Fix `mw.Api.assertCurrentUser` return type, this function extends the given query parameters, but does not do any actual API request.
- Fix `mw.Api.chunkedUploadToStash` not allowing an input HTML element as argument.
- Fix `mw.Api.getMessages` and `mw.Api.loadMessages` not allowing to query a single string message.
- Fix `mw.Api.loadMessagesIfMissing` returning an API result: the actual query result is consumed by the function, only the boolean `mw.Map.set` result is returned.
- Fix `wgCaseSensitiveNamespaces` property of `mw.config` being a list of strings instead of integers.
- Add missing `sameSiteLegacy` property to options of `mw.cookie.set`.
- Rename `mw.experiment` to `mw.experiments`.
- Fix `mw.ForeignRest` allowing a URI object as argument. However, `mw.ForeignRest` does not check for URI objects, while `mw.ForeignApi` does.
- Fix `mw.format` mistakenly allowing anything as parameter replacement.
- Fix `mw.html.element` not allowing attributes to have boolean or number values.
- Fix `mw.language.convertPlural` asking for string instead of integers, when specifying plural forms.
- Remove `commafyNumber`, `flipTransform`, and `pad` from `mw.language`. These declarations are mistakenly included in the API documentation (supposedly missing an `@ignore` annotation).
- Fix `mw.loader.register` signature when given multiple modules: all properties should be given multiple times, not only the module name.
- Fix `mw.Map.values` optional keys being required with `null` instead of being optional (and update html scrapper accordingly).
- Infer `mw.Map.get` return type from both selection type and fallback type.
- Add missing format parameter to `mw.Message.parser` and `mw.Message.toString`.
- Fix `mw.notify` and `mw.notification.notify` not allowing `mw.Message` objects as argument.
- Add missing options parameter to `mw.requestIdleCallback`.
- Add missing return type to `mw.storage.setExpires`.
- Fix `mw.Title.exists` not allowing a title string as argument.
- Fix `mw.Title.newFromUserInput` not allowing an empty object as options.
- Fix `mw.UriRelative` returning a `mw.Uri` instance instead of a new constructor. This is also wrongly typed in the MediaWiki source code.
- Fix `mw.Uri` constructor not allowing a boolean as options. This is marked as backward-compatibility in JSDoc, and is still handled in the source code.
- Fix `mw.user.getGroups` and `mw.user.getRights` not chaining the promise result correctly when given a callback argument.
- Fix `mw.util.debounce` and `mw.util.throttle` not indicating that the function's return type will be discarded.
- Fix `mw.util.getUrl` not allowing parameters to have boolean or number values, while these are explicitely stringified in the function.

## Other changes

- Remove redundant namespace prefixes.
- Remove unused imports.
- Remove `api_params.d.ts` linter exception, so issues (other than `no-empty-interface`) can still be detected.
