### PR TITLE
Remove deprecated type aliases from 1.8.0

### DIFF
--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -949,11 +949,6 @@ declare global {
                       JQuery.jqXHR<"" | null | undefined>
                   ]
                 | [string, ApiResponse, ApiResponse, JQuery.jqXHR<ApiResponse>];
-
-            namespace Promise {
-                /** @deprecated Use {@link Upload.Promise} instead. */
-                type Upload<TResolve extends ArgTuple = [ApiResponse]> = Upload.Promise<TResolve>;
-            }
         }
 
         namespace Upload {

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -972,7 +972,4 @@ declare global {
     }
 }
 
-/** @deprecated Use `mw.Api.Options` instead. Note that `ApiOptions` is strictly equivalent to `Required<mw.Api.Options>` as properties are now optional for consistency. */
-export type ApiOptions = Required<mw.Api.Options>;
-
 export {};

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -68,7 +68,4 @@ declare global {
     }
 }
 
-/** @deprecated Use `mw.ForeignApi.Options` instead. Note that `ForeignApiOptions` is strictly equivalent to `Required<mw.ForeignApi.Options>` as properties are now optional for consistency. */
-export type ForeignApiOptions = Required<mw.ForeignApi.Options>;
-
 export {};

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -162,7 +162,4 @@ declare global {
     }
 }
 
-/** @deprecated Use `mw.Rest.Options` instead. Note that `RestOptions` is strictly equivalent to `Required<mw.Rest.Options>` as properties are now optional for consistency. */
-export type RestOptions = Required<mw.Rest.Options>;
-
 export {};

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -246,7 +246,4 @@ declare global {
     }
 }
 
-/** @deprecated Use `mw.Api.UserInfo` instead. */
-export type UserInfo = mw.Api.UserInfo;
-
 export {};


### PR DESCRIPTION
In MediaWiki 1.42 some type declarations were added to the mw core JSdoc. Consequently, with [release 1.8.0](https://github.com/wikimedia-gadgets/types-mediawiki/releases/tag/1.8.0) from May 2024 some exported types were moved to the global scope to match the mw core declarations. This includes:

- `ApiOptions` from `types-mediawiki/mw/Api`, exposed as `mw.Api.Options`,
- `ForeignApiOptions` from `types-mediawiki/mw/ForeignApi`, exposed as `mw.ForeignApi.Options`,
- `RestOptions` from `types-mediawiki/mw/Rest`, exposed as `mw.Rest.Options`, and
- `UserInfo` from `types-mediawiki/mw/user`, exposed as `mw.Api.UserInfo`.

Now that we are going to increase the major release version number, this PR is about removing these (deprecated) exported type aliases.