### PR TITLE
Update package.json to allow Vue 3.5.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "typescript": "^4.2.2"
             },
             "peerDependencies": {
-                "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
+                "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27 || 3.5.13"
             },
             "peerDependenciesMeta": {
                 "vue": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "types-mediawiki-api": "^2.0.0"
     },
     "peerDependencies": {
-        "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27"
+        "vue": "3.2.23 || 3.2.37 || 3.3.9 || 3.4.27 || 3.5.13"
     },
     "peerDependenciesMeta": {
         "vue": {


### PR DESCRIPTION
MW Core currently uses Vue 3.5.13. I'd like to update this project so that this version is allowed as a peer dependency.

Alternatively, we could consider setting the allowed range of Vue versions in a more permissive way so this is not necessary again in the future.