### PR TITLE
Remove JSdoc type annotations (fix #17)

### DIFF
--- a/jquery/client.d.ts
+++ b/jquery/client.d.ts
@@ -38,9 +38,9 @@ interface Client {
      *     // This will only run in Gecko browsers on Linux.
      * }
      * ```
-     * @param {ClientNavigator} [nav] An object with a 'userAgent' and 'platform' property.
+     * @param nav An object with a 'userAgent' and 'platform' property.
      *  Defaults to the global `navigator` object.
-     * @returns {ClientProfile} The client object
+     * @returns The client object
      * @see https://doc.wikimedia.org/jquery-client/master/jQuery.client.html#.profile
      */
     profile(nav?: ClientNavigator): ClientProfile;
@@ -81,11 +81,11 @@ interface Client {
      * }
      * ```
      *
-     * @param {ClientSupportMap} map Browser support map
-     * @param {ClientProfile} [profile] A client-profile object
-     * @param {boolean} [exactMatchOnly=false] Only return true if the browser is matched,
+     * @param map Browser support map
+     * @param profile A client-profile object
+     * @param exactMatchOnly Only return true if the browser is matched,
      *  otherwise returns true if the browser is not found.
-     * @returns {boolean} The current browser is in the support map
+     * @returns The current browser is in the support map
      * @see https://doc.wikimedia.org/jquery-client/master/jQuery.client.html#.test
      */
     test(map: ClientSupportMap, profile?: ClientProfile, exactMatchOnly?: boolean): boolean;

--- a/jquery/colorUtil.d.ts
+++ b/jquery/colorUtil.d.ts
@@ -33,9 +33,9 @@ interface ColorUtil {
      * // > "rgb(118,29,29)"
      * ```
      *
-     * @param {Color|string} currentColor Current value in css
-     * @param {number} mod Wanted brightness modification between -1 and 1
-     * @returns {string} Like `'rgb(r,g,b)'`
+     * @param currentColor Current value in css
+     * @param mod Wanted brightness modification between -1 and 1
+     * @returns Like `'rgb(r,g,b)'`
      * @see https://doc.wikimedia.org/mediawiki-core/REL1_40/js/#!/api/jQuery.colorUtil-method-getColorBrightness
      */
     getColorBrightness(
@@ -49,8 +49,6 @@ interface ColorUtil {
      * Based on highlightFade by Blair Mitchelmore
      * {@link http://jquery.offput.ca/highlightFade/}
      *
-     * @param {Color|string} color
-     * @returns {Color}
      * @see https://doc.wikimedia.org/mediawiki-core/REL1_40/js/#!/api/jQuery.colorUtil-method-getRGB
      */
     getRGB<T extends Color>(color: string | T): T;
@@ -66,10 +64,10 @@ interface ColorUtil {
      * Assumes `h`, `s`, and `l` are contained in the set `[0, 1]` and
      * returns `r`, `g`, and `b` in the set `[0, 255]`.
      *
-     * @param {number} h The hue
-     * @param {number} s The saturation
-     * @param {number} l The lightness
-     * @returns {Color} The RGB representation
+     * @param h The hue
+     * @param s The saturation
+     * @param l The lightness
+     * @returns The RGB representation
      * @see https://doc.wikimedia.org/mediawiki-core/REL1_40/js/#!/api/jQuery.colorUtil-method-hslToRgb
      */
     hslToRgb(h: number, s: number, l: number): Color;
@@ -85,10 +83,10 @@ interface ColorUtil {
      * Assumes `r`, `g`, and `b` are contained in the set `[0, 255]` and
      * returns `h`, `s`, and `l` in the set `[0, 1]`.
      *
-     * @param {number} r The red color value
-     * @param {number} g The green color value
-     * @param {number} b The blue color value
-     * @returns {Color} The HSL representation
+     * @param r The red color value
+     * @param g The green color value
+     * @param b The blue color value
+     * @returns The HSL representation
      * @see https://doc.wikimedia.org/mediawiki-core/REL1_40/js/#!/api/jQuery.colorUtil-method-rgbToHsl
      */
     rgbToHsl(r: number, g: number, b: number): Color;

--- a/jquery/confirmable.d.ts
+++ b/jquery/confirmable.d.ts
@@ -35,9 +35,6 @@ type RequiredOrUndefined<T> = {
 };
 
 interface Confirmable {
-    /**
-     * @param {Options} [options]
-     */
     (options?: Options): this;
 
     /**

--- a/jquery/cookie.d.ts
+++ b/jquery/cookie.d.ts
@@ -11,12 +11,12 @@ declare global {
          *     $.cookie( 'name', 'value', {} );
          * } );
          * ```
-         * @param {string} [key] Cookie name or (when getting) omit to return an object with all
+         * @param key Cookie name or (when getting) omit to return an object with all
          *  current cookie keys and values.
-         * @param {string|null} [value] Cookie value to set. If `null`, this method will remove the cookie.
+         * @param value Cookie value to set. If `null`, this method will remove the cookie.
          *  If omited, this method will get and return the current value.
-         * @param {mw.cookie.CookieOptions} [options]
-         * @returns {string|Object} The current value (if getting a cookie), or an internal `document.cookie`
+         * @param options
+         * @returns The current value (if getting a cookie), or an internal `document.cookie`
          *  expression (if setting or removing).
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.cookie.html#.$.cookie
          */
@@ -35,9 +35,9 @@ declare global {
          *     $.removeCookie( 'name', {} );
          * } );
          * ```
-         * @param {string} key
-         * @param {mw.cookie.CookieOptions} options
-         * @returns {boolean} True if the cookie previously existed
+         * @param key
+         * @param options
+         * @returns True if the cookie previously existed
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.cookie.html#.$.removeCookie
          */
         removeCookie(key: string, options: mw.cookie.CookieOptions): boolean;

--- a/jquery/footHovzer.d.ts
+++ b/jquery/footHovzer.d.ts
@@ -10,7 +10,6 @@ declare global {
          * hovzer.update();
          * ```
          * @private
-         * @returns {FootHovzer}
          */
         getFootHovzer(): FootHovzer;
     }

--- a/jquery/highlightText.d.ts
+++ b/jquery/highlightText.d.ts
@@ -17,9 +17,8 @@ declare global {
          *     $( '#bodyContent' ).highlightText( 'bear' );
          * } );
          * ```
-         * @param {string} matchString String to match
-         * @param {Options} [options]
-         * @returns {JQuery}
+         * @param matchString String to match
+         * @param options
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.highlightText.html#.$.fn.highlightText
          */
         highlightText(matchString: string, options?: Options): this;

--- a/jquery/htmlform.d.ts
+++ b/jquery/htmlform.d.ts
@@ -3,8 +3,6 @@ declare global {
         /**
          * jQuery plugin to fade or snap to visible state.
          *
-         * @param {boolean} [instantToggle=false]
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/REL1_42/js/jQueryPlugins.html#.goIn
          */
         goIn(instantToggle?: boolean): this;
@@ -12,8 +10,6 @@ declare global {
         /**
          * jQuery plugin to fade or snap to hiding state.
          *
-         * @param {boolean} [instantToggle=false]
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/REL1_42/js/jQueryPlugins.html#.goOut
          */
         goOut(instantToggle?: boolean): this;

--- a/jquery/lengthLimit.d.ts
+++ b/jquery/lengthLimit.d.ts
@@ -9,12 +9,11 @@ declare global {
          * native maxlength by reconstructing where the insertion occurred.
          *
          * @deprecated Use `require( 'mediawiki.String' ).trimByteLength` instead.
-         * @param {string} safeVal Known value that was previously returned by this
+         * @param safeVal Known value that was previously returned by this
          * function, if none, pass empty string.
-         * @param {string} newVal New value that may have to be trimmed down.
-         * @param {number} byteLimit Number of bytes the value may be in size.
-         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
-         * @returns {TrimResult}
+         * @param newVal New value that may have to be trimmed down.
+         * @param byteLimit Number of bytes the value may be in size.
+         * @param filterFunction Function to call on the string before assessing the length.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.lengthLimit.html#.'$.fn.trimByteLength'
          */
         trimByteLength(
@@ -36,10 +35,9 @@ declare global {
          * value), a filter function (in case the limit should apply to something other than the
          * exact input value), or both. Order of parameters is important!
          *
-         * @param {number} [limit] Limit to enforce, fallsback to maxLength-attribute,
+         * @param limit Limit to enforce, fallsback to maxLength-attribute,
          *  called with fetched value as argument.
-         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
-         * @returns {JQuery}
+         * @param filterFunction Function to call on the string before assessing the length.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.lengthLimit.html#.$.fn.byteLimit
          */
         byteLimit(limit: number, filterFunction?: FilterFunction): this;
@@ -58,10 +56,9 @@ declare global {
          * value), a filter function (in case the limit should apply to something other than the
          * exact input value), or both. Order of parameters is important!
          *
-         * @param {number} [limit] Limit to enforce, fallsback to maxLength-attribute,
+         * @param limit Limit to enforce, fallsback to maxLength-attribute,
          *  called with fetched value as argument.
-         * @param {FilterFunction} [filterFunction] Function to call on the string before assessing the length.
-         * @returns {JQuery}
+         * @param filterFunction Function to call on the string before assessing the length.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.lengthLimit.html#.$.fn.codePointLimit
          */
         codePointLimit(limit: number, filterFunction?: FilterFunction): this;

--- a/jquery/makeCollapsible.d.ts
+++ b/jquery/makeCollapsible.d.ts
@@ -17,8 +17,6 @@ declare global {
          *     $( 'table' ).makeCollapsible();
          * } );
          * ```
-         * @param {Options} [options]
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.makeCollapsible.html#.$.fn.makeCollapsible
          */
         makeCollapsible(options?: Options): this;

--- a/jquery/spinner.d.ts
+++ b/jquery/spinner.d.ts
@@ -33,9 +33,8 @@ declare global {
          * ```
          *
          * @ignore
-         * @param {string|Options} [opts] Options. If a string is given, it will be treated as the value
+         * @param opts Options. If a string is given, it will be treated as the value
          *  of the {@link Options.id id} option.
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.spinner.html#.createSpinner
          */
         createSpinner(opts?: string | Options): JQuery;
@@ -44,8 +43,8 @@ declare global {
          * Remove a spinner element.
          *
          * @ignore
-         * @param {string} id Id of the spinner, as passed to {@link createSpinner}
-         * @returns {JQuery} The (now detached) spinner element
+         * @param id Id of the spinner, as passed to {@link createSpinner}
+         * @returns The (now detached) spinner element
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.spinner.html#.removeSpinner
          */
         removeSpinner(id: string): JQuery;
@@ -59,9 +58,8 @@ declare global {
          * Inserts spinner as siblings (not children) of the target elements.
          * Collection contents remain unchanged.
          *
-         * @param {string|Options} [opts] Options. If a string is given, it will be treated as the value
+         * @param opts Options. If a string is given, it will be treated as the value
          *  of the {@link Options.id id} option.
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.spinner.html#.$.fn.injectSpinner
          */
         injectSpinner(opts?: string | Options): this;

--- a/jquery/suggestions.d.ts
+++ b/jquery/suggestions.d.ts
@@ -18,9 +18,8 @@ declare global {
          * $( '#textbox' ).suggestions( { option1: value1, option2: value2 } );
          * $( '#textbox' ).suggestions( option, value );
          * ```
-         * @param {string} property Name of property
-         * @param {any} value Value to set property with
-         * @returns {JQuery}
+         * @param property Name of property
+         * @param value Value to set property with
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.suggestions.html#.$.fn.suggestions
          */
         suggestions<K extends keyof Options<T>, T = any>(property: K, value: Options<T>[K]): this;
@@ -68,9 +67,9 @@ interface Options<T = any> {
     /**
      * Callback that should fetch suggestions and set the suggestions property. Called in context of the text box.
      *
-     * @param {string} query
-     * @param {function(string[],any):void} response Callback to receive the suggestions with
-     * @param {number} maxRows
+     * @param query
+     * @param response Callback to receive the suggestions with
+     * @param maxRows
      */
     fetch(
         this: JQuery,

--- a/jquery/tablesorter.d.ts
+++ b/jquery/tablesorter.d.ts
@@ -17,8 +17,6 @@ declare global {
          * $( 'table' ).tablesorter( { sortList: [ { 0: 'desc' }, { 1: 'asc' } ] } );
          * ```
          *
-         * @param {TableSorterOptions} settings
-         * @returns {JQuery}
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.tablesorter.html#.$.fn.tablesorter
          */
         tablesorter(this: JQuery<HTMLTableElement>, settings?: TableSorterOptions): this;

--- a/jquery/textSelection.d.ts
+++ b/jquery/textSelection.d.ts
@@ -4,8 +4,7 @@ declare global {
          * Get the contents of the textarea.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @returns {string}
+         * @param command Command to execute
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.getContents
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -15,9 +14,8 @@ declare global {
          * Set the contents of the textarea, replacing anything that was there before.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {string} content
-         * @returns {JQuery}
+         * @param command Command to execute
+         * @param content
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.setContents
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -27,8 +25,7 @@ declare global {
          * Get the currently selected text in this textarea.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @returns {string}
+         * @param command Command to execute
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.getSelection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -38,9 +35,8 @@ declare global {
          * Replace the selected text in the textarea with the given text, or insert it at the cursor.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {string} value
-         * @returns {JQuery}
+         * @param command Command to execute
+         * @param value
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.replaceSelection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -53,9 +49,8 @@ declare global {
          *
          * Also focusses the textarea.
          *
-         * @param {string} command Command to execute
-         * @param {TextSelectionEncapsulateOptions} [options]
-         * @returns {JQuery}
+         * @param command Command to execute
+         * @param options
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.encapsulateSelection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -68,9 +63,9 @@ declare global {
          * Get the current cursor position (in UTF-16 code units) in a textarea.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {GetCaretPositionOptions} [options]
-         * @returns {number|number[]} Array with two numbers, for start and end of selection
+         * @param command Command to execute
+         * @param options
+         * @returns Array with two numbers, for start and end of selection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.getCaretPosition
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -91,9 +86,8 @@ declare global {
          * Set the current cursor position (in UTF-16 code units) in a textarea.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {SetSelectionOptions} options
-         * @returns {JQuery}
+         * @param command Command to execute
+         * @param options
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.setSelection
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -104,9 +98,8 @@ declare global {
          * position with 'setSelection'.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {ScrollToCaretPositionOptions} [options]
-         * @returns {JQuery}
+         * @param command Command to execute
+         * @param options
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.scrollToCaretPosition
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -119,8 +112,8 @@ declare global {
          * Register an alternative textSelection API for this element.
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
-         * @param {Object.<string, function(unknown):void>} functions Functions to replace. Keys are command names (as in {@link textSelection},
+         * @param command Command to execute
+         * @param functions Functions to replace. Keys are command names (as in {@link textSelection},
          *  except 'register' and 'unregister'). Values are functions to execute when a given command is
          *  called.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.register
@@ -135,7 +128,7 @@ declare global {
          * Unregister the alternative textSelection API for this element (see 'register').
          * Provided by the `jquery.textSelection` ResourceLoader module.
          *
-         * @param {string} command Command to execute
+         * @param command Command to execute
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.unregister
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
@@ -151,9 +144,9 @@ declare global {
          *     const contents = $( 'textarea' ).textSelection( 'getContents' );
          * } );
          * ```
-         * @param {string} command Command to execute
-         * @param {any} [commandOptions] Options to pass to the command
-         * @returns {any} Depending on the command
+         * @param command Command to execute
+         * @param commandOptions Options to pass to the command
+         * @returns Depending on the command
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-jquery.textSelection.html#.$.fn.textSelection
          */
         textSelection(command: string, commandOptions?: unknown): any;

--- a/jquery/tipsy.d.ts
+++ b/jquery/tipsy.d.ts
@@ -27,10 +27,10 @@ interface JQueryTipsy<T = HTMLElement> {
      * Yields a closure of the supplied parameters, producing a function that takes
      * no arguments and is suitable for use as an autogravity function like so:
      *
-     * @param {number} margin (int) - distance from the viewable region edge that an
+     * @param margin (int) - distance from the viewable region edge that an
      *  element should be before setting its tooltip's gravity to be away
      *  from that edge.
-     * @param {Direction} prefer (string, e.g. `n`, `sw`, `w`) - the direction to prefer
+     * @param prefer (string, e.g. `n`, `sw`, `w`) - the direction to prefer
      *  if there are no viewable region edges effecting the tooltip's
      *  gravity. It will try to vary from this minimally, for example,
      *  if `sw` is preferred and an element is near the right viewable

--- a/jquery/updateTooltipAccessKeys.d.ts
+++ b/jquery/updateTooltipAccessKeys.d.ts
@@ -22,7 +22,6 @@ interface TooltipAccessKeys<This = JQuery> {
      *     $a.updateTooltipAccessKeys();
      * } );
      * ```
-     * @returns {JQuery}
      * @see https://doc.wikimedia.org/mediawiki-core/REL1_42/js/jQueryPlugins.html#.updateTooltipAccessKeys
      */
     (): This;
@@ -33,22 +32,21 @@ interface TooltipAccessKeys<This = JQuery> {
      * Will use native accessKeyLabel if available (currently only in Firefox 8+),
      * falls back to #getAccessKeyModifiers.
      *
-     * @param {HTMLElement} element Element to get the label for
-     * @returns {string} Access key label
+     * @param element Element to get the label for
+     * @returns Access key label
      */
     // result may be HTMLElement.accessKeyLabel, the format of which depend very much on the browser.
     getAccessKeyLabel(element: HTMLElement): string;
 
     /**
-     * @param {ClientNavigator} [nav] An object with a 'userAgent' and 'platform' property.
-     * @returns {string}
+     * @param nav An object with a 'userAgent' and 'platform' property.
      */
     getAccessKeyPrefix(nav?: ClientNavigator): `${KeyModifier}-`;
 
     /**
      * Switch test mode on and off.
      *
-     * @param {boolean} mode New mode
+     * @param mode New mode
      */
     setTestMode(mode: boolean): void;
 }

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -83,8 +83,8 @@ export interface FinishUpload {
     /**
      * Call this function to finish the upload.
      *
-     * @param {ApiUploadParams} data Additional data for the upload.
-     * @returns {mw.Api.Promise<[ApiResponse], mw.Api.RejectArgTuple | [string, ApiResponse]>} API promise for the final upload.
+     * @param data Additional data for the upload.
+     * @returns API promise for the final upload.
      */
     (data?: ApiUploadParams): mw.Api.Promise<
         [ApiResponse],
@@ -130,7 +130,7 @@ declare global {
             /**
              * Create an instance of {@link mw.Api}.
              *
-             * @param {Api.Options} [options] See {@link mw.Api.Options}. This can also be overridden for
+             * @param options See {@link mw.Api.Options}. This can also be overridden for
              *  each request by passing them to {@link get()} or {@link post()} (or directly to {@link ajax()}) later on.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#Api
              */
@@ -148,9 +148,9 @@ declare global {
             /**
              * Perform the API call.
              *
-             * @param {UnknownApiParams} parameters Parameters to the API. See also {@link mw.Api.Options.parameters}.
-             * @param {JQuery.AjaxSettings} [ajaxOptions] Parameters to pass to jQuery.ajax. See also {@link mw.Api.Options.ajax}.
-             * @returns {Api.AbortablePromise} A promise that settles when the API response is processed.
+             * @param parameters Parameters to the API. See also {@link mw.Api.Options.parameters}.
+             * @param ajaxOptions Parameters to pass to jQuery.ajax. See also {@link mw.Api.Options.ajax}.
+             * @returns A promise that settles when the API response is processed.
              *   Has an 'abort' method which can be used to abort the request.
              *
              *   - On success, resolves to `( result, jqXHR )` where `result` is the parsed API response.
@@ -202,8 +202,7 @@ declare global {
              * api.postWithToken( 'csrf', api.assertCurrentUser( { action: 'edit', ... } ) )
              * ```
              * @since 1.27
-             * @param {UnknownApiParams} query Query parameters. The object will not be changed
-             * @returns {AssertUser}
+             * @param query Query parameters. The object will not be changed
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#assertCurrentUser
              */
             assertCurrentUser<T extends UnknownApiParams>(
@@ -218,7 +217,7 @@ declare global {
              * automatically.
              *
              * @since 1.26
-             * @param {string} type Token type
+             * @param type Token type
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#badToken
              */
             badToken(type: ApiTokenType): void;
@@ -229,11 +228,10 @@ declare global {
             /**
              * Upload a file in several chunks.
              *
-             * @param {File} file
-             * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
-             * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
-             * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
-             * @returns {Upload.AbortablePromise}
+             * @param file
+             * @param data Other upload options, see `action=upload` API docs for more
+             * @param chunkSize Size (in bytes) per chunk (default: 5MB)
+             * @param chunkRetries Amount of times to retry a failed chunk (default: 1)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#chunkedUpload
              */
             chunkedUpload(
@@ -249,12 +247,11 @@ declare global {
              * This function will return a promise that will resolve with a function to finish the stash upload.
              * See {@link uploadToStash}.
              *
-             * @param {File|HTMLInputElement} file
-             * @param {ApiUploadParams} [data]
-             * @param {number} [chunkSize] Size (in bytes) per chunk (default: 5MB)
-             * @param {number} [chunkRetries] Amount of times to retry a failed chunk (default: 1)
-             * @returns {Upload.Promise<[FinishUpload]>} Promise that resolves with a
-             *  function that should be called to finish the upload.
+             * @param file
+             * @param data
+             * @param chunkSize Size (in bytes) per chunk (default: 5MB)
+             * @param chunkRetries Amount of times to retry a failed chunk (default: 1)
+             * @returns Promise that resolves with a function that should be called to finish the upload.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#chunkedUploadToStash
              */
             chunkedUploadToStash(
@@ -275,10 +272,10 @@ declare global {
              * );
              * ```
              * @since 1.28
-             * @param {TitleLike} title Page title
-             * @param {ApiEditPageParams} params Edit API parameters
-             * @param {string} content Page content
-             * @returns {Api.Promise<[EditResult]>} API response
+             * @param title Page title
+             * @param params Edit API parameters
+             * @param content Page content
+             * @returns API response
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#create
              */
             create(
@@ -343,9 +340,9 @@ declare global {
              * ```
              *
              * @since 1.28
-             * @param {TitleLike} title Page title
-             * @param {Api.EditTransform} transform Callback that prepares the edit
-             * @returns {Api.Promise<[EditResult]>} Edit API response
+             * @param title Page title
+             * @param transform Callback that prepares the edit
+             * @returns Edit API response
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#edit
              */
             edit(title: TitleLike, transform: Api.EditTransform): Api.Promise<[EditResult]>;
@@ -353,9 +350,6 @@ declare global {
             /**
              * Perform API get request. See {@link ajax()} for details.
              *
-             * @param {UnknownApiParams} parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#get
              */
             get(
@@ -366,8 +360,8 @@ declare global {
             /**
              * Get the categories that a particular page on the wiki belongs to.
              *
-             * @param {TitleLike} title
-             * @returns {Api.AbortablePromise<[false|Title[]]>} Promise that resolves with an array of category titles, or with false if the title was not found.
+             * @param title
+             * @returns Promise that resolves with an array of category titles, or with false if the title was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getCategories
              */
             getCategories(title: TitleLike): Api.AbortablePromise<[false | Title[]]>;
@@ -377,8 +371,8 @@ declare global {
              *
              * E.g. given "Foo", return "Food", "Foolish people", "Foosball tables"...
              *
-             * @param {string} prefix Prefix to match.
-             * @returns {Api.AbortablePromise<[string[]]>} Promise that resolves with an array of matched categories
+             * @param prefix Prefix to match.
+             * @returns Promise that resolves with an array of matched categories
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getCategoriesByPrefix
              */
             getCategoriesByPrefix(prefix: string): Api.AbortablePromise<[string[]]>;
@@ -386,7 +380,7 @@ declare global {
             /**
              * API helper to grab a csrf token.
              *
-             * @returns {Api.AbortablePromise<[string]>} Received token.
+             * @returns Received token.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getEditToken
              */
             getEditToken(): Api.AbortablePromise<[string]>;
@@ -421,8 +415,8 @@ declare global {
              *     mw.notify( api.getErrorMessage( data ), { type: 'error' } );
              * } );
              * ```
-             * @param {ApiResponse} data API response indicating an error
-             * @returns {JQuery} Error messages, each wrapped in a `<div>`
+             * @param data API response indicating an error
+             * @returns Error messages, each wrapped in a `<div>`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getErrorMessage
              */
             getErrorMessage(data: ApiResponse): JQuery;
@@ -432,9 +426,8 @@ declare global {
              *
              * @since 1.27
              * @since 1.37 - accepts a single string message as parameter.
-             * @param {string|string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
-             * @returns {Api.Promise<[Object.<string, string>]>}
+             * @param messages Messages to retrieve
+             * @param options Additional parameters for the API call
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getMessages
              */
             getMessages<T extends string>(
@@ -448,9 +441,9 @@ declare global {
              * @since 1.22
              * @since 1.25 - assert parameter can be passed.
              * @since 1.35 - additional parameters can be passed as an object instead of `assert`.
-             * @param {string} type Token type
-             * @param {ApiQueryTokensParams|ApiAssert} [additionalParams] Additional parameters for the API. When given a string, it's treated as the `assert` parameter.
-             * @returns {Api.AbortablePromise<[string]>} Received token.
+             * @param type Token type
+             * @param additionalParams Additional parameters for the API. When given a string, it's treated as the `assert` parameter.
+             * @returns Received token.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getToken
              */
             getToken(
@@ -471,7 +464,6 @@ declare global {
              * Get the current user's groups and rights.
              *
              * @since 1.27
-             * @returns {Api.Promise<[Api.UserInfo], Api.RejectArgTuple | []>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#getUserInfo
              */
             getUserInfo(): Api.Promise<[Api.UserInfo], Api.RejectArgTuple | []>;
@@ -479,8 +471,8 @@ declare global {
             /**
              * Determine if a category exists.
              *
-             * @param {TitleLike} title
-             * @returns {Api.AbortablePromise<[boolean]>} Promise that resolves with a boolean indicating whether the category exists.
+             * @param title
+             * @returns Promise that resolves with a boolean indicating whether the category exists.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#isCategory
              */
             isCategory(title: TitleLike): Api.AbortablePromise<[boolean]>;
@@ -489,9 +481,8 @@ declare global {
              * Load a set of messages and add them to {@link mw.messages}.
              *
              * @since 1.37 - accepts a single string message as parameter.
-             * @param {string|string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
-             * @returns {Api.Promise<[boolean]>}
+             * @param messages Messages to retrieve
+             * @param options Additional parameters for the API call
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#loadMessages
              */
             loadMessages(
@@ -505,9 +496,8 @@ declare global {
              *
              * @since 1.27
              * @since 1.42 - accepts a single string message as parameter.
-             * @param {string|string[]} messages Messages to retrieve
-             * @param {ApiQueryAllMessagesParams} [options] Additional parameters for the API call
-             * @returns {Api.Promise<[] | [boolean]>}
+             * @param messages Messages to retrieve
+             * @param options Additional parameters for the API call
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#loadMessagesIfMissing
              */
             loadMessagesIfMissing(
@@ -516,9 +506,9 @@ declare global {
             ): Api.Promise<[] | [boolean]>;
 
             /**
-             * @param {string} username
-             * @param {string} password
-             * @returns {Api.AbortablePromise<[ApiResponse]>} See {@link post()}
+             * @param username
+             * @param password
+             * @returns See {@link post()}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#login
              */
             login(username: string, password: string): Api.AbortablePromise<[ApiResponse]>;
@@ -526,11 +516,11 @@ declare global {
             /**
              * Post a new section to the page.
              *
-             * @param {TitleLike} title Target page
-             * @param {string} header
-             * @param {string} message Wikitext message
-             * @param {ApiEditPageParams} additionalParams Additional API parameters
-             * @returns {Api.AbortablePromise} See {@link postWithEditToken}
+             * @param title Target page
+             * @param header
+             * @param message Wikitext message
+             * @param additionalParams Additional API parameters
+             * @returns See {@link postWithEditToken}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#newSection
              */
             newSection(
@@ -543,10 +533,10 @@ declare global {
             /**
              * Convenience method for `action=parse`.
              *
-             * @param {TitleLike} content Content to parse, either as a wikitext string or a {@link mw.Title}
-             * @param {ApiParseParams} [additionalParams] Parameters object to set custom settings, e.g.
+             * @param content Content to parse, either as a wikitext string or a {@link mw.Title}
+             * @param additionalParams Parameters object to set custom settings, e.g.
              *  `redirects`, `sectionpreview`. `prop` should not be overridden.
-             * @returns {Api.AbortablePromise<[string]>} Promise that resolves with the parsed HTML of `wikitext`
+             * @returns Promise that resolves with the parsed HTML of `wikitext`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#parse
              */
             parse(
@@ -557,9 +547,6 @@ declare global {
             /**
              * Perform API post request. See {@link ajax()} for details.
              *
-             * @param {UnknownApiParams} parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#post
              */
             post(
@@ -570,9 +557,9 @@ declare global {
             /**
              * Post to API with csrf token. If we have no token, get one and try to post. If we have a cached token try using that, and if it fails, blank out the cached token and start over.
              *
-             * @param {UnknownApiParams} params API parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.AbortablePromise} See {@link post}
+             * @param params API parameters
+             * @param ajaxOptions
+             * @returns See {@link post}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#postWithEditToken
              */
             postWithEditToken(
@@ -594,10 +581,10 @@ declare global {
              * } );
              * ```
              * @since 1.22
-             * @param {string} tokenType The name of the token, like `options` or `edit`.
-             * @param {UnknownApiParams} params API parameters
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Api.AbortablePromise} See {@link post()}
+             * @param tokenType The name of the token, like `options` or `edit`.
+             * @param params API parameters
+             * @param ajaxOptions
+             * @returns See {@link post()}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#postWithToken
              */
             postWithToken(
@@ -621,10 +608,9 @@ declare global {
              * Convenience method for `action=rollback`.
              *
              * @since 1.28
-             * @param {TitleLike} page
-             * @param {string} user
-             * @param {ApiRollbackParams} [params] Additional parameters
-             * @returns {Api.Promise<[RollbackInfo]>}
+             * @param page
+             * @param user
+             * @param params Additional parameters
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#rollback
              */
             rollback(
@@ -638,10 +624,9 @@ declare global {
              * See {@link saveOptions()}.
              *
              * @since 1.43 - params parameter can be passed.
-             * @param {string} name
-             * @param {string|null} value
-             * @param {UnknownApiParams} [params] additional parameters for API.
-             * @returns {Api.Promise}
+             * @param name
+             * @param value
+             * @param params additional parameters for API.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#saveOption
              */
             saveOption(name: string, value: string | null, params?: UnknownApiParams): Api.Promise;
@@ -662,9 +647,8 @@ declare global {
              * would fail anyway. See T214963.
              *
              * @since 1.43 - params parameter can be passed.
-             * @param {Object.<string, string|null>} options Options as a `{ name: value, … }` object
-             * @param {UnknownApiParams} [params] additional parameters for API.
-             * @returns {Api.Promise<[] | [ApiResponse, JQuery.jqXHR<ApiResponse>]>}
+             * @param options Options as a `{ name: value, … }` object
+             * @param params additional parameters for API.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#saveOptions
              */
             saveOptions<T extends Record<string, string | null>>(
@@ -675,10 +659,10 @@ declare global {
             /**
              * Convenience method for `action=watch&unwatch=1`.
              *
-             * @param {TypeOrArray<TitleLike>} pages Full page name or instance of {@link mw.Title}, or an
+             * @param pages Full page name or instance of {@link mw.Title}, or an
              *  array thereof. If an array is passed, the return value passed to the promise will also be an
              *  array of appropriate objects.
-             * @returns {Api.AbortablePromise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
+             * @returns A promise that resolves
              *  with an object (or array of objects) describing each page that was passed in and its
              *  current watched/unwatched status.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#unwatch
@@ -692,9 +676,8 @@ declare global {
              *
              * The file will be uploaded using AJAX and FormData.
              *
-             * @param {File|Blob|HTMLInputElement} file HTML `input type=file` element with a file already inside of it, or a File object.
-             * @param {ApiUploadParams} data Other upload options, see `action=upload` API docs for more
-             * @returns {Upload.AbortablePromise}
+             * @param file HTML `input type=file` element with a file already inside of it, or a File object.
+             * @param data Other upload options, see `action=upload` API docs for more
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#upload
              */
             upload(
@@ -705,9 +688,6 @@ declare global {
             /**
              * Finish an upload in the stash.
              *
-             * @param {string} filekey
-             * @param {ApiUploadParams} data
-             * @returns {Api.Promise<[ApiResponse], Api.RejectArgTuple | [string, ApiResponse]>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#uploadFromStash
              */
             uploadFromStash(
@@ -733,10 +713,9 @@ declare global {
              *     } );
              * } );
              * ```
-             * @param {File|HTMLInputElement} file
-             * @param {ApiUploadParams} [data]
-             * @returns {Upload.Promise<[FinishUpload]>} Promise that resolves with a
-             *  function that should be called to finish the upload.
+             * @param file
+             * @param data
+             * @returns Promise that resolves with a function that should be called to finish the upload.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#uploadToStash
              */
             uploadToStash(
@@ -748,13 +727,12 @@ declare global {
              * Convenience method for `action=watch`.
              *
              * @since 1.35 - expiry parameter can be passed when Watchlist Expiry is enabled.
-             * @param {TypeOrArray<TitleLike>} pages Full page name or instance of {@link mw.Title}, or an
+             * @param pages Full page name or instance of {@link mw.Title}, or an
              *  array thereof. If an array is passed, the return value passed to the promise will also be an
              *  array of appropriate objects.
-             * @param {string} [expiry] When the page should expire from the watchlist. If omitted, the
+             * @param expiry When the page should expire from the watchlist. If omitted, the
              *  page will not expire.
-             * @returns {Api.AbortablePromise<[TypeOrArray<Api.WatchedPage>]>} A promise that resolves
-             *  with an object (or array of objects) describing each page that was passed in and its
+             * @returns A promise that resolves with an object (or array of objects) describing each page that was passed in and its
              *  current watched/unwatched status.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#watch
              */
@@ -766,8 +744,8 @@ declare global {
             /**
              * Massage parameters from the nice format we accept into a format suitable for the API.
              *
-             * @param {UnknownApiParams} parameters (modified in-place)
-             * @param {boolean} useUS Whether to use U+001F when joining multi-valued parameters.
+             * @param parameters (modified in-place)
+             * @param useUS Whether to use U+001F when joining multi-valued parameters.
              */
             private preprocessParameters(parameters: UnknownApiParams, useUS: boolean): void;
         }
@@ -778,8 +756,8 @@ declare global {
              */
             interface EditTransform {
                 /**
-                 * @param {Revision} revision Current revision
-                 * @returns {string|ApiEditPageParams|JQuery.Promise<string|ApiEditPageParams>} New content, object with edit API parameters, or promise providing one of those.
+                 * @param revision Current revision
+                 * @returns New content, object with edit API parameters, or promise providing one of those.
                  */
                 (revision: Revision):
                     | string

--- a/mw/ForeignApi.d.ts
+++ b/mw/ForeignApi.d.ts
@@ -43,16 +43,14 @@ declare global {
             /**
              * Create an instance of {@link mw.ForeignApi}.
              *
-             * @param {string|Uri} url URL pointing to another wiki's `api.php` endpoint.
-             * @param {ForeignApi.Options} [options] Also accepts all the options from {@link mw.Api.Options}.
+             * @param url URL pointing to another wiki's `api.php` endpoint.
+             * @param options Also accepts all the options from {@link mw.Api.Options}.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.ForeignApi.html#ForeignApi
              */
             constructor(url: string | Uri, options?: ForeignApi.Options);
 
             /**
              * Return the origin to use for API requests, in the required format (protocol, host and port, if any).
-             *
-             * @returns {string|undefined}
              */
             protected getOrigin(): "*" | `${string}//${string}` | undefined;
         }

--- a/mw/ForeignRest.d.ts
+++ b/mw/ForeignRest.d.ts
@@ -39,9 +39,9 @@ declare global {
             /**
              * Create an instance of {@link mw.ForeignRest}.
              *
-             * @param {string} url URL pointing to another wiki's `rest.php` endpoint.
-             * @param {ForeignApi} foreignActionApi
-             * @param {ForeignRest.Options} [options] See {@link mw.Rest}.
+             * @param url URL pointing to another wiki's `rest.php` endpoint.
+             * @param foreignActionApi
+             * @param options See {@link mw.Rest}.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.ForeignRest.html#ForeignRest
              */
             constructor(url: string, foreignActionApi: ForeignApi, options?: ForeignRest.Options);

--- a/mw/ForeignUpload.d.ts
+++ b/mw/ForeignUpload.d.ts
@@ -38,11 +38,11 @@ declare global {
             /**
              * Used to represent an upload in progress on the frontend.
              *
-             * @param {string} [target] Used to set up the target
+             * @param target Used to set up the target
              *     wiki. If not remote, this class behaves identically to {@link mw.Upload} (unless further subclassed)
              *     Use the same names as set in $wgForeignFileRepos for this. Also,
              *     make sure there is an entry in the $wgForeignUploadTargets array for this name.
-             * @param {ForeignApi.Options} [apiconfig] Passed to the constructor of mw.ForeignApi or mw.Api, as needed.
+             * @param apiconfig Passed to the constructor of mw.ForeignApi or mw.Api, as needed.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.ForeignUpload.html#ForeignUpload
              */
             constructor(target: string, apiconfig?: ForeignApi.Options);

--- a/mw/RegExp.d.ts
+++ b/mw/RegExp.d.ts
@@ -13,8 +13,8 @@ declare global {
              *
              * @deprecated since 1.34
              * @since 1.26
-             * @param {string} str String to escape
-             * @returns {string} Escaped string
+             * @param str String to escape
+             * @returns Escaped string
              * @see https://doc.wikimedia.org/mediawiki-core/REL1_33/js/#!/api/mw.RegExp-static-method-escape
              */
             function escape(str: string): string;

--- a/mw/Rest.d.ts
+++ b/mw/Rest.d.ts
@@ -33,7 +33,7 @@ declare global {
             /**
              * Create an instance of {@link mw.Rest}.
              *
-             * @param {Rest.Options} [options] See {@link mw.Rest.Options}
+             * @param options See {@link mw.Rest.Options}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#Rest
              */
             constructor(options?: Rest.Options);
@@ -50,9 +50,9 @@ declare global {
             /**
              * Perform the API call.
              *
-             * @param {string} path
-             * @param {JQuery.AjaxSettings} [ajaxOptions]
-             * @returns {Rest.AbortablePromise} Done: API response data and the jqXHR object.
+             * @param path
+             * @param ajaxOptions
+             * @returns Done: API response data and the jqXHR object.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#ajax
              */
             ajax(path: string, ajaxOptions?: JQuery.AjaxSettings): Rest.AbortablePromise;
@@ -63,10 +63,6 @@ declare global {
              * Note: only sending `application/json` is currently supported.
              *
              * @since 1.39
-             * @param {string} path
-             * @param {Object.<string, any>} body
-             * @param {Object.<string, any>} [headers]
-             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#delete
              */
             delete(
@@ -78,10 +74,6 @@ declare global {
             /**
              * Perform REST API get request.
              *
-             * @param {string} path
-             * @param {Object.<string, any>} query
-             * @param {Object.<string, any>} [headers]
-             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#get
              */
             get(
@@ -96,10 +88,6 @@ declare global {
              * Note: only sending `application/json` is currently supported.
              *
              * @since 1.42 - body parameter is optional.
-             * @param {string} path
-             * @param {Object.<string, any>} [body]
-             * @param {Object.<string, any>} [headers]
-             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#post
              */
             post(
@@ -114,10 +102,6 @@ declare global {
              * Note: only sending `application/json` is currently supported.
              *
              * @since 1.39
-             * @param {string} path
-             * @param {Object.<string, any>} body
-             * @param {Object.<string, any>} [headers]
-             * @returns {Rest.AbortablePromise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Rest.html#put
              */
             put(

--- a/mw/Title.d.ts
+++ b/mw/Title.d.ts
@@ -24,9 +24,8 @@ interface TitleExistenceStore {
      * // To declare titles nonexistent
      * Title.exist.set( ['File:Foo_bar.jpg', ...], false );
      * ```
-     * @param {string|string[]} titles Title(s) in strict prefixedDb title form
-     * @param {boolean} [state=true] State of the given titles
-     * @returns {boolean}
+     * @param titles Title(s) in strict prefixedDb title form
+     * @param state State of the given titles, defaults to true
      */
     set(titles: string | string[], state?: boolean): boolean;
 }
@@ -89,9 +88,9 @@ declare global {
              * directly, passing invalid titles will result in an exception. Use {@link newFromText} to use the
              * logic directly and get null for invalid titles which is easier to work with.
              *
-             * @param {string} title Title of the page. If no second argument given,
+             * @param title Title of the page. If no second argument given,
              *  this will be searched for a namespace
-             * @param {number} [namespace=NS_MAIN] If given, will used as default namespace for the given title
+             * @param namespace If given, will used as default namespace for the given title
              * @throws {Error} When the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#Title
              */
@@ -100,7 +99,7 @@ declare global {
             /**
              * Check the title can have an associated talk page.
              *
-             * @returns {boolean} The title can have an associated talk page
+             * @returns The title can have an associated talk page
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#canHaveTalkPage
              */
             canHaveTalkPage(): boolean;
@@ -108,7 +107,7 @@ declare global {
             /**
              * Whether this title exists on the wiki. See {@link mw.Title.exists}.
              *
-             * @returns {boolean|null} Boolean if the information is available, otherwise null
+             * @returns Boolean if the information is available, otherwise null
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#exists
              */
             exists(): boolean | null;
@@ -116,7 +115,7 @@ declare global {
             /**
              * Get the extension of the page name (if any).
              *
-             * @returns {string|null} Name extension or null if there is none
+             * @returns Name extension or null if there is none
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getExtension
              */
             getExtension(): string | null;
@@ -130,7 +129,6 @@ declare global {
              * A title like `User:Dr._J._Fail` will be returned as `Dr. J`! Use {@link getMainText} instead.
              *
              * @since 1.40
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getFileNameTextWithoutExtension
              */
             getFileNameTextWithoutExtension(): string;
@@ -144,7 +142,6 @@ declare global {
              * A title like `User:Dr._J._Fail` will be returned as `Dr._J`! Use {@link getMain} instead.
              *
              * @since 1.40
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getFileNameWithoutExtension
              */
             getFileNameWithoutExtension(): string;
@@ -155,7 +152,6 @@ declare global {
              * Note that this method (by design) does not include the hash character and
              * the value is not url encoded.
              *
-             * @returns {string|null}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getFragment
              */
             getFragment(): string | null;
@@ -165,7 +161,6 @@ declare global {
              *
              * Example: `Example_image.svg` for `File:Example_image.svg`.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getMain
              */
             getMain(): string;
@@ -175,7 +170,6 @@ declare global {
              *
              * Example: `Example image.svg` for `File:Example_image.svg`.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getMainText
              */
             getMainText(): string;
@@ -186,7 +180,7 @@ declare global {
              * `Dr. J`! Use {@link getMain} or {@link getMainText} for the actual page name.
              *
              * @deprecated since 1.40, use {@link getFileNameWithoutExtension} instead
-             * @returns {string} File name without file extension, in the canonical form with underscores
+             * @returns File name without file extension, in the canonical form with underscores
              *  instead of spaces. For example, the title `File:Example_image.svg` will be returned as
              *  `Example_image`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getName
@@ -198,7 +192,6 @@ declare global {
              *
              * Example: 6 for `File:Example_image.svg`.
              *
-             * @returns {number}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getNamespaceId
              */
             getNamespaceId(): number;
@@ -209,7 +202,6 @@ declare global {
              * Example: `File:` for `File:Example_image.svg`.
              * In `NS_MAIN` this is '', otherwise namespace name plus ':'
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getNamespacePrefix
              */
             getNamespacePrefix(): string;
@@ -220,7 +212,7 @@ declare global {
              * `Dr. J`! Use {@link getMainText} for the actual page name.
              *
              * @deprecated since 1.40, use {@link getFileNameTextWithoutExtension} instead
-             * @returns {string} File name without file extension, formatted with spaces instead of
+             * @returns File name without file extension, formatted with spaces instead of
              *  underscores. For example, the title `File:Example_image.svg` will be returned as
              *  `Example image`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getNameText
@@ -233,7 +225,6 @@ declare global {
              * Example: `File:Example_image.svg`.
              * Most useful for API calls, anything that must identify the "title".
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getPrefixedDb
              */
             getPrefixedDb(): string;
@@ -243,7 +234,6 @@ declare global {
              *
              * Example: `File:Example image.svg` for `File:Example_image.svg`.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getPrefixedText
              */
             getPrefixedText(): string;
@@ -257,8 +247,7 @@ declare global {
              * - "Bar" relative to any non-main namespace becomes ":Bar".
              * - "Foo:Bar" relative to any namespace other than Foo stays "Foo:Bar".
              *
-             * @param {number} namespace The namespace to be relative to
-             * @returns {string}
+             * @param namespace The namespace to be relative to
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getRelativeText
              */
             getRelativeText(namespace: number): string;
@@ -266,7 +255,7 @@ declare global {
             /**
              * Get the title for the subject page of a talk page.
              *
-             * @returns {Title|null} The title for the subject page of a talk page, null if not available
+             * @returns The title for the subject page of a talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getSubjectPage
              */
             getSubjectPage(): Title | null;
@@ -274,7 +263,7 @@ declare global {
             /**
              * Get the title for the associated talk page.
              *
-             * @returns {Title|null} The title for the associated talk page, null if not available
+             * @returns The title for the associated talk page, null if not available
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getTalkPage
              */
             getTalkPage(): Title | null;
@@ -282,9 +271,8 @@ declare global {
             /**
              * Get the URL to this title. See {@link mw.util.getUrl()}.
              *
-             * @param {QueryParams} [params] A mapping of query parameter names to values,
+             * @param params A mapping of query parameter names to values,
              *     e.g. `{ action: 'edit' }`.
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#getUrl
              */
             getUrl(params?: QueryParams): string;
@@ -292,7 +280,7 @@ declare global {
             /**
              * Check if the title is in a talk namespace.
              *
-             * @returns {boolean} The title is in a talk namespace
+             * @returns The title is in a talk namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#isTalkPage
              */
             isTalkPage(): boolean;
@@ -314,8 +302,8 @@ declare global {
             /**
              * Whether this title exists on the wiki.
              *
-             * @param {string|Title} title prefixed db-key name (string) or instance of Title
-             * @returns {boolean|null} Boolean if the information is available, otherwise null
+             * @param title prefixed db-key name (string) or instance of Title
+             * @returns Boolean if the information is available, otherwise null
              * @throws {Error} If title is not a string or mw.Title
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.exists
              */
@@ -326,8 +314,8 @@ declare global {
              *
              * See NamespaceInfo::isTalk in PHP
              *
-             * @param {number} namespaceId Namespace ID
-             * @returns {boolean} Namespace is a talk namespace
+             * @param namespaceId Namespace ID
+             * @returns Namespace is a talk namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.isTalkNamespace
              */
             static isTalkNamespace(namespaceId: number): boolean;
@@ -341,9 +329,9 @@ declare global {
              * The single exception to this is when `namespace` is 0, indicating the main namespace. The
              * function behaves like {@link newFromText} in that case.
              *
-             * @param {number} namespace Namespace to use for the title
-             * @param {string} title
-             * @returns {Title|null} A valid Title object or null if the title is invalid
+             * @param namespace Namespace to use for the title
+             * @param title
+             * @returns A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.makeTitle
              */
             static makeTitle(namespace: number, title: string): Title | null;
@@ -353,9 +341,9 @@ declare global {
              * so it is most likely a valid MediaWiki title and file name after processing.
              * Returns null on fatal errors.
              *
-             * @param {string} uncleanName The unclean file name including file extension but
+             * @param uncleanName The unclean file name including file extension but
              *  without namespace
-             * @returns {Title|null} A valid Title object or null if the title is invalid
+             * @returns A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.newFromFileName
              */
             static newFromFileName(uncleanName: string): Title | null;
@@ -367,8 +355,8 @@ declare global {
              * ```js
              * var title = mw.Title.newFromImg( imageNode );
              * ```
-             * @param {HTMLElement|JQuery} img The image to use as a base
-             * @returns {Title|null} The file title or null if unsuccessful
+             * @param img The image to use as a base
+             * @returns The file title or null if unsuccessful
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.newFromImg
              */
             static newFromImg(img: HTMLElement | JQuery): Title | null;
@@ -380,9 +368,9 @@ declare global {
              * prefix in `title`. If you do not want this behavior, use {@link makeTitle}. See {@link constructor} for
              * details.
              *
-             * @param {string} title
-             * @param {number} [namespace=NS_MAIN] Default namespace
-             * @returns {Title|null} A valid Title object or null if the title is invalid
+             * @param title
+             * @param namespace Default namespace
+             * @returns A valid Title object or null if the title is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.newFromText
              */
             static newFromText(title: string, namespace?: number): Title | null;
@@ -391,11 +379,11 @@ declare global {
              * Constructor for Title objects from user input altering that input to
              * produce a title that MediaWiki will accept as legal.
              *
-             * @param {string} title
-             * @param {number} [defaultNamespace=NS_MAIN]
+             * @param title
+             * @param defaultNamespace
              *  If given, will used as default namespace for the given title.
-             * @param {UserInputOptions} [options] additional options
-             * @returns {Title|null} A valid Title object or null if the input cannot be turned into a valid title
+             * @param options additional options
+             * @returns A valid Title object or null if the input cannot be turned into a valid title
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.newFromUserInput
              */
             static newFromUserInput(
@@ -409,8 +397,8 @@ declare global {
              * and ensure it's clean. Extensions with non-alphanumeric characters will be discarded.
              * Keep in sync with File::normalizeExtension() in PHP.
              *
-             * @param {string} extension File extension (without the leading dot)
-             * @returns {string} File extension in canonical form
+             * @param extension File extension (without the leading dot)
+             * @returns File extension in canonical form
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.normalizeExtension
              */
             static normalizeExtension(extension: string): string;
@@ -418,8 +406,8 @@ declare global {
             /**
              * PHP's strtoupper differs from {@link String.toUpperCase} in a number of cases (T147646).
              *
-             * @param {string} chr Unicode character
-             * @returns {string} Unicode character, in upper case, according to the same rules as in PHP
+             * @param chr Unicode character
+             * @returns Unicode character, in upper case, according to the same rules as in PHP
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.phpCharToUpper
              */
             static phpCharToUpper(chr: string): string;
@@ -429,8 +417,8 @@ declare global {
              *
              * See NamespaceInfo::wantSignatures in PHP
              *
-             * @param {number} namespaceId Namespace ID
-             * @returns {boolean} Namespace is a signature namespace
+             * @param namespaceId Namespace ID
+             * @returns Namespace is a signature namespace
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Title.html#.wantSignaturesNamespace
              */
             static wantSignatureNamespace(namespaceId: number): boolean;

--- a/mw/Upload.d.ts
+++ b/mw/Upload.d.ts
@@ -53,7 +53,7 @@ declare global {
             /**
              * Used to represent an upload in progress on the frontend.
              *
-             * @param {Api|Api.Options} [apiconfig] A mw.Api object (or subclass), or configuration
+             * @param apiconfig A mw.Api object (or subclass), or configuration
              *     to pass to the constructor of mw.Api.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#Upload
              */
@@ -62,7 +62,6 @@ declare global {
             /**
              * Finish a stash upload.
              *
-             * @returns {Api.Promise<[ApiResponse], Api.RejectArgTuple | [string, ApiResponse]>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#finishStashUpload
              */
             finishStashUpload(): Api.Promise<
@@ -73,7 +72,6 @@ declare global {
             /**
              * Get the mw.Api instance used by this Upload object.
              *
-             * @returns {JQuery.Promise<Api>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getApi
              */
             getApi(): JQuery.Promise<Api>;
@@ -81,8 +79,6 @@ declare global {
             /**
              * Gets the base filename from a path name.
              *
-             * @param {string} path
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getBasename
              */
             getBasename(path: string): string;
@@ -90,7 +86,6 @@ declare global {
             /**
              * Get the current value of the edit comment for the upload.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getComment
              */
             getComment(): string;
@@ -98,7 +93,6 @@ declare global {
             /**
              * Get the file being uploaded.
              *
-             * @returns {HTMLInputElement|File|Blob}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getFile
              */
             getFile(): HTMLInputElement | File | Blob;
@@ -106,7 +100,6 @@ declare global {
             /**
              * Get the filename, to be finalized on upload.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getFilename
              */
             getFilename(): string;
@@ -116,7 +109,6 @@ declare global {
              * Only available once the upload is finished! Don't try to get it
              * beforehand.
              *
-             * @returns {ApiResponse|undefined}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getImageInfo
              */
             getImageInfo(): ApiResponse | undefined;
@@ -124,7 +116,6 @@ declare global {
             /**
              * Gets the state of the upload.
              *
-             * @returns {Upload.State}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getState
              */
             getState(): Upload.State;
@@ -132,7 +123,6 @@ declare global {
             /**
              * Gets details of the current state.
              *
-             * @returns {any}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getStateDetails
              */
             getStateDetails(): any;
@@ -140,7 +130,6 @@ declare global {
             /**
              * Get the text of the file page, to be created on file upload.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getText
              */
             getText(): string;
@@ -148,7 +137,6 @@ declare global {
             /**
              * Get the boolean for whether the file will be watchlisted after upload.
              *
-             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getWatchlist
              */
             getWatchlist(): boolean;
@@ -156,7 +144,6 @@ declare global {
             /**
              * Set the edit comment for the upload.
              *
-             * @param {string} comment
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setComment
              */
             setComment(comment: string): void;
@@ -164,7 +151,6 @@ declare global {
             /**
              * Set the file to be uploaded.
              *
-             * @param {HTMLInputElement|File|Blob} file
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setFile
              */
             setFile(file: HTMLInputElement | File | Blob): void;
@@ -172,7 +158,6 @@ declare global {
             /**
              * Set the stashed file to finish uploading.
              *
-             * @param {string} filekey
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setFilekey
              */
             setFilekey(filekey: string): void;
@@ -180,7 +165,6 @@ declare global {
             /**
              * Set the filename, to be finalized on upload.
              *
-             * @param {string} filename
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setFilename
              */
             setFilename(filename: string): void;
@@ -195,8 +179,6 @@ declare global {
             /**
              * Sets the state and state details (if any) of the upload.
              *
-             * @param {Upload.State} state
-             * @param {any} stateDetails
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setState
              */
             setState(state: Upload.State, stateDetails: any): void;
@@ -204,7 +186,6 @@ declare global {
             /**
              * Set the text of the file page, to be created on file upload.
              *
-             * @param {string} text
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setText
              */
             setText(text: string): void;
@@ -212,7 +193,6 @@ declare global {
             /**
              * Set whether the file should be watchlisted after upload.
              *
-             * @param {boolean} watchlist
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setWatchlist
              */
             setWatchlist(watchlist: boolean): void;
@@ -220,7 +200,6 @@ declare global {
             /**
              * Upload the file directly.
              *
-             * @returns {Upload.Promise}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#upload
              */
             upload(): Upload.Promise;
@@ -228,7 +207,6 @@ declare global {
             /**
              * Upload the file to the stash to be completed later.
              *
-             * @returns {Upload.Promise<[FinishUpload]>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#uploadToStash
              */
             uploadToStash(): Upload.Promise<[FinishUpload]>;

--- a/mw/Uri.d.ts
+++ b/mw/Uri.d.ts
@@ -12,9 +12,9 @@ declare global {
          * against (including protocol-relative URLs).
          *
          * @deprecated since 1.43, use browser native URL instead.
-         * @param {string|function():string} documentLocation A full url, or function returning one.
+         * @param documentLocation A full url, or function returning one.
          *  If passed a function, the return value may change over time and this will be honoured. (T74334)
-         * @returns {Function} An mw.Uri class constructor
+         * @returns An mw.Uri class constructor
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.UriRelative
          */
         function UriRelative(documentLocation: string | (() => string)): typeof Uri;
@@ -152,12 +152,12 @@ declare global {
              * Construct a new URI object. Throws error if arguments are illegal/impossible, or
              * otherwise don't parse.
              *
-             * @param {string|Uri|Object.<string,string>} [uri] URI string, or an Object with appropriate properties (especially
+             * @param uri URI string, or an Object with appropriate properties (especially
              *  another URI object to clone). Object must have non-blank `protocol`, `host`, and `path`
              *  properties. If omitted (or set to `undefined`, `null` or empty string), then an object
              *  will be created for the default `uri` of this constructor (`location.href` for mw.Uri,
              *  other values for other instances -- see {@link mw.UriRelative} for details).
-             * @param {Uri.UriOptions|boolean} [options] Object with options, or (backwards compatibility) a boolean
+             * @param options Object with options, or (backwards compatibility) a boolean
              *  for strictMode
              * @throws {Error} when the query string or fragment contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#Uri
@@ -170,7 +170,7 @@ declare global {
             /**
              * Clone this URI.
              *
-             * @returns {Uri} New URI object with same properties
+             * @returns New URI object with same properties
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#clone
              */
             clone(): Uri;
@@ -178,9 +178,9 @@ declare global {
             /**
              * Extend the query section of the URI with new parameters.
              *
-             * @param {QueryParams} parameters Query parameters to add to ours (or to override ours with) as an
+             * @param parameters Query parameters to add to ours (or to override ours with) as an
              *  object
-             * @returns {Uri} This URI object
+             * @returns This URI object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#extend
              */
             extend(parameters: QueryParams): Uri;
@@ -190,7 +190,6 @@ declare global {
              *
              * In most real-world URLs this is simply the hostname, but the definition of 'authority' section is more general.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#getAuthority
              */
             getAuthority(): string;
@@ -198,7 +197,6 @@ declare global {
             /**
              * Get host and port section of a URI.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#getHostPort
              */
             getHostPort(): string;
@@ -208,7 +206,6 @@ declare global {
              *
              * Does not preserve the original order of arguments passed in the URI. Does handle escaping.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#getQueryString
              */
             getQueryString(): string;
@@ -216,7 +213,6 @@ declare global {
             /**
              * Get everything after the authority section of the URI.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#getRelativePath
              */
             getRelativePath(): string;
@@ -224,7 +220,6 @@ declare global {
             /**
              * Get user and password section of a URI.
              *
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#getUserInfo
              */
             getUserInfo(): string;
@@ -240,7 +235,7 @@ declare global {
              * web2017-polyfills, which loads a polyfill if needed) in contexts where the fragment
              * is important.
              *
-             * @returns {string} The URI string
+             * @returns The URI string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#toString
              */
             toString(): `${string}://${string}`;
@@ -248,8 +243,8 @@ declare global {
             /**
              * Parse a string and set our properties accordingly.
              *
-             * @param {string} str URI, see constructor.
-             * @param {Uri.UriOptions} options See constructor.
+             * @param str URI, see constructor.
+             * @param options See constructor.
              * @throws {Error} when the query string or fragment contains an unknown % sequence
              */
             private parse(str: string, options: Uri.UriOptions): void;
@@ -260,8 +255,8 @@ declare global {
              * Reversed {@link encode}. Standard decodeURIComponent, with addition of replacing
              * `+` with a space.
              *
-             * @param {string} s String to decode
-             * @returns {string} Decoded string
+             * @param s String to decode
+             * @returns Decoded string
              * @throws {Error} when the string contains an unknown % sequence
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#.decode
              */
@@ -274,8 +269,8 @@ declare global {
              * compliant with RFC 3986. Similar to rawurlencode from PHP and our JS library
              * {@link mw.util.rawurlencode}, except this also replaces spaces with `+`.
              *
-             * @param {string} s String to encode
-             * @returns {string} Encoded string for URI
+             * @param s String to encode
+             * @returns Encoded string for URI
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Uri.html#.encode
              */
             static encode(s: string): string;

--- a/mw/cldr.d.ts
+++ b/mw/cldr.d.ts
@@ -13,9 +13,9 @@ declare global {
              * In case none of the rules passed, we return `pluralRules.length` -
              * that means it is the "other" form.
              *
-             * @param {number} number
-             * @param {string[]} pluralRules
-             * @returns {number} plural form index
+             * @param number
+             * @param pluralRules
+             * @returns plural form index
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.cldr.html#.getPluralForm
              */
             function getPluralForm(number: number, pluralRules: string[]): number;

--- a/mw/confirmCloseWindow.d.ts
+++ b/mw/confirmCloseWindow.d.ts
@@ -7,7 +7,7 @@ interface Options {
     namespace?: string;
 
     /**
-     * @returns {boolean} Whether to show the dialog to the user.
+     * @returns Whether to show the dialog to the user.
      */
     test?(): boolean;
 }
@@ -25,8 +25,6 @@ interface ConfirmCloseWindow {
      * Check, if options.test() returns true and show an alert to the user if he/she want
      * to leave this page. Returns false, if options.test() returns false or the user
      * cancelled the alert window (~don't leave the page), true otherwise.
-     *
-     * @returns {boolean}
      */
     trigger(): boolean;
 }
@@ -61,8 +59,8 @@ declare global {
          *     }
          * })
          * ```
-         * @param {Options} [options]
-         * @returns {ConfirmCloseWindow} An object of functions to work with this module
+         * @param options
+         * @returns An object of functions to work with this module
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.confirmCloseWindow
          */
         function confirmCloseWindow(options?: Options): ConfirmCloseWindow;

--- a/mw/cookie.d.ts
+++ b/mw/cookie.d.ts
@@ -18,10 +18,10 @@ declare global {
             /**
              * Get the value of a cookie.
              *
-             * @param {string} key The key for the cookie
-             * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {string|null} [defaultValue] A value to return if the cookie does not exist
-             * @returns {string|null} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param key The key for the cookie
+             * @param prefix The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
+             * @param defaultValue A value to return if the cookie does not exist
+             * @returns If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.cookie.html#.get
              */
             function get<D extends string | null>(
@@ -35,10 +35,10 @@ declare global {
              * Get the value of a cookie.
              *
              * @deprecated since 1.43, use {@link mw.cookie.get} instead
-             * @param {string} key The key for the cookie
-             * @param {string} [prefix] The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
-             * @param {string|null} [defaultValue] A value to return if the cookie does not exist
-             * @returns {string|null|undefined} If the cookie exists, the value of the cookie, otherwise `defaultValue`
+             * @param key The key for the cookie
+             * @param prefix The prefix of the key. If undefined or null, `$wgCookiePrefix` is used
+             * @param defaultValue A value to return if the cookie does not exist
+             * @returns If the cookie exists, the value of the cookie, otherwise `defaultValue`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.cookie.html#.getCrossSite
              */
             function getCrossSite<D extends string | null>(
@@ -57,9 +57,9 @@ declare global {
              *
              * Without an expiry, this creates a session cookie. In a browser, session cookies persist for the lifetime of the browser *process*. Including across tabs, page views, and windows, until the browser itself is *fully* closed, or until the browser clears all storage for a given website. An exception to this is if the user evokes a "restore previous session" feature that some browsers have.
              *
-             * @param {string} key
-             * @param {string|null} value Value of cookie. If `value` is `null` then this method will instead remove a cookie by name of `key`
-             * @param {CookieOptions|Date|number} [options] Options object, or expiry date
+             * @param key
+             * @param value Value of cookie. If `value` is `null` then this method will instead remove a cookie by name of `key`
+             * @param options Options object, or expiry date
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.cookie.html#.set
              */
             // see https://stackoverflow.com/a/64932909 for <SS>

--- a/mw/debug.d.ts
+++ b/mw/debug.d.ts
@@ -59,7 +59,7 @@ declare global {
             /**
              * Build the console panel.
              *
-             * @returns {JQuery} Console panel
+             * @returns Console panel
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.buildConsoleTable
              */
             function buildConsoleTable(): JQuery;
@@ -67,7 +67,6 @@ declare global {
             /**
              * Build legacy debug log pane.
              *
-             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.buildDebugLogTable
              */
             function buildDebugLogTable(): JQuery;
@@ -82,7 +81,6 @@ declare global {
             /**
              * Build included files pane.
              *
-             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.buildIncludesPane
              */
             function buildIncludesPane(): JQuery;
@@ -90,7 +88,6 @@ declare global {
             /**
              * Build query list pane.
              *
-             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.buildQueryTable
              */
             function buildQueryTable(): JQuery;
@@ -98,7 +95,6 @@ declare global {
             /**
              * Build request information pane.
              *
-             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.buildRequestPane
              */
             function buildRequestPane(): JQuery;
@@ -109,7 +105,7 @@ declare global {
              * Shouldn't be called before the document is ready
              * (since it binds to elements on the page).
              *
-             * @param {Data} [data] Defaults to 'debugInfo' from {@link mw.config}
+             * @param data Defaults to 'debugInfo' from {@link mw.config}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.init
              */
             function init(data?: Data): void;
@@ -120,7 +116,6 @@ declare global {
              * Should be called with an HTMLElement as its thisArg,
              * because it's meant to be an event handler.
              *
-             * @param {JQuery.Event} e
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Debug.html#.switchPane
              */
             function switchPane(e: JQuery.Event): void;

--- a/mw/deflate.d.ts
+++ b/mw/deflate.d.ts
@@ -10,8 +10,8 @@ declare global {
          *     return mw.deflate( html );
          * } );
          * ```
-         * @param {string|ArrayBuffer} data Undeflated data
-         * @returns {string} Deflated data
+         * @param data Undeflated data
+         * @returns Deflated data
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.deflate
          */
         function deflate(data: string | ArrayBuffer): `rawdeflate,${string}`;

--- a/mw/errorLogger.d.ts
+++ b/mw/errorLogger.d.ts
@@ -11,10 +11,10 @@ declare global {
              * (by default `error.caught`) that an event has occurred.
              *
              * @since 1.36
-             * @param {Error} error
-             * @param {string} [topic='error.caught'] Error topic. Conventionally in the form
+             * @param error
+             * @param topic Error topic. Conventionally in the form
              *  'error.%component%' (where %component% identifies the code logging the error at a
-             *  high level; e.g. an extension name).
+             *  high level; e.g. an extension name). Defaults to `error.caught`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.errorLogger.html#.logError
              */
             function logError(error: Error, topic?: `error.${string}`): void;

--- a/mw/experiments.d.ts
+++ b/mw/experiments.d.ts
@@ -43,10 +43,10 @@ declare global {
              *     }
              * }
              * ```
-             * @param {Experiment} experiment
-             * @param {string} token A token that uniquely identifies the user for the
+             * @param experiment
+             * @param token A token that uniquely identifies the user for the
              *  duration of the experiment
-             * @returns {string|undefined} The bucket
+             * @returns The bucket
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.experiments.html#.getBucket
              */
             function getBucket(experiment: Experiment, token: string): string | undefined;

--- a/mw/global.d.ts
+++ b/mw/global.d.ts
@@ -3,7 +3,6 @@ declare global {
      * Schedule a function to run once the page is ready (DOM loaded).
      *
      * @since 1.5.8
-     * @param {function():void} fn
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/window.html#.addOnloadHook
      */
     function addOnloadHook(fn: () => void): void;
@@ -15,8 +14,8 @@ declare global {
      * be loaded and executed once.
      *
      * @since 1.12.2
-     * @param {string} title
-     * @returns {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @param title
+     * @returns Script tag, or null if it was already imported before
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/window.html#.importScript
      */
     function importScript(title: string): HTMLScriptElement | null;
@@ -25,8 +24,8 @@ declare global {
      * Import a script using an absolute URI.
      *
      * @since 1.12.2
-     * @param {string} url
-     * @returns {HTMLScriptElement|null} Script tag, or null if it was already imported before
+     * @param url
+     * @returns Script tag, or null if it was already imported before
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/window.html#.importScriptURI
      */
     function importScriptURI(url: string): HTMLScriptElement | null;
@@ -35,8 +34,8 @@ declare global {
      * Import a local CSS content page, for use by user scripts and site-wide scripts.
      *
      * @since 1.12.2
-     * @param {string} title
-     * @returns {HTMLLinkElement} Link tag
+     * @param title
+     * @returns Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/window.html#.importStylesheet
      */
     function importStylesheet(title: string): HTMLLinkElement;
@@ -45,9 +44,9 @@ declare global {
      * Import a stylesheet using an absolute URI.
      *
      * @since 1.12.2
-     * @param {string} url
-     * @param {string} media
-     * @returns {HTMLLinkElement} Link tag
+     * @param url
+     * @param media
+     * @returns Link tag
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/window.html#.importStylesheetURI
      */
     function importStylesheetURI(url: string, media: string): HTMLLinkElement;

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -47,8 +47,7 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Register a hook handler.
      *
-     * @param {...Function} handler Function to bind.
-     * @returns {Hook}
+     * @param handler Function to bind.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hook.html#.add
      */
     add(...handler: Array<(...data: T) => any>): this;
@@ -56,8 +55,6 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Call hook handlers with data.
      *
-     * @param {...any} data
-     * @returns {Hook}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hook.html#.fire
      */
     fire(...data: T): this;
@@ -65,8 +62,7 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Unregister a hook handler.
      *
-     * @param {...Function} handler Function to unbind.
-     * @returns {Hook}
+     * @param handler Function to unbind.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hook.html#.remove
      */
     remove(...handler: Array<(...data: T) => any>): this;
@@ -341,8 +337,7 @@ declare global {
          * hook.add( () => alert( 'Hook was fired' ) );
          * hook.fire();
          * ```
-         * @param {string} name Name of hook.
-         * @returns {Hook}
+         * @param name Name of hook.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook<T extends any[] = any[]>(name: string): Hook<T>;

--- a/mw/html.d.ts
+++ b/mw/html.d.ts
@@ -19,14 +19,14 @@ declare global {
             /**
              * Create an HTML element string, with safe escaping.
              *
-             * @param {string} name The tag name.
-             * @param {Object.<string, string|number|boolean>} [attrs] An object with members mapping element names to values
-             * @param {string|Raw|null} [contents=null] The contents of the element.
+             * @param name The tag name.
+             * @param attrs An object with members mapping element names to values
+             * @param contents The contents of the element.
              *
              *  - string: Text to be escaped.
              *  - null: The element is treated as void with short closing form, e.g. `<br/>`.
              *  - this.Raw: The raw value is directly included.
-             * @returns {string} HTML
+             * @returns HTML
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html.html#.element
              */
             function element(
@@ -45,8 +45,8 @@ declare global {
              * mw.html.escape( '< > \' & "' );
              * // Returns &lt; &gt; &#039; &amp; &quot;
              * ```
-             * @param {string} s The string to escape
-             * @returns {string} HTML
+             * @param s The string to escape
+             * @returns HTML
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html.html#.escape
              */
             function escape(s: string): string;
@@ -65,7 +65,6 @@ declare global {
                 value: V;
 
                 /**
-                 * @param {string} value
                  * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html.Raw.html#Raw
                  */
                 constructor(value: V);

--- a/mw/index.d.ts
+++ b/mw/index.d.ts
@@ -124,9 +124,9 @@ declare global {
          * Used by {@link mw.Message.parse}.
          *
          * @since 1.25
-         * @param {string} formatString Format string
-         * @param {...string} parameters Values for $N replacements
-         * @returns {string} Formatted string
+         * @param formatString Format string
+         * @param parameters Values for $N replacements
+         * @returns Formatted string
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.format
          */
         function format(formatString: string, ...parameters: string[]): string;
@@ -138,7 +138,7 @@ declare global {
          * floating-point values with microsecond precision that are guaranteed to be monotonic.
          * On all other browsers, it will fall back to using `Date`.
          *
-         * @returns {number} Current time
+         * @returns Current time
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.now
          */
         function now(): number;
@@ -165,8 +165,6 @@ declare global {
          * - {@link https://w3c.github.io/requestidlecallback/}
          * - {@link https://developers.google.com/web/updates/2015/08/using-requestidlecallback}
          *
-         * @param {Function} callback
-         * @param {IdleCallbackOptions} [options]
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.requestIdleCallback
          */
         function requestIdleCallback(
@@ -187,8 +185,8 @@ declare global {
          * events that match their subscription, including buffered events that fired before the handler
          * was subscribed.
          *
-         * @param {string} topic Topic name
-         * @param {AnalyticEventData} [data] Data describing the event.
+         * @param topic Topic name
+         * @param data Data describing the event.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.track
          */
         function track(topic: string, data?: AnalyticEventData): void;
@@ -201,7 +199,7 @@ declare global {
          * even while `mediawiki.base` and `mw.track` are still in-flight.
          *
          * @private
-         * @param {ErrorAnalyticEventData} data Data describing the event, encoded as an object; see {@link errorLogger.logError}
+         * @param data Data describing the event, encoded as an object; see {@link errorLogger.logError}
          */
         function trackError(topic: string, data: ErrorAnalyticEventData): void;
 
@@ -223,8 +221,8 @@ declare global {
          * // To subscribe to any of `foo.*`, e.g. both `foo.bar` and `foo.quux`
          * mw.trackSubscribe( 'foo.', console.log );
          * ```
-         * @param {string} topic Handle events whose name starts with this string prefix
-         * @param {function(string, AnalyticEventData): void} callback Handler to call for each matching tracked event
+         * @param topic Handle events whose name starts with this string prefix
+         * @param callback Handler to call for each matching tracked event
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.trackSubscribe
          */
         function trackSubscribe(topic: string, callback: AnalyticEventCallback): void;
@@ -232,7 +230,6 @@ declare global {
         /**
          * Stop handling events for a particular handler.
          *
-         * @param {function(string, AnalyticEventData): void} callback
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.trackUnsubscribe
          */
         function trackUnsubscribe(callback: AnalyticEventCallback): void;

--- a/mw/inspect.d.ts
+++ b/mw/inspect.d.ts
@@ -81,7 +81,6 @@ declare global {
          *
          * When invoked without arguments, prints all available reports.
          *
-         * @param {...string} [reports]
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.inspect
          */
         function inspect(...reports: ResourceLoaderReport[]): void;
@@ -102,8 +101,8 @@ declare global {
              * contains and the number which match some element in the current
              * document.
              *
-             * @param {string} css CSS source
-             * @returns {SelectorCounts} Selector counts
+             * @param css CSS source
+             * @returns Selector counts
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.auditSelectors
              */
             function auditSelectors(css: string): SelectorCounts;
@@ -111,7 +110,7 @@ declare global {
             /**
              * Print tabular data to the console using console.table.
              *
-             * @param {any[]} data Tabular data represented as an array of objects
+             * @param data Tabular data represented as an array of objects
              *  with common properties.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.dumpTable
              */
@@ -120,8 +119,7 @@ declare global {
             /**
              * Return a map of all dependency relationships between loaded modules.
              *
-             * @returns {Object.<string, Dependency>} Maps module names to objects. Each sub-object has
-             *  two properties, 'requires' and 'requiredBy'.
+             * @returns Maps module names to objects. Each sub-object has two properties, 'requires' and 'requiredBy'.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.getDependencyGraph
              */
             function getDependencyGraph(): Record<string, Dependency>;
@@ -129,7 +127,7 @@ declare global {
             /**
              * Get a list of all loaded ResourceLoader modules.
              *
-             * @returns {string[]} List of module names
+             * @returns List of module names
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.getLoadedModules
              */
             function getLoadedModules(): string[];
@@ -137,8 +135,8 @@ declare global {
             /**
              * Calculate the byte size of a ResourceLoader module.
              *
-             * @param {string} moduleName The name of the module
-             * @returns {number|null} Module size in bytes or null
+             * @param moduleName The name of the module
+             * @returns Module size in bytes or null
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.getModuleSize
              */
             function getModuleSize(moduleName: string): number | null;
@@ -148,8 +146,8 @@ declare global {
              * of all loaded modules and return an array of the names of the
              * modules that matched.
              *
-             * @param {string|RegExp} pattern String or regexp to match.
-             * @returns {string[]} Array of the names of modules that matched.
+             * @param pattern String or regexp to match.
+             * @returns Array of the names of modules that matched.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.grep
              */
             function grep(pattern: string | RegExp): string[];
@@ -159,7 +157,7 @@ declare global {
              *
              * When invoked without arguments, prints all available reports.
              *
-             * @param {...ResourceLoaderReport} [reports] One or more of "size", "css", "store", or "time".
+             * @param reports One or more of "size", "css", "store", or "time".
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mediawiki.inspect.html#.runReports
              */
             function runReports(...reports: ResourceLoaderReport[]): void;

--- a/mw/language.d.ts
+++ b/mw/language.d.ts
@@ -52,8 +52,7 @@ declare global {
              * Formats language tags according the BCP 47 standard.
              * See LanguageCode::bcp47 for the PHP implementation.
              *
-             * @param {string} languageTag Well-formed language tag
-             * @returns {string}
+             * @param languageTag Well-formed language tag
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.bcp47
              */
             function bcp47(languageTag: string): string;
@@ -68,11 +67,10 @@ declare global {
              *  it is poorly named, corresponds to a deprecated function in core, and
              *  its functionality should be rolled into convertNumber().
              * @deprecated Removed since 1.40.
-             * @param {number} value
-             * @param {string} pattern Pattern string as described by Unicode TR35
-             * @param {number|null} [minimumGroupingDigits=null]
+             * @param value
+             * @param pattern Pattern string as described by Unicode TR35
+             * @param minimumGroupingDigits
              * @throws {Error} If unable to find a number expression in `pattern`.
-             * @returns {string}
              */
             function commafy(
                 value: number,
@@ -87,9 +85,6 @@ declare global {
              * The rules can be defined in $wgGrammarForms global or computed
              * dynamically by overriding this method per language.
              *
-             * @param {string} word
-             * @param {string} form
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.convertGrammar
              */
             function convertGrammar(word: string, form: string): string;
@@ -97,9 +92,9 @@ declare global {
             /**
              * Converts a number using {@link getDigitTransformTable()}.
              *
-             * @param {number} num Value to be converted
-             * @param {boolean} [integer=false] Whether to convert the return value to an integer
-             * @returns {number|string} Formatted number
+             * @param num Value to be converted
+             * @param integer Whether to convert the return value to an integer. Defaults to `false`.
+             * @returns Formatted number
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.convertNumber
              */
             function convertNumber(num: number, integer: true): number;
@@ -109,10 +104,10 @@ declare global {
             /**
              * Plural form transformations, needed for some languages.
              *
-             * @param {number} count Non-localized quantifier
-             * @param {string[]} forms List of plural forms
-             * @param {Object.<number, string>} [explicitPluralForms] List of explicit plural forms
-             * @returns {string} Correct form for quantifier in this language
+             * @param count Non-localized quantifier
+             * @param forms List of plural forms
+             * @param explicitPluralForms List of explicit plural forms
+             * @returns Correct form for quantifier in this language
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.convertPlural
              */
             function convertPlural(
@@ -129,9 +124,8 @@ declare global {
              *
              * These details may be overridden per language.
              *
-             * @param {string} gender 'male', 'female', or anything else for neutral.
-             * @param {string[]} forms List of gender forms
-             * @returns {string}
+             * @param gender 'male', 'female', or anything else for neutral.
+             * @param forms List of gender forms
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.gender
              */
             function gender<T extends string>(gender: string, forms: [T, T?, T?]): T;
@@ -143,25 +137,22 @@ declare global {
              * Structured by language code and data key, covering for the potential inexistence of a
              * data object for this language.
              *
-             * @param {string} langCode
-             * @param {string} dataKey
-             * @returns {any} Value stored in the mw.Map (or `undefined` if there is no map for the
-             *  specified langCode)
+             * @param langCode
+             * @param dataKey
+             * @returns Value stored in the mw.Map (or `undefined` if there is no map for the specified langCode)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.getData
              */
             function getData(langCode: string, dataKey: string): any;
 
             /**
              * Get the digit transform table for current UI language.
-             *
-             * @returns {Object.<number|string, string>|string[]}
              */
             function getDigitTransformTable(): string[] | Record<number | string, string>;
 
             /**
              * Get the language fallback chain for current UI language, including the language itself.
              *
-             * @returns {string[]} List of language keys, e.g. `['pfl', de', 'en']`
+             * @returns List of language keys, e.g. `['pfl', de', 'en']`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.getFallbackLanguageChain
              */
             function getFallbackLanguageChain(): string[];
@@ -169,15 +160,13 @@ declare global {
             /**
              * Get the language fallback chain for current UI language (not including the language itself).
              *
-             * @returns {string[]} List of language keys, e.g. `['de', 'en']`
+             * @returns List of language keys, e.g. `['de', 'en']`
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.getFallbackLanguages
              */
             function getFallbackLanguages(): string[];
 
             /**
              * Get the separator transform table for current UI language.
-             *
-             * @returns {Object.<number|string, string>|string[]}
              */
             function getSeparatorTransformTable(): string[] | Record<number | string, string>;
 
@@ -186,8 +175,6 @@ declare global {
              *
              * See Language::listToText in languages/Language.php
              *
-             * @param {string[]} list
-             * @returns {string}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.listToText
              */
             function listToText(list: string[]): string;
@@ -197,9 +184,9 @@ declare global {
              *
              * Creates the data {@link mw.Map} if there isn't one for the specified language already.
              *
-             * @param {string} langCode
-             * @param {string|Object.<string, any>} dataKey Key or object of key/values
-             * @param {any} [value] Value for dataKey, omit if dataKey is an object
+             * @param langCode
+             * @param dataKey Key or object of key/values
+             * @param value Value for dataKey, omit if dataKey is an object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.language.html#.setData
              */
             function setData(langCode: string, dataKey: string, value: any): void;
@@ -209,9 +196,9 @@ declare global {
              * Pads an array to a specific length by copying the last one element.
              *
              * @private
-             * @param {string[]} forms Number of forms given to convertPlural
-             * @param {number} count Number of forms required
-             * @returns {string[]} Padded array of forms
+             * @param forms Number of forms given to convertPlural
+             * @param count Number of forms required
+             * @returns Padded array of forms
              */
             function preConvertPlural<T extends string[]>(
                 forms: T,

--- a/mw/loader.d.ts
+++ b/mw/loader.d.ts
@@ -30,8 +30,8 @@ interface ModuleRequire {
     /**
      * Get the exported value of a module.
      *
-     * @param {string} moduleName Module name
-     * @returns {any} Exported value
+     * @param moduleName Module name
+     * @returns Exported value
      */
     (moduleName: string): any;
 }
@@ -97,10 +97,9 @@ declare global {
             /**
              * Create a new style element and add it to the DOM.
              *
-             * @param {string} text CSS text
-             * @param {Node|null} [nextNode] The element where the style tag
-             *  should be inserted before
-             * @returns {HTMLStyleElement} Reference to the created style element
+             * @param text CSS text
+             * @param nextNode The element where the style tag should be inserted before
+             * @returns Reference to the created style element
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.addStyleTag
              */
             function addStyleTag(text: string, nextNode?: Node | null): HTMLStyleElement;
@@ -108,7 +107,6 @@ declare global {
             /**
              * Get the names of all registered ResourceLoader modules.
              *
-             * @returns {string[]}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.getModuleNames
              */
             function getModuleNames(): string[];
@@ -129,8 +127,8 @@ declare global {
              *     } );
              * } );
              * ```
-             * @param {string} url Script URL
-             * @returns {JQuery.Promise} Resolved when the script is loaded
+             * @param url Script URL
+             * @returns Resolved when the script is loaded
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.getScript
              */
             function getScript(url: string): JQuery.Promise<any>;
@@ -172,9 +170,8 @@ declare global {
              *    The module was registered client-side and requested, but the server denied knowledge
              *    of the module's existence.
              *
-             * @param {string} module Name of module
-             * @returns {string|null} The state, or null if the module (or its state) is not
-             *  in the registry.
+             * @param module Name of module
+             * @returns The state, or null if the module (or its state) is not in the registry.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.getState
              */
             function getState(module: string): ModuleState | null;
@@ -191,11 +188,11 @@ declare global {
              * - This method is used for preloading, which must not throw. Later code that
              *   calls {@link using()} will handle the error.
              *
-             * @param {string|string[]} modules Either the name of a module, array of modules,
+             * @param modules Either the name of a module, array of modules,
              *  or a URL of an external script or style
-             * @param {string} [type="text/javascript"] MIME type to use if calling with a URL of an
+             * @param type MIME type to use if calling with a URL of an
              *  external script or style; acceptable values are "text/css" and
-             *  "text/javascript"; if no type is provided, text/javascript is assumed.
+             *  "text/javascript"; if no type is provided, `text/javascript` is assumed.
              * @throws {Error} If type is invalid
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.load
              */
@@ -231,11 +228,11 @@ declare global {
              * ```
              * @since 1.23 - this returns a promise.
              * @since 1.28 - the promise is resolved with a `require` function.
-             * @param {string|string[]} dependencies Module name or array of modules names the
+             * @param dependencies Module name or array of modules names the
              *  callback depends on to be ready before executing
-             * @param {function(ModuleRequire):void} [ready] Callback to execute when all dependencies are ready
-             * @param {function(Error, ...any):void} [error] Callback to execute if one or more dependencies failed
-             * @returns {JQuery.Promise<ModuleRequire>} With a `require` function
+             * @param ready Callback to execute when all dependencies are ready
+             * @param error Callback to execute if one or more dependencies failed
+             * @returns With a `require` function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.loader.html#.using
              */
             function using(
@@ -264,10 +261,9 @@ declare global {
              *
              * @private
              * @since 1.39
-             * @param {string} url URL
-             * @param {string} [media] Media attribute
-             * @param {Node|null} [nextNode]
-             * @returns {HTMLLinkElement}
+             * @param url URL
+             * @param media Media attribute
+             * @param nextNode
              */
             function addLinkTag(
                 url: string,
@@ -280,11 +276,10 @@ declare global {
              *
              * @private
              * @since 1.39
-             * @param {string} src URL to script, will be used as the src attribute in the script tag
-             * @param {function():void} [callback] Callback to run after request resolution
-             * @param {string[]} [modules] List of modules being requested, for state to be marked as error
+             * @param src URL to script, will be used as the src attribute in the script tag
+             * @param callback Callback to run after request resolution
+             * @param modules List of modules being requested, for state to be marked as error
              * in case the script fails to load
-             * @returns {HTMLScriptElement}
              */
             function addScriptTag(
                 src: string,
@@ -302,7 +297,7 @@ declare global {
              * mw.loader.addSource( { mediawikiwiki: 'https://www.mediawiki.org/w/load.php' } );
              * ```
              * @private
-             * @param {Object.<string, string>} ids An object mapping ids to load.php end point urls
+             * @param ids An object mapping ids to load.php end point urls
              * @throws {Error} If source id is already registered
              */
             function addSource(ids: Record<string, string>): void;
@@ -313,9 +308,9 @@ declare global {
              * See also {@link work()}.
              *
              * @private
-             * @param {string[]} dependencies Array of module names in the registry
-             * @param {function():void} [ready] Callback to execute when all dependencies are ready
-             * @param {function(Error, ...any):void} [error] Callback to execute when any dependency fails
+             * @param dependencies Array of module names in the registry
+             * @param ready Callback to execute when all dependencies are ready
+             * @param error Callback to execute when any dependency fails
              */
             function enqueue(
                 dependencies: string[],
@@ -328,7 +323,7 @@ declare global {
              *
              * @private
              * @since 1.41
-             * @param {ModuleDeclarator} declarator The declarator should return an array with the following keys:
+             * @param declarator The declarator should return an array with the following keys:
              *
              * - 0. {string} module Name of module and current module version. Formatted
              *   as `[name]@[version]`. This version should match the requested version
@@ -376,15 +371,15 @@ declare global {
              * @private
              * @since 1.41 - deprecationWarning parameter can be passed.
              * @deprecated since 1.41
-             * @param {string} module
-             * @param {ModuleScript} [script] Module code. This can be a function,
+             * @param module
+             * @param script Module code. This can be a function,
              *  a list of URLs to load via `<script src>`, a string for `domEval()`, or an
              *  object like {"files": {"foo.js":function, "bar.js": function, ...}, "main": "foo.js"}.
              *  If an object is provided, the main file will be executed immediately, and the other
              *  files will only be executed if loaded via require(). If a function or string is
              *  provided, it will be executed/evaluated immediately. If an array is provided, all
              *  URLs in the array will be loaded immediately, and executed as soon as they arrive.
-             * @param {ModuleStyle} [style] Should follow one of the following patterns:
+             * @param style Should follow one of the following patterns:
              *
              * ```js
              * { "css": [css, ..] }
@@ -393,9 +388,9 @@ declare global {
              *
              * The reason css strings are not concatenated anymore is T33676. We now check
              * whether it's safe to extend the stylesheet.
-             * @param {ModuleMessages} [messages] List of key/value pairs to be added to {@link mw.messages}.
-             * @param {ModuleTemplates} [templates] List of key/value pairs to be added to {@link mw.templates}.
-             * @param {string|null} [deprecationWarning] Deprecation warning if any
+             * @param messages List of key/value pairs to be added to {@link mw.messages}.
+             * @param templates List of key/value pairs to be added to {@link mw.templates}.
+             * @param deprecationWarning Deprecation warning if any
              */
             function implement(
                 module: string,
@@ -417,13 +412,13 @@ declare global {
              *
              * @private
              * @since 1.41 - version can no longer be a number (timestamp).
-             * @param {string|Array} modules Module name or array of arrays, each containing
+             * @param modules Module name or array of arrays, each containing
              *  a list of arguments compatible with this method
-             * @param {string|number} [version] Module version hash (falls backs to empty string)
-             * @param {Array<string|number>} [dependencies] Array of module names on which this module depends.
-             * @param {string|null} [group=null] Group which the module is in
-             * @param {string} [source="local"] Name of the source
-             * @param {string|null} [skip=null] Script body of the skip function
+             * @param version Module version hash (falls backs to empty string)
+             * @param dependencies Array of module names on which this module depends.
+             * @param group Group which the module is in
+             * @param source Name of the source, defaults to "local"
+             * @param skip Script body of the skip function
              */
             function register(
                 modules: string,
@@ -465,8 +460,8 @@ declare global {
              * Get names of module that a module depends on, in their proper dependency order.
              *
              * @private
-             * @param {string[]} modules Array of string module names
-             * @returns {string[]} List of dependencies, including 'module'.
+             * @param modules Array of string module names
+             * @returns List of dependencies, including 'module'.
              * @throws {Error} If an unregistered module or a dependency loop is encountered
              */
             // note: U is required so T is not inferred from the "modules" argument
@@ -476,7 +471,7 @@ declare global {
              * Change the state of one or more modules.
              *
              * @private
-             * @param {Object.<string, ModuleState>} states Object of module name/state pairs
+             * @param states Object of module name/state pairs
              */
             function state(states: Record<string, ModuleState>): void;
 
@@ -505,7 +500,7 @@ declare global {
                  * Queue the name of a module that the next update should consider storing.
                  *
                  * @since 1.32
-                 * @param {string} module Module name
+                 * @param module Module name
                  */
                 function add(module: string): void;
 
@@ -517,8 +512,8 @@ declare global {
                 /**
                  * Retrieve a module from the store and update cache hit stats.
                  *
-                 * @param {string} module Module name
-                 * @returns {string|boolean} Module implementation or false if unavailable
+                 * @param module Module name
+                 * @returns Module implementation or false if unavailable
                  */
                 function get(module: string): string | false;
 
@@ -545,7 +540,7 @@ declare global {
                  * Construct a JSON-serializable object representing the content of the store.
                  *
                  * @deprecated Removed since 1.41.
-                 * @returns {JsonModuleStore} Module store contents.
+                 * @returns Module store contents.
                  */
                 function toJSON(): JsonModuleStore;
 
@@ -580,7 +575,7 @@ declare global {
                  * be called if the store is enabled.
                  *
                  * @private
-                 * @param {string} module Module name
+                 * @param module Module name
                  */
                 function set(module: string): void;
 

--- a/mw/log.d.ts
+++ b/mw/log.d.ts
@@ -9,7 +9,7 @@ declare global {
          * See {@link mw.log} for other logging methods.
          *
          * @variation 2
-         * @param {...any} msg Messages to output to console.
+         * @param msg Messages to output to console.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.log2
          */
         function log(...msg: any[]): void;
@@ -34,11 +34,11 @@ declare global {
              * ```js
              * mw.log.deprecate( Thing, 'old', old, 'Use Other.thing instead', 'Thing.old'  );
              * ```
-             * @param {Object} obj Host object of deprecated property
-             * @param {string} key Name of property to create in `obj`
-             * @param {any} val The value this property should return when accessed
-             * @param {string} [msg] Optional extra text to add to the deprecation warning
-             * @param {string} [logName] Name of the feature for deprecation tracker.
+             * @param obj Host object of deprecated property
+             * @param key Name of property to create in `obj`
+             * @param val The value this property should return when accessed
+             * @param msg Optional extra text to add to the deprecation warning
+             * @param logName Name of the feature for deprecation tracker.
              *  Tracking is disabled by default, except for global variables on `window`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.log.html#.deprecate
              */
@@ -57,7 +57,7 @@ declare global {
              * argument is an Error object.
              *
              * @since 1.26
-             * @param {...any} msg Messages to output to console
+             * @param msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.log.html#.error
              */
             function error(...msg: any[]): void;
@@ -80,10 +80,9 @@ declare global {
              * hello( 1 );
              * ```
              * @since 1.38
-             * @param {string|null} key Name of the feature for deprecation tracker,
+             * @param key Name of the feature for deprecation tracker,
              *  or null for a console-only deprecation.
-             * @param {string} msg Deprecation warning.
-             * @returns {function():void}
+             * @param msg Deprecation warning.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.log.html#.makeDeprecated
              */
             function makeDeprecated(key: string | null, msg: string): () => void;
@@ -91,7 +90,7 @@ declare global {
             /**
              * Write a message to the browser console's warning channel.
              *
-             * @param {...any} msg Messages to output to console
+             * @param msg Messages to output to console
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.log.html#.warn
              */
             function warn(...msg: any[]): void;

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -5,9 +5,8 @@ declare global {
          *
          * Shortcut for `new mw.Message( mw.messages, key, parameters )`.
          *
-         * @param {string} key Key of message to get
-         * @param {...any} parameters Values for $N replacements
-         * @returns {Message}
+         * @param key Key of message to get
+         * @param parameters Values for $N replacements
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.message
          */
         function message(key: string, ...parameters: any[]): Message;
@@ -101,9 +100,9 @@ declare global {
              * mw.log( obj.escaped() );
              * // You will find: Time &quot;after&quot; &lt;time&gt;
              * ```
-             * @param {Map} map Message store
-             * @param {string} key
-             * @param {Array} [parameters]
+             * @param map Message store
+             * @param key
+             * @param parameters
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#Message
              */
             constructor(map: Map<Record<string, string>>, key: string, parameters?: any[]);
@@ -113,7 +112,7 @@ declare global {
              *
              * This is equivalent to the {@link text} format, which is then HTML-escaped.
              *
-             * @returns {string} String form of html escaped message
+             * @returns String form of html escaped message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#escaped
              */
             escaped(): string;
@@ -121,7 +120,6 @@ declare global {
             /**
              * Check if a message exists. Equivalent to {@link mw.Map.exists}.
              *
-             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#exists
              */
             exists(): boolean;
@@ -132,7 +130,6 @@ declare global {
              * This method is only available when jqueryMsg is loaded.
              *
              * @since 1.41
-             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#isParseable
              */
             isParseable(): boolean;
@@ -140,8 +137,7 @@ declare global {
             /**
              * Add (does not replace) parameters for `$N` placeholder values.
              *
-             * @param {Array} parameters
-             * @returns {Message}
+             * @param parameters
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#params
              */
             params(parameters: any[]): this;
@@ -152,7 +148,7 @@ declare global {
              * If jqueryMsg is loaded, this transforms text and parses a subset of supported wikitext
              * into HTML. Without jqueryMsg, it is equivalent to {@link escaped}.
              *
-             * @returns {string} String form of parsed message
+             * @returns String form of parsed message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#parse
              */
             parse(): string;
@@ -163,7 +159,6 @@ declare global {
              * This method is only available when jqueryMsg is loaded.
              *
              * @since 1.27
-             * @returns {JQuery}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#parseDom
              */
             parseDom(): JQuery;
@@ -174,7 +169,7 @@ declare global {
              * This substitutes parameters, but otherwise does not transform the
              * message content.
              *
-             * @returns {string} String form of plain message
+             * @returns String form of plain message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#plain
              */
             plain(): string;
@@ -186,7 +181,7 @@ declare global {
              * magic words such as `{{plural:}}`, `{{gender:}}`, and `{{int:}}`.
              * Without jqueryMsg, it is equivalent to {@link plain}.
              *
-             * @returns {string} String form of text message
+             * @returns String form of text message
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Message.html#text
              */
             text(): string;
@@ -202,8 +197,8 @@ declare global {
              *
              * @private For internal use by mediawiki.jqueryMsg only
              * @since 1.38 - format parameter can be passed.
-             * @param {string} format
-             * @returns {string} Parsed message
+             * @param format
+             * @returns Parsed message
              */
             private parser(format: string): string;
 
@@ -215,10 +210,9 @@ declare global {
              * other format methods.
              *
              * @since 1.38 - format parameter can be passed.
-             * @param {string} [format="text"] Internal parameter. Uses "text" if called
+             * @param format Internal parameter. Uses "text" if called
              *  implicitly through string casting.
-             * @returns {string} Message in the given format, or `⧼key⧽` if the key
-             *  does not exist.
+             * @returns Message in the given format, or `⧼key⧽` if the key does not exist.
              */
             private toString(format?: "escaped" | "parse" | "plain" | "text"): string;
         }
@@ -228,9 +222,8 @@ declare global {
          *
          * Shortcut for `mw.message( key, parameters... ).text()`.
          *
-         * @param {string} key Key of message to get
-         * @param {...any} parameters Values for $N replacements
-         * @returns {string}
+         * @param key Key of message to get
+         * @param parameters Values for $N replacements
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.msg
          */
         function msg(key: string, ...parameters: any[]): string;

--- a/mw/notification.d.ts
+++ b/mw/notification.d.ts
@@ -58,10 +58,10 @@ declare global {
         /**
          * Convenience method for loading and accessing the {@link mw.notification.notify mw.notification module}.
          *
-         * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
-         * @param {notification.NotificationOptions} [options] The options to use for the notification.
+         * @param message
+         * @param options The options to use for the notification.
          *  See {@link notification.defaults the defaults}.
-         * @returns {JQuery.Promise<Notification>} Notification object
+         * @returns Notification object
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.notify
          */
         function notify(
@@ -115,10 +115,10 @@ declare global {
             /**
              * Display a notification message to the user.
              *
-             * @param {HTMLElement|HTMLElement[]|JQuery|Message|string} message
-             * @param {NotificationOptions} [options] The options to use for the notification.
+             * @param message
+             * @param options The options to use for the notification.
              *  Options not specified default to the values in {@link defaults}.
-             * @returns {Notification} Notification object
+             * @returns Notification object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.notification.html#.notify
              */
             function notify(

--- a/mw/pluralRuleParser.d.ts
+++ b/mw/pluralRuleParser.d.ts
@@ -3,9 +3,9 @@ declare global {
         /**
          * Evaluates a plural rule in CLDR syntax for a number.
          *
-         * @param {string} rule
-         * @param {number} number
-         * @returns {boolean} true if evaluation passed, false if evaluation failed.
+         * @param rule
+         * @param number
+         * @returns true if evaluation passed, false if evaluation failed.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.libs.pluralruleparser.html
          */
         function pluralRuleParser(rule: string, number: number): boolean;

--- a/mw/searchSuggest.d.ts
+++ b/mw/searchSuggest.d.ts
@@ -5,8 +5,8 @@ import { ApiResponse } from "./Api";
  */
 interface ResponseFunction {
     /**
-     * @param {string[]} titles titles of pages that match search
-     * @param {ResponseMetaData} meta meta data relating to search
+     * @param titles titles of pages that match search
+     * @param meta meta data relating to search
      */
     (titles: string[], meta: ResponseMetaData): void;
 }
@@ -47,12 +47,6 @@ declare global {
             /**
              * Queries the wiki and calls response with the result.
              *
-             * @param {Api} api
-             * @param {string} query
-             * @param {ResponseFunction} response
-             * @param {string|number} [limit]
-             * @param {string|number|string[]|number[]} [namespace]
-             * @returns {JQuery.Promise<ApiResponse>}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.searchSuggest.html#.request
              */
             function request(

--- a/mw/storage.d.ts
+++ b/mw/storage.d.ts
@@ -11,9 +11,8 @@ interface SafeStorage {
     /**
      * Retrieve value from device storage.
      *
-     * @param {string} key Key of item to retrieve
-     * @returns {string|null|false} String value, null if no value exists, or false
-     *  if storage is not available.
+     * @param key Key of item to retrieve
+     * @returns String value, null if no value exists, or false if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#get
      */
     get(key: string): string | null | false;
@@ -21,9 +20,8 @@ interface SafeStorage {
     /**
      * Retrieve JSON object from device storage.
      *
-     * @param {string} key Key of item to retrieve
-     * @returns {Object|null|boolean} Object, null if no value exists or value
-     *  is not JSON-parseable, or false if storage is not available.
+     * @param key Key of item to retrieve
+     * @returns Object, null if no value exists or value is not JSON-parseable, or false if storage is not available.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#getObject
      */
     getObject(key: string): any;
@@ -31,8 +29,8 @@ interface SafeStorage {
     /**
      * Remove a value from device storage.
      *
-     * @param {string} key Key of item to remove
-     * @returns {boolean} Whether the key was removed
+     * @param key Key of item to remove
+     * @returns Whether the key was removed
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#remove
      */
     remove(key: string): boolean;
@@ -41,10 +39,10 @@ interface SafeStorage {
      * Set a value in device storage.
      *
      * @since 1.39 - expiry parameter can be passed.
-     * @param {string} key Key name to store under
-     * @param {string} value Value to be stored
-     * @param {number} [expiry] Number of seconds after which this item can be deleted
-     * @returns {boolean} The value was set
+     * @param key Key name to store under
+     * @param value Value to be stored
+     * @param expiry Number of seconds after which this item can be deleted
+     * @returns The value was set
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#set
      */
     set(key: string, value: string, expiry?: number): boolean;
@@ -54,11 +52,11 @@ interface SafeStorage {
      *
      * @since 1.39
      * @since 1.41 - returns a boolean indicating whether the expiry was set.
-     * @param {string} key Key name
-     * @param {number} [expiry] Number of seconds after which this item can be deleted,
+     * @param key Key name
+     * @param expiry Number of seconds after which this item can be deleted,
      *  omit to clear the expiry (either making the item never expire, or to clean up
      *  when deleting a key).
-     * @returns {boolean} The expiry was set (or cleared)
+     * @returns The expiry was set (or cleared)
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#setExpires
      */
     setExpires(key: string, expiry?: number): boolean;
@@ -68,10 +66,10 @@ interface SafeStorage {
      *
      * @since 1.39 - expiry parameter can be passed.
      * @since 1.41 - returns a boolean indicating whether the value was set.
-     * @param {string} key Key name to store under
-     * @param {Object} value Object value to be stored
-     * @param {number} [expiry] Number of seconds after which this item can be deleted
-     * @returns {boolean} The value was set
+     * @param key Key name to store under
+     * @param value Object value to be stored
+     * @param expiry Number of seconds after which this item can be deleted
+     * @returns The value was set
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.storage-SafeStorage.html#setObject
      */
     setObject(key: string, value: any, expiry?: number): boolean;
@@ -81,7 +79,7 @@ interface SafeStorage {
      *
      * @private
      * @since 1.39
-     * @returns {JQuery.Promise} Resolves when items have been expired
+     * @returns Resolves when items have been expired
      */
     clearExpired(): JQuery.Promise<undefined>;
 
@@ -90,7 +88,7 @@ interface SafeStorage {
      *
      * @private
      * @since 1.39
-     * @returns {JQuery.Promise<string[]>} Promise resolving with all the keys which have
+     * @returns Promise resolving with all the keys which have
      *  expiry values (unprefixed), or as many could be retrieved in the allocated time.
      */
     getExpiryKeys(): JQuery.Promise<string[]>;
@@ -100,8 +98,8 @@ interface SafeStorage {
      *
      * @private
      * @since 1.39
-     * @param {string} key Key name
-     * @returns {boolean} Whether key is expired
+     * @param key Key name
+     * @returns Whether key is expired
      */
     isExpired(key: string): boolean;
 }

--- a/mw/tempUserCreated.d.ts
+++ b/mw/tempUserCreated.d.ts
@@ -9,6 +9,7 @@ declare global {
         namespace tempUserCreated {
             /**
              * Show popup after creation of a temporary user.
+             *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.tempUserCreated.html#.showPopup
              */
             function showPopup(): void;

--- a/mw/template.d.ts
+++ b/mw/template.d.ts
@@ -5,9 +5,8 @@ interface TemplateRenderer {
     /**
      * Compiles a template for rendering.
      *
-     * @param {Object} [data] for the template
-     * @param {Object} [partials] additional partial templates
-     * @returns {JQuery}
+     * @param data for the template
+     * @param partials additional partial templates
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#~TemplateCompileFunction
      */
     render(data?: unknown, partials?: unknown): JQuery;
@@ -20,8 +19,8 @@ interface TemplateCompiler {
     /**
      * Compiles a template for rendering.
      *
-     * @param {string} src source of the template
-     * @returns {TemplateRenderer} for rendering
+     * @param src source of the template
+     * @returns for rendering
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#~TemplateCompileFunction
      */
     compile(src: string): TemplateRenderer;
@@ -58,10 +57,10 @@ declare global {
              *
              * Precompiles the newly added template based on the suffix in its name.
              *
-             * @param {string} moduleName Name of the ResourceLoader module the template is associated with
-             * @param {string} templateName Name of the template (including suffix)
-             * @param {string} templateBody Contents of the template (e.g. html markup)
-             * @returns {TemplateRenderer} Compiled template
+             * @param moduleName Name of the ResourceLoader module the template is associated with
+             * @param templateName Name of the template (including suffix)
+             * @param templateBody Contents of the template (e.g. html markup)
+             * @returns Compiled template
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.add
              */
             function add(
@@ -73,9 +72,9 @@ declare global {
             /**
              * Compile a string of template markup with an engine of choice.
              *
-             * @param {string} templateBody Template body
-             * @param {string} compilerName The name of a registered compiler.
-             * @returns {TemplateRenderer} Compiled template
+             * @param templateBody Template body
+             * @param compilerName The name of a registered compiler.
+             * @returns Compiled template
              * @throws {Error} when unknown compiler name provided.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.compile
              */
@@ -84,9 +83,9 @@ declare global {
             /**
              * Get a compiled template by module and template name.
              *
-             * @param {string} moduleName Name of the module to retrieve the template from
-             * @param {string} templateName Name of template to be retrieved
-             * @returns {TemplateRenderer} Compiled template
+             * @param moduleName Name of the module to retrieve the template from
+             * @param templateName Name of template to be retrieved
+             * @returns Compiled template
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.get
              */
             function get(moduleName: string, templateName: string): TemplateRenderer;
@@ -94,8 +93,8 @@ declare global {
             /**
              * Get a compiler via its name.
              *
-             * @param {string} name Name of a compiler
-             * @returns {TemplateCompiler} The compiler
+             * @param name Name of a compiler
+             * @returns The compiler
              * @throws {Error} when unknown compiler provided
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.getCompiler
              */
@@ -104,8 +103,8 @@ declare global {
             /**
              * Get the name of the associated compiler based on a template name.
              *
-             * @param {string} templateName Name of a template (including suffix)
-             * @returns {string} Name of a compiler
+             * @param templateName Name of a template (including suffix)
+             * @returns Name of a compiler
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.getCompilerName
              */
             function getCompilerName(templateName: string): string;
@@ -118,8 +117,8 @@ declare global {
              *
              * The compiler name must correspond with the name suffix of templates that use this compiler.
              *
-             * @param {string} name Compiler name
-             * @param {TemplateCompiler} compiler
+             * @param name Compiler name
+             * @param compiler
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.template.html#.registerCompiler
              */
             function registerCompiler(name: string, compiler: TemplateCompiler): void;

--- a/mw/user.d.ts
+++ b/mw/user.d.ts
@@ -32,8 +32,8 @@ export interface User {
         /**
          * Retrieve the current value of the feature from the HTML document element.
          *
-         * @param {string} feature
-         * @returns {false|string} returns false if the feature is not recognized.
+         * @param feature
+         * @returns returns false if the feature is not recognized.
          *  returns string if a feature was found.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.clientPrefs.html#.get
          */
@@ -42,9 +42,9 @@ export interface User {
         /**
          * Change the class on the HTML document element, and save the value in a cookie.
          *
-         * @param {string} feature
-         * @param {string} value
-         * @returns {boolean} True if feature was stored successfully, false if the value
+         * @param feature
+         * @param value
+         * @returns True if feature was stored successfully, false if the value
          *  uses a forbidden character or the feature is not recognised
          *  e.g. a matching class was not defined on the HTML document element.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.clientPrefs.html#.set
@@ -77,7 +77,7 @@ export interface User {
      * created yet, and the name is not visible to other users.
      *
      * @since 1.41
-     * @returns {JQuery.Promise<string>} Promise resolved with the username if we succeeded,
+     * @returns Promise resolved with the username if we succeeded,
      *  or resolved with `null` if we failed
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.acquireTempUserName
      */
@@ -104,7 +104,7 @@ export interface User {
      *
      * `n(p;H) = n(0.01,2^80)= sqrt (2 * 2^80 * ln(1/(1-0.01)))`
      *
-     * @returns {string} 80 bit integer (20 characters) in hex format, padded
+     * @returns 80 bit integer (20 characters) in hex format, padded
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.generateRandomSessionId
      */
     generateRandomSessionId(): string;
@@ -113,7 +113,7 @@ export interface User {
      * Get date user first registered, if available.
      *
      * @since 1.42
-     * @returns {false|null|Date} False for anonymous users, null if data is
+     * @returns False for anonymous users, null if data is
      *  unavailable, or Date for when the user registered. For temporary users
      *  that is when their temporary account was created.
      */
@@ -122,8 +122,6 @@ export interface User {
     /**
      * Get the current user's groups.
      *
-     * @param {function(string[]):any} [callback]
-     * @returns {JQuery.Promise<string[]>}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getGroups
      */
     getGroups<T>(callback: (groups: string[]) => T): JQuery.Promise<T>;
@@ -134,7 +132,7 @@ export interface User {
      *
      * Not to be confused with {@link id}.
      *
-     * @returns {number} Current user's id, or 0 if user is anonymous
+     * @returns Current user's id, or 0 if user is anonymous
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getId
      */
     getId(): number;
@@ -142,7 +140,7 @@ export interface User {
     /**
      * Get the current user's name.
      *
-     * @returns {string|null} User name string or null if user is anonymous
+     * @returns User name string or null if user is anonymous
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getName
      */
     getName(): string | null;
@@ -152,7 +150,7 @@ export interface User {
      * cached within this class (also known as a page view token).
      *
      * @since 1.32
-     * @returns {string} 80 bit integer in hex format, padded
+     * @returns 80 bit integer in hex format, padded
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getPageviewToken
      */
     getPageviewToken(): string;
@@ -160,7 +158,7 @@ export interface User {
     /**
      * Get date user registered, if available.
      *
-     * @returns {false|null|Date} False for anonymous users, null if data is
+     * @returns False for anonymous users, null if data is
      *  unavailable, or Date for when the user registered.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getRegistration
      */
@@ -169,8 +167,6 @@ export interface User {
     /**
      * Get the current user's rights.
      *
-     * @param {function(string[]):any} [callback]
-     * @returns {JQuery.Promise<string[]>}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.getRights
      */
     getRights<T>(callback: (rights: string[]) => T): JQuery.Promise<T>;
@@ -181,7 +177,7 @@ export interface User {
      *
      * Not to be confused with {@link getId}.
      *
-     * @returns {string} User name or random session ID
+     * @returns User name or random session ID
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.id
      */
     id(): string;
@@ -189,7 +185,6 @@ export interface User {
     /**
      * Check whether the current user is anonymous.
      *
-     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.isAnon
      */
     isAnon(): boolean;
@@ -198,7 +193,6 @@ export interface User {
      * Check whether the user is a normal non-temporary registered user.
      *
      * @since 1.40
-     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.isNamed
      */
     isNamed(): boolean;
@@ -207,7 +201,6 @@ export interface User {
      * Check whether the user is an autocreated temporary user.
      *
      * @since 1.40
-     * @returns {boolean}
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.isTemp
      */
     isTemp(): boolean;
@@ -221,7 +214,7 @@ export interface User {
      *
      * **Note:** Server-side code must never interpret or modify this value.
      *
-     * @returns {string} Random session ID (20 hex characters)
+     * @returns Random session ID (20 hex characters)
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.user.html#.sessionId
      */
     sessionId(): string;
@@ -230,7 +223,6 @@ export interface User {
      * Get the current user's groups or rights.
      *
      * @private
-     * @returns {JQuery.Promise<mw.Api.UserInfo>}
      */
     getUserInfo(): JQuery.Promise<mw.Api.UserInfo>;
 }

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -90,8 +90,8 @@ declare global {
              *
              * See also {@link https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet MDN: CSSStyleSheet}.
              *
-             * @param {string} text CSS to be appended
-             * @returns {CSSStyleSheet} The sheet object
+             * @param text CSS to be appended
+             * @returns The sheet object
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addCSS
              */
             function addCSS(text: string): CSSStyleSheet;
@@ -107,9 +107,9 @@ declare global {
              * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 2' );
              * ```
              * @since 1.41
-             * @param {string} id of the new portlet.
-             * @param {string} [label] of the new portlet.
-             * @param {string} [selectorHint] selector of the element the new portlet would like to
+             * @param id of the new portlet.
+             * @param label of the new portlet.
+             * @param selectorHint selector of the element the new portlet would like to
              *  be inserted near. Typically the portlet will be inserted after this selector, but in some
              *  skins, the skin may relocate the element when provided to the closest available space.
              *  If this argument is not passed then the caller is responsible for appending the element
@@ -119,7 +119,7 @@ declare global {
              *  When provided, skins can use the parameter to infer information about how the user intended
              *  the menu to be rendered. For example, in vector and vector-2022 targeting '#p-cactions' will
              *  result in the creation of a dropdown.
-             * @returns {HTMLElement|null} will be null if it was not possible to create an portlet with
+             * @returns will be null if it was not possible to create an portlet with
              *  the required information e.g. the selector given in `selectorHint` parameter could not be resolved
              *  to an existing element in the page.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortlet
@@ -183,19 +183,19 @@ declare global {
              * } );
              * ```
              *
-             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
-             * @param {string} href Link URL
-             * @param {string} text Link text
-             * @param {string} [id] ID of the list item, should be unique and preferably have
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @param href Link URL
+             * @param text Link text
+             * @param id ID of the list item, should be unique and preferably have
              *  the appropriate prefix ('ca-', 'pt-', 'n-' or 't-')
-             * @param {string} [tooltip] Text to show when hovering over the link, without accesskey suffix
-             * @param {string} [accesskey] Access key to activate this link. One character only,
+             * @param tooltip Text to show when hovering over the link, without accesskey suffix
+             * @param accesskey Access key to activate this link. One character only,
              *  avoid conflicts with other links. Use `$( '[accesskey=x]' )` in the console to
              *  see if 'x' is already used.
-             * @param {HTMLElement|JQuery|string} [nextnode] Element that the new item should be added before.
+             * @param nextnode Element that the new item should be added before.
              *  Must be another item in the same list, it will be ignored otherwise.
              *  Can be specified as DOM reference, as jQuery object, or as CSS selector string.
-             * @returns {HTMLLIElement|null} The added list item, or null if no element was added.
+             * @returns The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortletLink
              */
             function addPortletLink(
@@ -212,7 +212,6 @@ declare global {
              * Add content to the subtitle of the skin.
              *
              * @since 1.40
-             * @param {HTMLElement|string} nodeOrHTMLString
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addSubtitle
              */
             function addSubtitle(nodeOrHTMLString: HTMLElement | string): void;
@@ -238,10 +237,10 @@ declare global {
              *
              * @since 1.34
              * @since 1.38 - swapped parameter order; immediate parameter can be passed.
-             * @param {Function} func Function to debounce
-             * @param {number} [wait=0] Wait period in milliseconds
-             * @param {boolean} [immediate] Trigger on leading edge
-             * @returns {Function} Debounced function
+             * @param func Function to debounce
+             * @param wait Wait period in milliseconds, defaults to 0
+             * @param immediate Trigger on leading edge
+             * @returns Debounced function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.debounce
              */
             function debounce<T extends (...args: any[]) => any>(
@@ -261,9 +260,9 @@ declare global {
              *
              * @since 1.34
              * @deprecated since 1.38 - use `mw.util.debounce(func, wait)` instead of `mw.util.debounce(wait, func)`.
-             * @param {number} delay Wait period in milliseconds
-             * @param {Function} callback Function to debounce
-             * @returns {Function} Debounced function
+             * @param delay Wait period in milliseconds
+             * @param callback Function to debounce
+             * @returns Debounced function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.debounce
              */
             function debounce<T extends (...args: any[]) => any>(
@@ -277,8 +276,8 @@ declare global {
              * Analog to `Sanitizer::escapeIdForAttribute()` in PHP.
              *
              * @since 1.30
-             * @param {string} str String to encode
-             * @returns {string} Encoded string
+             * @param str String to encode
+             * @returns Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.escapeIdForAttribute
              */
             function escapeIdForAttribute(str: string): string;
@@ -289,8 +288,8 @@ declare global {
              * Analog to `Sanitizer::escapeIdForLink()` in PHP.
              *
              * @since 1.30
-             * @param {string} str String to encode
-             * @returns {string} Encoded string
+             * @param str String to encode
+             * @returns Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.escapeIdForLink
              */
             function escapeIdForLink(str: string): string;
@@ -306,8 +305,8 @@ declare global {
              *
              * @since 1.26
              * @since 1.34 - moved to {@link mw.util}.
-             * @param {string} str String to escape
-             * @returns {string} Escaped string
+             * @param str String to escape
+             * @returns Escaped string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.escapeRegExp
              */
             function escapeRegExp(str: string): string;
@@ -324,9 +323,9 @@ declare global {
              * mw.util.getArrayParam( 'foo', new URLSearchParams( '?foo=a' ) ); // null
              * ```
              * @since 1.41
-             * @param {string} param The parameter name.
-             * @param {URLSearchParams} [params] Parsed URL parameters to search through, defaulting to the current browsing location.
-             * @returns {string[]|null} Parameter value, or null if parameter was not found.
+             * @param param The parameter name.
+             * @param params Parsed URL parameters to search through, defaulting to the current browsing location.
+             * @returns Parameter value, or null if parameter was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.getArrayParam
              */
             function getArrayParam(param: string, params?: URLSearchParams): string[] | null;
@@ -340,9 +339,9 @@ declare global {
              * mw.util.getParamValue( 'foo', '/?foo=' ); // ""
              * mw.util.getParamValue( 'foo', '/' ); // null
              * ```
-             * @param {string} param The parameter name.
-             * @param {string} [url=location.href] URL to search through, defaulting to the current browsing location.
-             * @returns {string|null} Parameter value, or null if parameter was not found.
+             * @param param The parameter name.
+             * @param url URL to search through, defaulting to the current browsing location.
+             * @returns Parameter value, or null if parameter was not found.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.getParamValue
              */
             function getParamValue(param: string, url?: string): string | null;
@@ -363,9 +362,9 @@ declare global {
              * so we use the percent-decode.
              *
              * @since 1.39
-             * @param {string} [hash] Hash fragment, without the leading '#'.
+             * @param hash Hash fragment, without the leading '#'.
              *  Taken from location.hash if omitted.
-             * @returns {HTMLElement|null} Element, if found
+             * @returns Element, if found
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.getTargetFromFragment
              */
             function getTargetFromFragment(hash?: string): HTMLElement | null;
@@ -373,10 +372,10 @@ declare global {
             /**
              * Get the URL to a given local wiki page name.
              *
-             * @param {string|null} [pageName="wgPageName"] Page name
-             * @param {QueryParams} [params] A mapping of query parameter names to values,
+             * @param pageName Page name
+             * @param params A mapping of query parameter names to values,
              *  e.g. `{ action: 'edit' }`
-             * @returns {string} URL, relative to `wgServer`.
+             * @returns URL, relative to `wgServer`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.getUrl
              */
             // params are handled by $.param, which converts any value to a string. However, instead of using toString(),
@@ -387,7 +386,7 @@ declare global {
              * Hide a portlet.
              *
              * @since 1.36
-             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.hidePortlet
              */
             function hidePortlet(portletId: string): void;
@@ -398,8 +397,6 @@ declare global {
              * such as watchlisting, page protection, and block expiries.
              *
              * @since 1.42
-             * @param {string|null} str
-             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isInfinity
              */
             function isInfinity(str: string | null): boolean;
@@ -408,9 +405,8 @@ declare global {
              * Check whether a string is a valid IP address.
              *
              * @since 1.25
-             * @param {string} address String to check
-             * @param {boolean} [allowBlock=false] If a block of IPs should be allowed
-             * @returns {boolean}
+             * @param address String to check
+             * @param allowBlock If a block of IPs should be allowed
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isIPAddress
              */
             function isIPAddress(address: string, allowBlock?: boolean): boolean;
@@ -430,9 +426,8 @@ declare global {
              * mw.util.isIPv4Address( '192.0.2.0/24' );
              * mw.util.isIPv4Address( 'hello' );
              * ```
-             * @param {string} address
-             * @param {boolean} [allowBlock=false]
-             * @returns {boolean}
+             * @param address
+             * @param allowBlock Defaults to `false`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isIPv4Address
              */
             function isIPv4Address(
@@ -459,9 +454,8 @@ declare global {
              * mw.util.isIPv6Address( '2001:db8:a::/32' );
              * mw.util.isIPv6Address( 'hello' );
              * ```
-             * @param {string} address
-             * @param {boolean} [allowBlock=false]
-             * @returns {boolean}
+             * @param address
+             * @param allowBlock Defaults to `false`.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isIPv6Address
              */
             function isIPv6Address(address: string, allowBlock?: boolean): boolean;
@@ -470,8 +464,7 @@ declare global {
              * Whether a portlet is visible.
              *
              * @since 1.36
-             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
-             * @returns {boolean}
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isPortletVisible
              */
             function isPortletVisible(portletId: string): boolean;
@@ -482,8 +475,6 @@ declare global {
              * This functionality has been adapted from `MediaWiki\User\TempUser\Pattern::isMatch()`
              *
              * @since 1.40
-             * @param {string} username
-             * @returns {boolean}
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.isTemporaryUser
              */
             function isTemporaryUser(username: string): boolean;
@@ -493,10 +484,9 @@ declare global {
              * have been added to the page e.g. mediawiki.codex.messagebox.styles.
              *
              * @since 1.43
-             * @param {string|Node} textOrElement text or node.
-             * @param {string} [type] defaults to notice.
-             * @param {boolean} [inline] whether the notice should be inline.
-             * @returns {Element}
+             * @param textOrElement text or node.
+             * @param type defaults to notice.
+             * @param inline whether the notice should be inline.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.messageBox
              */
             function messageBox(
@@ -515,8 +505,8 @@ declare global {
              * and return the image name, thumbnail size and a template that can be used to resize
              * the image.
              *
-             * @param {string} url URL to parse (URL-encoded)
-             * @returns {ResizeableThumbnailUrl|null} URL data, or null if the URL is not a valid MediaWiki
+             * @param url URL to parse (URL-encoded)
+             * @returns URL data, or null if the URL is not a valid MediaWiki
              *  image/thumbnail URL.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.parseImageUrl
              */
@@ -535,8 +525,8 @@ declare global {
              * to effectively expose the percent-decode implementation.
              *
              * @since 1.39
-             * @param {string} text Text to decode
-             * @returns {string|null} Decoded text, null if decoding failed
+             * @param text Text to decode
+             * @returns Decoded text, null if decoding failed
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.percentDecodeFragment
              */
             function percentDecodeFragment(text: string): string | null;
@@ -549,8 +539,7 @@ declare global {
              * This functionality has been adapted from `\Wikimedia\IPUtils::prettifyIP()`
              *
              * @since 1.38
-             * @param {string} ip IP address in quad or octet form (CIDR or not).
-             * @returns {string|null}
+             * @param ip IP address in quad or octet form (CIDR or not).
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.prettifyIP
              */
             function prettifyIP(ip: string): string | null;
@@ -558,8 +547,8 @@ declare global {
             /**
              * Encode the string like PHP's rawurlencode.
              *
-             * @param {string} str String to be encoded.
-             * @returns {string} Encoded string
+             * @param str String to be encoded.
+             * @returns Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.rawurlencode
              */
             function rawurlencode(str: string): string;
@@ -574,8 +563,7 @@ declare global {
              * This functionality has been adapted from `\Wikimedia\IPUtils::sanitizeIP()`
              *
              * @since 1.38
-             * @param {string} ip IP address in quad or octet form (CIDR or not).
-             * @returns {string|null}
+             * @param ip IP address in quad or octet form (CIDR or not).
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.sanitizeIP
              */
             function sanitizeIP(ip: string): string | null;
@@ -584,7 +572,7 @@ declare global {
              * Reveal a portlet if it is hidden.
              *
              * @since 1.36
-             * @param {string} portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.showPortlet
              */
             function showPortlet(portletId: string): void;
@@ -601,9 +589,9 @@ declare global {
              * Ported from OOUI.
              *
              * @since 1.38
-             * @param {Function} func Function to throttle
-             * @param {number} wait Throttle window length, in milliseconds
-             * @returns {Function} Throttled function
+             * @param func Function to throttle
+             * @param wait Throttle window length, in milliseconds
+             * @returns Throttled function
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.throttle
              */
             function throttle<T extends (...args: any[]) => any>(
@@ -620,8 +608,8 @@ declare global {
              * ```js
              * mw.util.validateEmail( "me@example.org" ) === true;
              * ```
-             * @param {string} email E-mail address
-             * @returns {boolean|null} True if valid, false if invalid, null if `email` was empty.
+             * @param email E-mail address
+             * @returns True if valid, false if invalid, null if `email` was empty.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.validateEmail
              */
             function validateEmail(email: string): boolean | null;
@@ -632,8 +620,8 @@ declare global {
              * Similar to `wfScript()` in PHP.
              *
              * @since 1.18
-             * @param {string} [str="index"] Name of entry point (e.g. 'index' or 'api')
-             * @returns {string} URL to the script file (e.g. `/w/api.php`)
+             * @param str Name of entry point (e.g. `index` or `api`), defaults to `index`.
+             * @returns URL to the script file (e.g. `/w/api.php`)
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.wikiScript
              */
             function wikiScript(str?: string): string;
@@ -647,8 +635,8 @@ declare global {
              * purging after edits, thus leading to stale content being served from a
              * non-canonical URL.
              *
-             * @param {string} str String to be encoded.
-             * @returns {string} Encoded string
+             * @param str String to be encoded.
+             * @returns Encoded string
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.wikiUrlencode
              */
             function wikiUrlencode(str: string): string;

--- a/vue/index.d.ts
+++ b/vue/index.d.ts
@@ -14,10 +14,7 @@ declare module "vue" {
      * `vue.createMwApp()` is recommended anywhere one would normally use `Vue.createApp()`.
      *
      * @since 1.38
-     * @method createMwApp
-     * @param {...any} args
-     * @returns {Object} Vue app instance
-     * @memberof module:vue
+     * @returns Vue app instance
      * @see {@link https://doc.wikimedia.org/mediawiki-core/master/js/module-vue.html#.createMwApp}
      */
     export const createMwApp: typeof createApp;
@@ -39,10 +36,8 @@ declare module "vue" {
          * Note that this method only works for messages that return text. For messages that
          * need to be parsed to HTML, use the `v-i18n-html` directive.
          *
-         * @param {string} key Key of message to get
-         * @param {...any} parameters Values for $N replacements
-         * @returns {mw.Message}
-         * @memberof module:vue.prototype
+         * @param key Key of message to get
+         * @param parameters Values for $N replacements
          * @see {@link https://doc.wikimedia.org/mediawiki-core/master/js/module-vue.html#$i18n}
          */
         $i18n: (key: string, ...parameters: any[]) => mw.Message;


### PR DESCRIPTION
All type signatures are now at least as specific as the JSdoc types (sometimes more than the JSdoc), so the proposal here is to drop all type annotations in JSdoc, as discussed in #17.