### PR TITLE
fix: change Api.AssertUser interface -> type alias

### DIFF
--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -52,10 +52,11 @@ interface EditChangedResult extends EditSuccessResult {
     newtimestamp: string;
 }
 
-interface AssertUser {
+// type alias to fix #45
+type AssertUser = {
     assert: "anon" | "user";
     assertUser: string;
-}
+};
 
 interface WatchStatus {
     ns: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "types-mediawiki",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "types-mediawiki",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@types/jquery": "^3.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "types-mediawiki",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "TypeScript definitions for MediaWiki JS interface",
     "types": "index.d.ts",
     "scripts": {

--- a/test-d/regression/45.test-d.ts
+++ b/test-d/regression/45.test-d.ts
@@ -1,0 +1,10 @@
+// https://github.com/wikimedia-gadgets/types-mediawiki/issues/45
+const api = new mw.Api();
+api.postWithEditToken(
+    api.assertCurrentUser({
+        formatversion: "2",
+        action: "edit",
+        title: "Wikipedia:Sandbox",
+        appendtext: "Test",
+    })
+);


### PR DESCRIPTION
The interface causes issues with satisfying the index signature of `UnknownApiParams` (which is a `Record<string, ...>`). A type alias instead of an interface allows the index signature to work properly. See microsoft/TypeScript#15300

Fixes #45