### PR TITLE
`mw.Api`: Narrow `ApiParams` to `UnknownApiParams` (fix #55)

### DIFF
--- a/api_params/index.d.ts
+++ b/api_params/index.d.ts
@@ -1,5 +1,7 @@
 // tslint:disable:no-empty-interface
 
+import { UnknownApiParams } from "../mw/Api";
+
 type timestamp = string;
 type expiry = string;
 type namespace = number;
@@ -32,7 +34,7 @@ export type ApiLegacyTokenType =
     | "protect"
     | "unblock";
 
-export interface ApiParams {
+export interface ApiParams extends UnknownApiParams {
     action?: string;
     format?: "json" | "jsonfm" | "xml" | "xmlfm" | "php" | "none";
     maxlag?: number;

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -16,7 +16,10 @@ type Tail<T extends any[]> = T extends [] ? T : T extends [any?, ...infer R] ? R
 type TypeOrArray<T> = T extends any ? T | T[] : never; // T[] would be a mixed array
 type ReplaceValue<T extends U | U[], U, V> = T extends U[] ? V[] : V;
 
-type UnknownApiParams = Record<string, string | number | boolean | string[] | number[] | undefined>;
+type UnknownApiParams = Record<
+    string,
+    string | number | boolean | File | string[] | number[] | undefined
+>;
 
 export type ApiResponse = Record<string, any>; // it will always be a JSON object, the rest is uncertain ...
 

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -16,7 +16,7 @@ type Tail<T extends any[]> = T extends [] ? T : T extends [any?, ...infer R] ? R
 type TypeOrArray<T> = T extends any ? T | T[] : never; // T[] would be a mixed array
 type ReplaceValue<T extends U | U[], U, V> = T extends U[] ? V[] : V;
 
-type UnknownApiParams = Record<
+export type UnknownApiParams = Record<
     string,
     string | number | boolean | File | string[] | number[] | undefined
 >;

--- a/test-d/regression/55.test-d.ts
+++ b/test-d/regression/55.test-d.ts
@@ -1,0 +1,5 @@
+// https://github.com/wikimedia-gadgets/types-mediawiki/issues/55
+import { ApiUploadParams } from "../../api_params";
+
+const params: ApiUploadParams = {};
+new mw.Api().ajax(params);


### PR DESCRIPTION
A fix for #55:
- Allow `File` object values in `UnknownApiParams`, that `ApiImportParams` and `ApiUploadParams` expect for their `xml`,`file`, and `chunk` parameters.
- Following the discussion from #41 a few weeks ago: in this PR I propose to make `ApiParams` more specific (only allowing values accepted by `UnknownApiParams`). If there is any compatibility issue, we can generalize `UnknownApiParams` to add the missing value types.