### PR TITLE
Make `vue` a peer dependency (fix #56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@types/jquery": "^3.5.5",
-                "@types/oojs-ui": "^0.46.0",
-                "vue": "3.3.9"
+                "@types/oojs-ui": "^0.46.0"
             },
             "devDependencies": {
                 "husky": "^4.3.7",
@@ -20,6 +19,9 @@
                 "tsd": "^0.31.0",
                 "tslint-config-prettier": "^1.18.0",
                 "typescript": "^4.2.2"
+            },
+            "peerDependencies": {
+                "vue": "^3.2.23"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -58,6 +60,7 @@
             "version": "7.24.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
             "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "peer": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -80,7 +83,8 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "peer": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -203,6 +207,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
             "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.23.3",
                 "@vue/shared": "3.3.9",
@@ -214,6 +219,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
             "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-core": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -223,6 +229,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
             "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.23.3",
                 "@vue/compiler-core": "3.3.9",
@@ -240,6 +247,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
             "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -249,6 +257,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
             "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
+            "peer": true,
             "dependencies": {
                 "@vue/shared": "3.3.9"
             }
@@ -257,6 +266,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
             "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.23.3",
                 "@vue/compiler-core": "3.3.9",
@@ -269,6 +279,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
             "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
+            "peer": true,
             "dependencies": {
                 "@vue/reactivity": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -278,6 +289,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
             "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
+            "peer": true,
             "dependencies": {
                 "@vue/runtime-core": "3.3.9",
                 "@vue/shared": "3.3.9",
@@ -288,6 +300,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
             "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-ssr": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -299,7 +312,8 @@
         "node_modules/@vue/shared": {
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
+            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
+            "peer": true
         },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
@@ -586,7 +600,8 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "peer": true
         },
         "node_modules/debug": {
             "version": "4.3.1",
@@ -758,7 +773,8 @@
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "peer": true
         },
         "node_modules/execa": {
             "version": "4.1.0",
@@ -1442,6 +1458,7 @@
             "version": "0.30.10",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
             "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
             }
@@ -1572,6 +1589,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -1765,7 +1783,8 @@
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "peer": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -1894,6 +1913,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -2247,6 +2267,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
             "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2513,6 +2534,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
             "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.3.9",
                 "@vue/compiler-sfc": "3.3.9",
@@ -2645,7 +2667,8 @@
         "@babel/parser": {
             "version": "7.24.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg=="
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "peer": true
         },
         "@jest/schemas": {
             "version": "29.6.3",
@@ -2659,7 +2682,8 @@
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "peer": true
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2770,6 +2794,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
             "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+            "peer": true,
             "requires": {
                 "@babel/parser": "^7.23.3",
                 "@vue/shared": "3.3.9",
@@ -2781,6 +2806,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
             "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+            "peer": true,
             "requires": {
                 "@vue/compiler-core": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -2790,6 +2816,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
             "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
+            "peer": true,
             "requires": {
                 "@babel/parser": "^7.23.3",
                 "@vue/compiler-core": "3.3.9",
@@ -2807,6 +2834,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
             "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+            "peer": true,
             "requires": {
                 "@vue/compiler-dom": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -2816,6 +2844,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
             "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
+            "peer": true,
             "requires": {
                 "@vue/shared": "3.3.9"
             }
@@ -2824,6 +2853,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
             "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
+            "peer": true,
             "requires": {
                 "@babel/parser": "^7.23.3",
                 "@vue/compiler-core": "3.3.9",
@@ -2836,6 +2866,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
             "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
+            "peer": true,
             "requires": {
                 "@vue/reactivity": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -2845,6 +2876,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
             "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
+            "peer": true,
             "requires": {
                 "@vue/runtime-core": "3.3.9",
                 "@vue/shared": "3.3.9",
@@ -2855,6 +2887,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
             "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+            "peer": true,
             "requires": {
                 "@vue/compiler-ssr": "3.3.9",
                 "@vue/shared": "3.3.9"
@@ -2863,7 +2896,8 @@
         "@vue/shared": {
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
+            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
+            "peer": true
         },
         "aggregate-error": {
             "version": "3.1.0",
@@ -3080,7 +3114,8 @@
         "csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "peer": true
         },
         "debug": {
             "version": "4.3.1",
@@ -3212,7 +3247,8 @@
         "estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "peer": true
         },
         "execa": {
             "version": "4.1.0",
@@ -3704,6 +3740,7 @@
             "version": "0.30.10",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
             "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "peer": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
             }
@@ -3796,7 +3833,8 @@
         "nanoid": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "peer": true
         },
         "normalize-package-data": {
             "version": "3.0.3",
@@ -3930,7 +3968,8 @@
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "peer": true
         },
         "picomatch": {
             "version": "2.3.1",
@@ -4008,6 +4047,7 @@
             "version": "8.4.38",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
             "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "peer": true,
             "requires": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -4253,7 +4293,8 @@
         "source-map-js": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "peer": true
         },
         "spdx-correct": {
             "version": "3.2.0",
@@ -4454,6 +4495,7 @@
             "version": "3.3.9",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
             "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
+            "peer": true,
             "requires": {
                 "@vue/compiler-dom": "3.3.9",
                 "@vue/compiler-sfc": "3.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "typescript": "^4.2.2"
             },
             "peerDependencies": {
-                "vue": "^3.2.23"
+                "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,11 @@
             },
             "peerDependencies": {
                 "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
+            },
+            "peerDependenciesMeta": {
+                "vue": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@babel/code-frame": {
@@ -37,6 +42,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
             "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "optional": true,
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -46,6 +52,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
             "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "devOptional": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -71,6 +78,7 @@
             "version": "7.26.9",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
             "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@babel/types": "^7.26.9"
@@ -86,6 +94,7 @@
             "version": "7.26.9",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
             "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -111,6 +120,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "optional": true,
             "peer": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -234,6 +244,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
             "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.24.4",
@@ -247,6 +258,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
             "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/compiler-core": "3.4.27",
@@ -257,6 +269,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
             "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.24.4",
@@ -274,6 +287,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
             "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.4.27",
@@ -284,6 +298,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
             "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/shared": "3.4.27"
@@ -293,6 +308,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
             "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/reactivity": "3.4.27",
@@ -303,6 +319,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
             "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/runtime-core": "3.4.27",
@@ -314,6 +331,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
             "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/compiler-ssr": "3.4.27",
@@ -327,6 +345,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
             "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
+            "optional": true,
             "peer": true
         },
         "node_modules/aggregate-error": {
@@ -615,6 +634,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "optional": true,
             "peer": true
         },
         "node_modules/debug": {
@@ -726,6 +746,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "optional": true,
             "peer": true,
             "engines": {
                 "node": ">=0.12"
@@ -800,6 +821,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "optional": true,
             "peer": true
         },
         "node_modules/execa": {
@@ -1484,6 +1506,7 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -1615,6 +1638,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "optional": true,
             "peer": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -1810,6 +1834,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "optional": true,
             "peer": true
         },
         "node_modules/picomatch": {
@@ -1939,6 +1964,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
@@ -2293,6 +2319,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "optional": true,
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2560,6 +2587,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
             "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.4.27",
@@ -2669,12 +2697,14 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
             "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "optional": true,
             "peer": true
         },
         "@babel/helper-validator-identifier": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "devOptional": true
         },
         "@babel/highlight": {
             "version": "7.13.10",
@@ -2699,6 +2729,7 @@
             "version": "7.26.9",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
             "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@babel/types": "^7.26.9"
@@ -2708,6 +2739,7 @@
             "version": "7.26.9",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
             "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -2727,6 +2759,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "optional": true,
             "peer": true
         },
         "@nodelib/fs.scandir": {
@@ -2838,6 +2871,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
             "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@babel/parser": "^7.24.4",
@@ -2851,6 +2885,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
             "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/compiler-core": "3.4.27",
@@ -2861,6 +2896,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
             "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@babel/parser": "^7.24.4",
@@ -2878,6 +2914,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
             "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/compiler-dom": "3.4.27",
@@ -2888,6 +2925,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
             "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/shared": "3.4.27"
@@ -2897,6 +2935,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
             "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/reactivity": "3.4.27",
@@ -2907,6 +2946,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
             "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/runtime-core": "3.4.27",
@@ -2918,6 +2958,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
             "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/compiler-ssr": "3.4.27",
@@ -2928,6 +2969,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
             "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
+            "optional": true,
             "peer": true
         },
         "aggregate-error": {
@@ -3146,6 +3188,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "optional": true,
             "peer": true
         },
         "debug": {
@@ -3230,6 +3273,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "optional": true,
             "peer": true
         },
         "error-ex": {
@@ -3285,6 +3329,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "optional": true,
             "peer": true
         },
         "execa": {
@@ -3777,6 +3822,7 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -3871,6 +3917,7 @@
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
             "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "optional": true,
             "peer": true
         },
         "normalize-package-data": {
@@ -4006,6 +4053,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "optional": true,
             "peer": true
         },
         "picomatch": {
@@ -4084,6 +4132,7 @@
             "version": "8.5.3",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
             "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "nanoid": "^3.3.8",
@@ -4331,6 +4380,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "optional": true,
             "peer": true
         },
         "spdx-correct": {
@@ -4532,6 +4582,7 @@
             "version": "3.4.27",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
             "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+            "optional": true,
             "peer": true,
             "requires": {
                 "@vue/compiler-dom": "3.4.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,22 @@
                 "@babel/highlight": "^7.12.13"
             }
         },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "peer": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-            "dev": true
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
         },
         "node_modules/@babel/highlight": {
             "version": "7.13.10",
@@ -57,15 +68,31 @@
             "dev": true
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+            "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
             "peer": true,
+            "dependencies": {
+                "@babel/types": "^7.26.9"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+            "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@jest/schemas": {
@@ -81,9 +108,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "peer": true
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -204,115 +231,102 @@
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
-            "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+            "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.23.3",
-                "@vue/shared": "3.3.9",
+                "@babel/parser": "^7.24.4",
+                "@vue/shared": "3.4.27",
+                "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
-            "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+            "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-core": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-core": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
-            "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+            "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.23.3",
-                "@vue/compiler-core": "3.3.9",
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/compiler-ssr": "3.3.9",
-                "@vue/reactivity-transform": "3.3.9",
-                "@vue/shared": "3.3.9",
+                "@babel/parser": "^7.24.4",
+                "@vue/compiler-core": "3.4.27",
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/compiler-ssr": "3.4.27",
+                "@vue/shared": "3.4.27",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5",
-                "postcss": "^8.4.31",
-                "source-map-js": "^1.0.2"
+                "magic-string": "^0.30.10",
+                "postcss": "^8.4.38",
+                "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
-            "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+            "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
-            "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+            "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
             "peer": true,
             "dependencies": {
-                "@vue/shared": "3.3.9"
-            }
-        },
-        "node_modules/@vue/reactivity-transform": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
-            "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.23.3",
-                "@vue/compiler-core": "3.3.9",
-                "@vue/shared": "3.3.9",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5"
+                "@vue/shared": "3.4.27"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
-            "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+            "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
             "peer": true,
             "dependencies": {
-                "@vue/reactivity": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/reactivity": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
-            "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+            "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
             "peer": true,
             "dependencies": {
-                "@vue/runtime-core": "3.3.9",
-                "@vue/shared": "3.3.9",
-                "csstype": "^3.1.2"
+                "@vue/runtime-core": "3.4.27",
+                "@vue/shared": "3.4.27",
+                "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
-            "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+            "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-ssr": "3.4.27",
+                "@vue/shared": "3.4.27"
             },
             "peerDependencies": {
-                "vue": "3.3.9"
+                "vue": "3.4.27"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+            "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
             "peer": true
         },
         "node_modules/aggregate-error": {
@@ -706,6 +720,18 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -1455,12 +1481,12 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.10",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "peer": true,
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/map-obj": {
@@ -1580,9 +1606,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
@@ -1781,9 +1807,9 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "peer": true
         },
         "node_modules/picomatch": {
@@ -1896,9 +1922,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.38",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1915,9 +1941,9 @@
             ],
             "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.2.0"
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -2264,9 +2290,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2531,16 +2557,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
-            "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+            "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
             "peer": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/compiler-sfc": "3.3.9",
-                "@vue/runtime-dom": "3.3.9",
-                "@vue/server-renderer": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/compiler-sfc": "3.4.27",
+                "@vue/runtime-dom": "3.4.27",
+                "@vue/server-renderer": "3.4.27",
+                "@vue/shared": "3.4.27"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -2639,11 +2665,16 @@
                 "@babel/highlight": "^7.12.13"
             }
         },
+        "@babel/helper-string-parser": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "peer": true
+        },
         "@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-            "dev": true
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="
         },
         "@babel/highlight": {
             "version": "7.13.10",
@@ -2665,10 +2696,23 @@
             }
         },
         "@babel/parser": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-            "peer": true
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+            "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+            "peer": true,
+            "requires": {
+                "@babel/types": "^7.26.9"
+            }
+        },
+        "@babel/types": {
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+            "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+            "peer": true,
+            "requires": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            }
         },
         "@jest/schemas": {
             "version": "29.6.3",
@@ -2680,9 +2724,9 @@
             }
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "peer": true
         },
         "@nodelib/fs.scandir": {
@@ -2791,112 +2835,99 @@
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
         },
         "@vue/compiler-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
-            "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+            "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
             "peer": true,
             "requires": {
-                "@babel/parser": "^7.23.3",
-                "@vue/shared": "3.3.9",
+                "@babel/parser": "^7.24.4",
+                "@vue/shared": "3.4.27",
+                "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             }
         },
         "@vue/compiler-dom": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
-            "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+            "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
             "peer": true,
             "requires": {
-                "@vue/compiler-core": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-core": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
-            "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+            "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
             "peer": true,
             "requires": {
-                "@babel/parser": "^7.23.3",
-                "@vue/compiler-core": "3.3.9",
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/compiler-ssr": "3.3.9",
-                "@vue/reactivity-transform": "3.3.9",
-                "@vue/shared": "3.3.9",
+                "@babel/parser": "^7.24.4",
+                "@vue/compiler-core": "3.4.27",
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/compiler-ssr": "3.4.27",
+                "@vue/shared": "3.4.27",
                 "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5",
-                "postcss": "^8.4.31",
-                "source-map-js": "^1.0.2"
+                "magic-string": "^0.30.10",
+                "postcss": "^8.4.38",
+                "source-map-js": "^1.2.0"
             }
         },
         "@vue/compiler-ssr": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
-            "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+            "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "@vue/reactivity": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
-            "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+            "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
             "peer": true,
             "requires": {
-                "@vue/shared": "3.3.9"
-            }
-        },
-        "@vue/reactivity-transform": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
-            "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
-            "peer": true,
-            "requires": {
-                "@babel/parser": "^7.23.3",
-                "@vue/compiler-core": "3.3.9",
-                "@vue/shared": "3.3.9",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.5"
+                "@vue/shared": "3.4.27"
             }
         },
         "@vue/runtime-core": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
-            "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+            "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
             "peer": true,
             "requires": {
-                "@vue/reactivity": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/reactivity": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "@vue/runtime-dom": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
-            "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+            "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
             "peer": true,
             "requires": {
-                "@vue/runtime-core": "3.3.9",
-                "@vue/shared": "3.3.9",
-                "csstype": "^3.1.2"
+                "@vue/runtime-core": "3.4.27",
+                "@vue/shared": "3.4.27",
+                "csstype": "^3.1.3"
             }
         },
         "@vue/server-renderer": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
-            "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+            "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
             "peer": true,
             "requires": {
-                "@vue/compiler-ssr": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-ssr": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "@vue/shared": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-            "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+            "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
             "peer": true
         },
         "aggregate-error": {
@@ -3194,6 +3225,12 @@
             "requires": {
                 "ansi-colors": "^4.1.1"
             }
+        },
+        "entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "peer": true
         },
         "error-ex": {
             "version": "1.3.2",
@@ -3737,12 +3774,12 @@
             }
         },
         "magic-string": {
-            "version": "0.30.10",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "peer": true,
             "requires": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "map-obj": {
@@ -3831,9 +3868,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "peer": true
         },
         "normalize-package-data": {
@@ -3966,9 +4003,9 @@
             "dev": true
         },
         "picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "peer": true
         },
         "picomatch": {
@@ -4044,14 +4081,14 @@
             }
         },
         "postcss": {
-            "version": "8.4.38",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "peer": true,
             "requires": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.2.0"
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             }
         },
         "prettier": {
@@ -4291,9 +4328,9 @@
             }
         },
         "source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "peer": true
         },
         "spdx-correct": {
@@ -4492,16 +4529,16 @@
             }
         },
         "vue": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
-            "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
+            "version": "3.4.27",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+            "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
             "peer": true,
             "requires": {
-                "@vue/compiler-dom": "3.3.9",
-                "@vue/compiler-sfc": "3.3.9",
-                "@vue/runtime-dom": "3.3.9",
-                "@vue/server-renderer": "3.3.9",
-                "@vue/shared": "3.3.9"
+                "@vue/compiler-dom": "3.4.27",
+                "@vue/compiler-sfc": "3.4.27",
+                "@vue/runtime-dom": "3.4.27",
+                "@vue/server-renderer": "3.4.27",
+                "@vue/shared": "3.4.27"
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "homepage": "https://github.com/wikimedia-gadgets/types-mediawiki#readme",
     "dependencies": {
         "@types/jquery": "^3.5.5",
-        "@types/oojs-ui": "^0.46.0",
-        "vue": "3.3.9"
+        "@types/oojs-ui": "^0.46.0"
+    },
+    "peerDependencies": {
+        "vue": "^3.2.23"
     },
     "devDependencies": {
         "husky": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     "peerDependencies": {
         "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
     },
+    "peerDependenciesMeta": {
+        "vue": {
+            "optional": true
+        }
+    },
     "devDependencies": {
         "husky": "^4.3.7",
         "lint-staged": "^10.5.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@types/oojs-ui": "^0.46.0"
     },
     "peerDependencies": {
-        "vue": "^3.2.23"
+        "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
     },
     "devDependencies": {
         "husky": "^4.3.7",

--- a/vue/index.d.ts
+++ b/vue/index.d.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { createApp } from "vue";
 
 export * from "vue";


### PR DESCRIPTION
A fix for #56: Make the `vue` package a peer dependency instead of a normal one.

MediaWiki releases prior to 1.38 used vue 2, and types provided in this package are currently not compatible with it, so also widen the package version range to `^3.2.23` (used by MW 1.38).