### PR TITLE
Update to 1.45.0-wmf.16

### DIFF
--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -47,10 +47,10 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Register a hook handler.
      *
-     * @param handler Function to bind.
+     * @param handlers Function(s) to bind.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hook.html#.add
      */
-    add(...handler: Array<(...data: T) => any>): this;
+    add(...handlers: Array<(...data: T) => any>): this;
 
     /**
      * Enable a deprecation warning, logged after registering a hook handler.
@@ -83,10 +83,10 @@ interface Hook<T extends any[] = any[]> {
     /**
      * Unregister a hook handler.
      *
-     * @param handler Function to unbind.
+     * @param handlers Function(s) to unbind.
      * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hook.html#.remove
      */
-    remove(...handler: Array<(...data: T) => any>): this;
+    remove(...handlers: Array<(...data: T) => any>): this;
 }
 
 interface PostEditData {


### PR DESCRIPTION
This PR contains JSdoc and type changes from *MediaWiki* 1.44 to 1.45.

Currently up-to-date with [1.45.0-wmf.16](https://www.mediawiki.org/wiki/Special:MyLanguage/MediaWiki_1.45/wmf.16).

All (non-JSdoc) changes are listed below, breaking changes are annotated with ⚠.

## Changes
