### PR TITLE
`mediawiki.Api`: Use `AbortablePromise`

### DIFF
--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -151,7 +151,7 @@ declare global {
              *
              * @param {UnknownApiParams} parameters Parameters to the API. See also {@link mw.Api.Options.parameters}.
              * @param {JQuery.AjaxSettings} [ajaxOptions] Parameters to pass to jQuery.ajax. See also {@link mw.Api.Options.ajax}.
-             * @returns {Api.Promise} A promise that settles when the API response is processed.
+             * @returns {Api.AbortablePromise} A promise that settles when the API response is processed.
              *   Has an 'abort' method which can be used to abort the request.
              *
              *   - On success, resolves to `( result, jqXHR )` where `result` is the parsed API response.
@@ -175,7 +175,10 @@ declare global {
              *       {@link JSON.parse}.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#ajax
              */
-            ajax(parameters: UnknownApiParams, ajaxOptions?: JQuery.AjaxSettings): Api.Promise;
+            ajax(
+                parameters: UnknownApiParams,
+                ajaxOptions?: JQuery.AjaxSettings
+            ): Api.AbortablePromise;
 
             /**
              * Extend an API parameter object with an assertion that the user won't change.
@@ -231,7 +234,7 @@ declare global {
              * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
              * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
              * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
-             * @returns {Upload.Promise}
+             * @returns {Upload.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#chunkedUpload
              */
             chunkedUpload(
@@ -239,7 +242,7 @@ declare global {
                 data: ApiUploadParams,
                 chunkSize?: number,
                 chunkRetries?: number
-            ): Upload.Promise;
+            ): Upload.AbortablePromise;
 
             /**
              * Upload a file to the stash, in chunks.
@@ -353,19 +356,22 @@ declare global {
              *
              * @param {UnknownApiParams} parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.Promise}
+             * @returns {Api.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#get
              */
-            get(parameters: UnknownApiParams, ajaxOptions?: JQuery.AjaxSettings): Api.Promise;
+            get(
+                parameters: UnknownApiParams,
+                ajaxOptions?: JQuery.AjaxSettings
+            ): Api.AbortablePromise;
 
             /**
              * Get the categories that a particular page on the wiki belongs to.
              *
              * @param {TitleLike} title
-             * @returns {Api.Promise<[false|Title[]]>} Promise that resolves with an array of category titles, or with false if the title was not found.
+             * @returns {Api.AbortablePromise<[false|Title[]]>} Promise that resolves with an array of category titles, or with false if the title was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getCategories
              */
-            getCategories(title: TitleLike): Api.Promise<[false | Title[]]>;
+            getCategories(title: TitleLike): Api.AbortablePromise<[false | Title[]]>;
 
             /**
              * Get a list of categories that match a certain prefix.
@@ -373,18 +379,18 @@ declare global {
              * E.g. given "Foo", return "Food", "Foolish people", "Foosball tables"...
              *
              * @param {string} prefix Prefix to match.
-             * @returns {Api.Promise<[string[]]>} Promise that resolves with an array of matched categories
+             * @returns {Api.AbortablePromise<[string[]]>} Promise that resolves with an array of matched categories
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getCategoriesByPrefix
              */
-            getCategoriesByPrefix(prefix: string): Api.Promise<[string[]]>;
+            getCategoriesByPrefix(prefix: string): Api.AbortablePromise<[string[]]>;
 
             /**
              * API helper to grab a csrf token.
              *
-             * @returns {Api.Promise<[string]>} Received token.
+             * @returns {Api.AbortablePromise<[string]>} Received token.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getEditToken
              */
-            getEditToken(): Api.Promise<[string]>;
+            getEditToken(): Api.AbortablePromise<[string]>;
 
             /**
              * Given an API response indicating an error, get a jQuery object containing a human-readable
@@ -445,22 +451,22 @@ declare global {
              * @since 1.35 - additional parameters can be passed as an object instead of `assert`.
              * @param {string} type Token type
              * @param {ApiQueryTokensParams|ApiAssert} [additionalParams] Additional parameters for the API. When given a string, it's treated as the `assert` parameter.
-             * @returns {Api.Promise<[string]>} Received token.
+             * @returns {Api.AbortablePromise<[string]>} Received token.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getToken
              */
             getToken(
                 type: ApiTokenType,
                 additionalParams?: ApiQueryTokensParams | ApiAssert
-            ): Api.Promise<[string]>;
+            ): Api.AbortablePromise<[string]>;
             /** @deprecated Use `getToken('csrf')` instead */
             getToken(
                 type: ApiLegacyTokenType,
                 additionalParams?: ApiQueryTokensParams | ApiAssert
-            ): Api.Promise<[string]>;
+            ): Api.AbortablePromise<[string]>;
             getToken(
                 type: string,
                 additionalParams?: ApiQueryTokensParams | ApiAssert
-            ): Api.Promise<[string]>;
+            ): Api.AbortablePromise<[string]>;
 
             /**
              * Get the current user's groups and rights.
@@ -475,10 +481,10 @@ declare global {
              * Determine if a category exists.
              *
              * @param {TitleLike} title
-             * @returns {Api.Promise<[boolean]>} Promise that resolves with a boolean indicating whether the category exists.
+             * @returns {Api.AbortablePromise<[boolean]>} Promise that resolves with a boolean indicating whether the category exists.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#isCategory
              */
-            isCategory(title: TitleLike): Api.Promise<[boolean]>;
+            isCategory(title: TitleLike): Api.AbortablePromise<[boolean]>;
 
             /**
              * Load a set of messages and add them to {@link mw.messages}.
@@ -513,10 +519,10 @@ declare global {
             /**
              * @param {string} username
              * @param {string} password
-             * @returns {Api.Promise<[ApiResponse]>} See {@link post()}
+             * @returns {Api.AbortablePromise<[ApiResponse]>} See {@link post()}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#login
              */
-            login(username: string, password: string): Api.Promise<[ApiResponse]>;
+            login(username: string, password: string): Api.AbortablePromise<[ApiResponse]>;
 
             /**
              * Post a new section to the page.
@@ -525,7 +531,7 @@ declare global {
              * @param {string} header
              * @param {string} message Wikitext message
              * @param {ApiEditPageParams} additionalParams Additional API parameters
-             * @returns {Api.Promise} See {@link postWithEditToken}
+             * @returns {Api.AbortablePromise} See {@link postWithEditToken}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#newSection
              */
             newSection(
@@ -533,7 +539,7 @@ declare global {
                 header: string,
                 message: string,
                 additionalParams?: ApiEditPageParams
-            ): Api.Promise;
+            ): Api.AbortablePromise;
 
             /**
              * Convenience method for `action=parse`.
@@ -541,33 +547,39 @@ declare global {
              * @param {TitleLike} content Content to parse, either as a wikitext string or a {@link mw.Title}
              * @param {ApiParseParams} [additionalParams] Parameters object to set custom settings, e.g.
              *  `redirects`, `sectionpreview`. `prop` should not be overridden.
-             * @returns {Api.Promise<[string]>} Promise that resolves with the parsed HTML of `wikitext`
+             * @returns {Api.AbortablePromise<[string]>} Promise that resolves with the parsed HTML of `wikitext`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#parse
              */
-            parse(content: TitleLike, additionalParams?: ApiParseParams): Api.Promise<[string]>;
+            parse(
+                content: TitleLike,
+                additionalParams?: ApiParseParams
+            ): Api.AbortablePromise<[string]>;
 
             /**
              * Perform API post request. See {@link ajax()} for details.
              *
              * @param {UnknownApiParams} parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.Promise}
+             * @returns {Api.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#post
              */
-            post(parameters: UnknownApiParams, ajaxOptions?: JQuery.AjaxSettings): Api.Promise;
+            post(
+                parameters: UnknownApiParams,
+                ajaxOptions?: JQuery.AjaxSettings
+            ): Api.AbortablePromise;
 
             /**
              * Post to API with csrf token. If we have no token, get one and try to post. If we have a cached token try using that, and if it fails, blank out the cached token and start over.
              *
              * @param {UnknownApiParams} params API parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.Promise} See {@link post}
+             * @returns {Api.AbortablePromise} See {@link post}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#postWithEditToken
              */
             postWithEditToken(
                 params: UnknownApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
-            ): Api.Promise;
+            ): Api.AbortablePromise;
 
             /**
              * Post to API with the specified type of token. If we have no token, get one and try to post.
@@ -586,25 +598,25 @@ declare global {
              * @param {string} tokenType The name of the token, like `options` or `edit`.
              * @param {UnknownApiParams} params API parameters
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.Promise} See {@link post()}
+             * @returns {Api.AbortablePromise} See {@link post()}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#postWithToken
              */
             postWithToken(
                 tokenType: ApiTokenType,
                 params: UnknownApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
-            ): Api.Promise;
+            ): Api.AbortablePromise;
             /** @deprecated Use `postWithToken('csrf', params)` instead */
             postWithToken(
                 tokenType: ApiLegacyTokenType,
                 params: UnknownApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
-            ): Api.Promise;
+            ): Api.AbortablePromise;
             postWithToken(
                 tokenType: string,
                 params: UnknownApiParams,
                 ajaxOptions?: JQuery.AjaxSettings
-            ): Api.Promise;
+            ): Api.AbortablePromise;
 
             /**
              * Convenience method for `action=rollback`.
@@ -667,14 +679,14 @@ declare global {
              * @param {TypeOrArray<TitleLike>} pages Full page name or instance of {@link mw.Title}, or an
              *  array thereof. If an array is passed, the return value passed to the promise will also be an
              *  array of appropriate objects.
-             * @returns {Api.Promise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
+             * @returns {Api.AbortablePromise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
              *  with an object (or array of objects) describing each page that was passed in and its
              *  current watched/unwatched status.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#unwatch
              */
             unwatch<P extends TypeOrArray<TitleLike>>(
                 pages: P
-            ): Api.Promise<[ReplaceValue<P, TitleLike, Api.WatchedPage>]>;
+            ): Api.AbortablePromise<[ReplaceValue<P, TitleLike, Api.WatchedPage>]>;
 
             /**
              * Upload a file to MediaWiki.
@@ -683,10 +695,13 @@ declare global {
              *
              * @param {File|Blob|HTMLInputElement} file HTML `input type=file` element with a file already inside of it, or a File object.
              * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
-             * @returns {Upload.Promise}
+             * @returns {Upload.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#upload
              */
-            upload(file: File | Blob | HTMLInputElement, data: ApiUploadParams): Upload.Promise;
+            upload(
+                file: File | Blob | HTMLInputElement,
+                data: ApiUploadParams
+            ): Upload.AbortablePromise;
 
             /**
              * Finish an upload in the stash.
@@ -739,7 +754,7 @@ declare global {
              *  array of appropriate objects.
              * @param {string} [expiry] When the page should expire from the watchlist. If omitted, the
              *  page will not expire.
-             * @returns {Api.Promise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
+             * @returns {Api.AbortablePromise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
              *  with an object (or array of objects) describing each page that was passed in and its
              *  current watched/unwatched status.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#watch
@@ -747,7 +762,7 @@ declare global {
             watch<P extends TypeOrArray<TitleLike>>(
                 pages: P,
                 expiry?: string
-            ): Api.Promise<[ReplaceValue<P, TitleLike, Api.WatchedPage>]>;
+            ): Api.AbortablePromise<[ReplaceValue<P, TitleLike, Api.WatchedPage>]>;
 
             /**
              * Massage parameters from the nice format we accept into a format suitable for the API.

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -881,6 +881,8 @@ declare global {
             interface Abortable {
                 /**
                  * Cancel the promise, rejecting it and stopping related async operations.
+                 *
+                 * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api-AbortablePromise.html#abort
                  */
                 abort(): void;
             }
@@ -930,6 +932,7 @@ declare global {
              * setTimeout( function() { promise.abort(); }, 500 );
              * // => TypeError: promise.abort is not a function
              * ```
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api-AbortablePromise.html
              */
             interface AbortablePromise<
                 TResolve extends ArgTuple = [ApiResponse, JQuery.jqXHR<ApiResponse>],

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -825,15 +825,16 @@ declare global {
                 watched: boolean;
             }
 
-            type Arg<
-                T extends ArgTuple,
-                N extends number,
-                TAcc extends never[] = []
-            > = false extends (T extends [] ? true : false)
-                ? TAcc["length"] extends N
-                    ? T[0]
-                    : Arg<Tail<T>, N, [...TAcc, never]>
-                : never;
+            /**
+             * Extract an argument type from a promise callback {@link ArgTuple}.
+             */
+            type Arg<T extends ArgTuple, N extends number, TAcc extends never[] = []> = [
+                T
+            ] extends [[]]
+                ? never
+                : TAcc["length"] extends N
+                ? T[0]
+                : Arg<Tail<T>, N, [...TAcc, never]>;
 
             interface PromiseBase<
                 TResolve extends ArgTuple,

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -836,6 +836,11 @@ declare global {
                 ? T[0]
                 : Arg<Tail<T>, N, [...TAcc, never]>;
 
+            /**
+             * Argument tuple for promise callbacks.
+             */
+            type ArgTuple = any[];
+
             interface PromiseBase<
                 TResolve extends ArgTuple,
                 TReject extends ArgTuple,
@@ -850,13 +855,11 @@ declare global {
                         Arg<TResolve, 2>,
                         Arg<TReject, 2>,
                         Arg<TNotify, 2>,
-                        Arg<TResolve, 3>,
-                        Arg<TReject, 3>,
-                        Arg<TNotify, 3>
+                        Tail<Tail<Tail<TResolve>>>[number],
+                        Tail<Tail<Tail<TReject>>>[number],
+                        Tail<Tail<Tail<TNotify>>>[number]
                     >,
                     Pick<JQuery.jqXHR, "abort"> {}
-
-            type ArgTuple = [any?, any?, any?, any?];
 
             type Promise<
                 TResolve extends Api.ArgTuple = [ApiResponse, JQuery.jqXHR<ApiResponse>],

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -52,10 +52,10 @@ declare global {
              *
              * @param {string} path
              * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Rest.Promise} Done: API response data and the jqXHR object.
+             * @returns {Rest.AbortablePromise} Done: API response data and the jqXHR object.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#ajax
              */
-            ajax(path: string, ajaxOptions?: JQuery.AjaxSettings): Rest.Promise;
+            ajax(path: string, ajaxOptions?: JQuery.AjaxSettings): Rest.AbortablePromise;
 
             /**
              * Perform REST API DELETE request.
@@ -66,14 +66,14 @@ declare global {
              * @param {string} path
              * @param {Object.<string, any>} body
              * @param {Object.<string, any>} [headers]
-             * @returns {Rest.Promise}
+             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#delete
              */
             delete(
                 path: string,
                 body: Record<string, any>,
                 headers?: Record<string, any>
-            ): Rest.Promise;
+            ): Rest.AbortablePromise;
 
             /**
              * Perform REST API get request.
@@ -81,14 +81,14 @@ declare global {
              * @param {string} path
              * @param {Object.<string, any>} query
              * @param {Object.<string, any>} [headers]
-             * @returns {Rest.Promise}
+             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#get
              */
             get(
                 path: string,
                 query: Record<string, any>,
                 headers?: Record<string, any>
-            ): Rest.Promise;
+            ): Rest.AbortablePromise;
 
             /**
              * Perform REST API post request.
@@ -99,14 +99,14 @@ declare global {
              * @param {string} path
              * @param {Object.<string, any>} [body]
              * @param {Object.<string, any>} [headers]
-             * @returns {Rest.Promise}
+             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#post
              */
             post(
                 path: string,
                 body?: Record<string, any>,
                 headers?: Record<string, any>
-            ): Rest.Promise;
+            ): Rest.AbortablePromise;
 
             /**
              * Perform REST API PUT request.
@@ -117,14 +117,14 @@ declare global {
              * @param {string} path
              * @param {Object.<string, any>} body
              * @param {Object.<string, any>} [headers]
-             * @returns {Rest.Promise}
+             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#put
              */
             put(
                 path: string,
                 body: Record<string, any>,
                 headers?: Record<string, any>
-            ): Rest.Promise;
+            ): Rest.AbortablePromise;
         }
 
         namespace Rest {
@@ -143,7 +143,13 @@ declare global {
                 TResolve extends Api.ArgTuple = [RestResponse, JQuery.jqXHR<RestResponse>],
                 TReject extends Api.ArgTuple = RejectArgTuple,
                 TNotify extends Api.ArgTuple = []
-            > = Api.PromiseBase<TResolve, TReject, TNotify>;
+            > = Api.Promise<TResolve, TReject, TNotify>;
+
+            type AbortablePromise<
+                TResolve extends Api.ArgTuple = [RestResponse, JQuery.jqXHR<RestResponse>],
+                TReject extends Api.ArgTuple = RejectArgTuple,
+                TNotify extends Api.ArgTuple = []
+            > = Api.AbortablePromise<TResolve, TReject, TNotify>;
 
             type RejectArgTuple = ["http", HttpErrorData];
 


### PR DESCRIPTION
## Context

With MediaWiki 1.44 [abort signals](https://phabricator.wikimedia.org/T346984) will *(or [may not](https://phabricator.wikimedia.org/T383480#10481233))* be introduced, and with these an [`AbortablePromise` type definition](https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api-AbortablePromise.html) will be added.

With PR #51 `mw.Api.Promise`/`mw.Rest.Promise`/`mw.Upload.Promise` type definitions were added to:
- manage promises with multiple callback arguments, and
- provide an `abort` method.

## Proposed changes

To make it clearer with the 1.44 type definition:
- make `mw.Api.Promise`/`mw.Rest.Promise`/`mw.Upload.Promise` only provide the callback argument modification, and
- add `mw.Api.AbortablePromise`/`mw.Rest.AbortablePromise`, extending `mw.Api.Promise`/`mw.Rest.Promise` and providing an `abort` method.