### PR TITLE
Narrow types of `apisandbox.formatRequest` hook parameters

### DIFF
--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -111,9 +111,9 @@ declare global {
         ): Hook<
             [
                 items: OO.ui.MenuOptionWidget[],
-                displayParams: object,
-                rawParams: object,
-                method: string,
+                displayParams: Record<string, unknown>,
+                rawParams: Record<string, unknown>,
+                method: "get" | "post",
                 ajaxOptions: JQuery.AjaxSettings
             ]
         >;


### PR DESCRIPTION
Narrow the types of some parameters passed through the `apisandbox.formatRequest` hook. For some context:
- `displayParams` and `rawParams` both map the name of an input-type widget to its current input value (as an easily-stringifyable value for `displayParams`).
- `method` is the name of the `mw.Api` instance method used with the request.