### PR TITLE
feat: Add missing and update hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   * `wgPageParseReport` and `wgRestrictionMove` can be undefined.
   * `wgPostEdit` can have a `+tempuser` suffix.
   * `wgUserRegistration` can be null.
+- Added missing hooks defined in MediaWiki core: `codex.userlookup`, `RcFilters.highlight.enable`, `RcFilters.popup.open`, `SpecialBlock.block`, `SpecialBlock.form`, and `typeaheadSearch.appendUrlParams`.
+- Narrowed hook argument types from `any`:
+  * information (2nd) argument of `util.addPortletLink`.
+  * sections (1st) argument of `wikipage.tableOfContents`.
 
 ## 2.0.0
 

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -123,6 +123,13 @@ interface SearchIndexEntry {
     $wrapper: JQuery;
 }
 
+interface PortletLinkInformation {
+    /**
+     * ID of the list item.
+     */
+    id: string | undefined;
+}
+
 declare global {
     namespace mw {
         /**
@@ -244,7 +251,7 @@ declare global {
          */
         function hook(
             name: "util.addPortletLink"
-        ): Hook<[item: HTMLLIElement, information: object]>;
+        ): Hook<[item: HTMLLIElement, information: PortletLinkInformation]>;
 
         /**
          * Create an instance of {@link Hook}, fired when categories are being added to the DOM.

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -1,4 +1,7 @@
+import { ApiResponse } from "./Api";
 import { User } from "./user";
+// @ts-ignore
+import { DefineSetupFnComponent, Ref } from "vue";
 
 /**
  * An instance of a hook, created via {@link mw.hook mw.hook method}.
@@ -199,6 +202,16 @@ declare global {
         >;
 
         /**
+         * Create an instance of {@link Hook}, for custom components to be added to the UserLookup component.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(
+            name: "codex.userlookup"
+        ): Hook<[customComponents: Ref<DefineSetupFnComponent<Record<string, any>>[]>]>;
+
+        /**
          * Create an instance of {@link Hook}, fired after EditRecovery has loaded any recovery data, added event handlers, etc.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'editRecovery.loadEnd'
@@ -245,6 +258,22 @@ declare global {
         function hook(name: "postEdit.afterRemoval"): Hook<[]>;
 
         /**
+         * Create an instance of {@link Hook}, fired when highlight feature is enabled.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'RcFilters.highlight.enable'
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(name: "RcFilters.highlight.enable"): Hook<[]>;
+
+        /**
+         * Create an instance of {@link Hook}, fired when the RCFilters tag multi selector menu is toggled.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'RcFilters.popup.open'
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(name: "RcFilters.popup.open"): Hook<[]>;
+
+        /**
          * Create an instance of {@link Hook}.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
@@ -262,12 +291,39 @@ declare global {
         function hook(name: "skin.logout"): Hook<[href: string]>;
 
         /**
+         * Create an instance of {@link Hook}, fired after a successful (re-)block on Special:Block.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(name: "SpecialBlock.block"): Hook<[data: ApiResponse]>;
+
+        /**
+         * Create an instance of {@link Hook}, fired after a successful (re-)block on Special:Block.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(
+            name: "SpecialBlock.form"
+        ): Hook<[newValue: boolean, targetUser: string, blockId: number | null]>;
+
+        /**
          * Create an instance of {@link Hook}, fired when initialization of the filtering interface for changes list is complete.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'structuredChangeFilters.ui.initialized'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(name: "structuredChangeFilters.ui.initialized"): Hook<[]>;
+
+        /**
+         * Create an instance of {@link Hook}.
+         *
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
+         */
+        function hook(
+            name: "typeaheadSearch.appendUrlParams"
+        ): Hook<[appendUrlParams: (key: string, value: string) => void]>;
 
         /**
          * Create an instance of {@link Hook}, fired when a portlet is successfully created.

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -107,6 +107,8 @@ interface PostEditData {
     message?: string | JQuery | HTMLElement[];
     /**
      * Whether a temporary user account was created.
+     *
+     * @since 1.39
      */
     tempUserCreated?: boolean;
     /**
@@ -187,6 +189,8 @@ declare global {
         /**
          * Create an instance of {@link Hook}.
          *
+         * @since 1.29
+         * @since 1.42 - HTTP method and AJAX options are passed.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(
@@ -204,7 +208,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, for custom components to be added to the UserLookup component.
          *
-         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
+         * @since 1.44
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(
@@ -214,6 +218,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired after EditRecovery has loaded any recovery data, added event handlers, etc.
          *
+         * @since 1.41
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'editRecovery.loadEnd'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -222,6 +227,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired on page load to enhance any HTML forms on the page.
          *
+         * @since 1.25
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'htmlform.enhance'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -243,6 +249,7 @@ declare global {
          * // Now fire the hook.
          * mw.hook( 'postEdit' ).fire();
          * ```
+         * @since 1.25 - data can be passed.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'postEdit'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -251,7 +258,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired after the listener for #postEdit removes the notification.
          *
-         * @deprecated
+         * @deprecated since 1.38, use the `postEdit` hook instead, and an additional pause if required.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'postEdit.afterRemoval'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -260,6 +267,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired when highlight feature is enabled.
          *
+         * @since 1.29
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'RcFilters.highlight.enable'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -268,6 +276,8 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired when the RCFilters tag multi selector menu is toggled.
          *
+         * @since 1.29
+         * @since 1.30 - selected item is no longer passed.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'RcFilters.popup.open'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -276,6 +286,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}.
          *
+         * @since 1.41
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(name: "prefs.search.buildIndex"): Hook<[index: SearchIndex]>;
@@ -285,6 +296,7 @@ declare global {
          *
          * This will end the user session, and either redirect to the given URL on success, or queue an error message via {@link mw.notification}.
          *
+         * @since 1.40
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'skin.logout'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -293,6 +305,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired after a successful (re-)block on Special:Block.
          *
+         * @since 1.44
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -301,7 +314,8 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired after a successful (re-)block on Special:Block.
          *
-         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.block'
+         * @since 1.44
+         * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'SpecialBlock.form'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(
@@ -311,6 +325,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired when initialization of the filtering interface for changes list is complete.
          *
+         * @since 1.30
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'structuredChangeFilters.ui.initialized'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -319,6 +334,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}.
          *
+         * @since 1.45
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(
@@ -334,6 +350,7 @@ declare global {
          *     p.style.border = 'solid 1px black';
          * } );
          * ```
+         * @since 1.41
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'util.addPortlet'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -351,6 +368,7 @@ declare global {
          *     link.appendChild( span );
          * } );
          * ```
+         * @since 1.35
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'util.addPortletLink'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -365,6 +383,7 @@ declare global {
          *
          * This includes the ready event on a page load (including post-edit loads) and when content has been previewed with LivePreview.
          *
+         * @since 1.27
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.categories'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -375,6 +394,7 @@ declare global {
          *
          * This gives an option to modify the collapsible behavior.
          *
+         * @since 1.27
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.collapsibleContent'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -397,6 +417,7 @@ declare global {
          *
          * Similar to the wikipage.content hook, `$diff` may still be detached when the hook is fired.
          *
+         * @since 1.27
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.diff'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -405,6 +426,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired when the diff type switch is present so others can decide how to manipulate the DOM.
          *
+         * @since 1.41
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.diff.diffTypeSwitch'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -415,6 +437,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}.
          *
+         * @since 1.41
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.diff.wikitextDiffBody'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -425,6 +448,7 @@ declare global {
          *
          * Similar to the wikipage.content hook, $editForm can still be detached when this hook is fired.
          *
+         * @since 1.26
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.editform'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -435,6 +459,7 @@ declare global {
          * {@link https://www.mediawiki.org/wiki/Special:MyLanguage/Help:Page_status_indicators status indicators}
          * are being added to the DOM or updated.
          *
+         * @since 1.36
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.indicators'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -443,6 +468,7 @@ declare global {
         /**
          * Create an instance of {@link Hook}, fired when dynamic changes have been made to the table of contents.
          *
+         * @since 1.39
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.tableOfContents'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
@@ -457,6 +483,7 @@ declare global {
          *     // Do things
          * } );
          * ```
+         * @since 1.38
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.watchlistChange'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -89,6 +89,13 @@ interface Hook<T extends any[] = any[]> {
     remove(...handlers: Array<(...data: T) => any>): this;
 }
 
+interface EditRecovery {
+    /**
+     * Handle an edit form field changing.
+     */
+    fieldChangeHandler(): void;
+}
+
 interface PostEditData {
     /**
      * Message that listeners should use when displaying notifications.
@@ -114,10 +121,6 @@ interface SearchIndexEntry {
     $highlight: JQuery;
     $tabPanel: JQuery;
     $wrapper: JQuery;
-}
-
-interface EditRecovery {
-    fieldChangeHandler(): void;
 }
 
 declare global {
@@ -153,7 +156,7 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'htmlform.enhance'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
-        function hook(name: "htmlform.enhance"): Hook<[document: JQuery]>;
+        function hook(name: "htmlform.enhance"): Hook<[$root: JQuery]>;
 
         /**
          * Create an instance of {@link Hook}, fired after an edit was successfully saved.

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -130,6 +130,55 @@ interface PortletLinkInformation {
     id: string | undefined;
 }
 
+interface TOCSectionMetadata {
+    /**
+     * "True" value of the ID attribute.
+     */
+    anchor: string;
+    /**
+     * Codepoint offset where the section shows up in wikitext; this is null
+     * if this section comes from a template, if it comes from a literal
+     * HTML <h_> tag, or otherwise doesn't correspond to a "preprocessor
+     * section".
+     */
+    byteoffset: number | null;
+    /**
+     * Arbitrary data attached to this section by extensions.
+     */
+    extensionData?: {};
+    /**
+     * The title of the page that generated this heading.
+     * For template-generated sections, this will be the template title.
+     * This string is in "prefixed DB key" format.
+     */
+    fromtitle: string | false;
+    /**
+     * Section id (integer, assigned in depth first traversal order).
+     * Template generated sections get a `T-` prefix.
+     */
+    index: string;
+    /**
+     * The heading tag level.
+     */
+    level: string;
+    /**
+     * HTML heading of the section.
+     */
+    line: string;
+    /**
+     * URL-escaped value of the anchor, for use in constructing a URL fragment link.
+     */
+    linkAnchor: string;
+    /**
+     * TOC number string (3.1.3, 4.5.2, etc.).
+     */
+    number: string;
+    /**
+     * One-indexed TOC level and the nesting level.
+     */
+    toclevel: number;
+}
+
 declare global {
     namespace mw {
         /**
@@ -341,7 +390,7 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'wikipage.tableOfContents'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
-        function hook(name: "wikipage.tableOfContents"): Hook<[sections: any[]]>;
+        function hook(name: "wikipage.tableOfContents"): Hook<[sections: TOCSectionMetadata[]]>;
 
         /**
          * Create an instance of {@link Hook}, fired when the page watch status has changed.


### PR DESCRIPTION
1. Add missing hooks fired in MediaWiki core:
   - `codex.userlookup`
   - `RcFilters.highlight.enable`
   - `RcFilters.popup.open`
   - `SpecialBlock.block`
   - `SpecialBlock.form`
   - `typeaheadSearch.appendUrlParams`
2. Narrow some remaining `any` hook argument types:
   - `util.addPortletLink`: information (2nd) argument
   - `wikipage.tableOfContents`: sections (1st) argument
3. Add `@since`/`@deprecated` annotations to most hooks (added since 1.25).