### PR TITLE
Update to MediaWiki 1.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+-   Updated to MediaWiki 1.47:
+    -   Added `blockIndefiniteExpiry` and `blockIndefiniteExpiryLabel` configuration values (see `mw.config`).
+    -   Added `mw.tempUserCreated.showCondensedPopup()` function.
+    -   `mw.util.addPortletLink()` accepts a portlet options object as single argument. The legacy signature is deprecated.
+    -   Removed `labels` (3rd) optional parameter from `new mw.Api().watch()`.
+
 ## 2.1.0
 
 -   Updated to MediaWiki 1.45:

--- a/jquery/cookie.d.ts
+++ b/jquery/cookie.d.ts
@@ -14,7 +14,7 @@ declare global {
          * @param key Cookie name or (when getting) omit to return an object with all
          *  current cookie keys and values.
          * @param value Cookie value to set. If `null`, this method will remove the cookie.
-         *  If omited, this method will get and return the current value.
+         *  If ommited, this method will get and return the current value.
          * @param options
          * @returns The current value (if getting a cookie), or an internal `document.cookie`
          *  expression (if setting or removing).

--- a/mw/Api.d.ts
+++ b/mw/Api.d.ts
@@ -794,6 +794,26 @@ declare global {
              *
              * @since 1.35 - expiry parameter can be passed when Watchlist Expiry is enabled.
              * @since 1.46 - labels parameter can be passed.
+             * @since 1.47 - labels parameter can no longer be passed.
+             * @param pages Full page name or instance of {@link mw.Title}, or an
+             *  array thereof. If an array is passed, the return value passed to the promise will also be an
+             *  array of appropriate objects.
+             * @param expiry When the page should expire from the watchlist. If omitted, the
+             *  page will not expire.
+             * @returns A promise that resolves with an object (or array of objects) describing each page that was passed in and its
+             *  current watched/unwatched status.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Api.html#watch
+             */
+            watch<P extends TypeOrArray<TitleLike>>(
+                pages: P,
+                expiry?: string
+            ): Api.AbortablePromise<[ReplaceValue<P, TitleLike, Api.WatchedPage>]>;
+            /**
+             * Convenience method for `action=watch`.
+             *
+             * @since 1.35 - expiry parameter can be passed when Watchlist Expiry is enabled.
+             * @since 1.46 - labels parameter can be passed.
+             * @deprecated since 1.47 - labels parameter can no longer be passed.
              * @param pages Full page name or instance of {@link mw.Title}, or an
              *  array thereof. If an array is passed, the return value passed to the promise will also be an
              *  array of appropriate objects.

--- a/mw/Map.d.ts
+++ b/mw/Map.d.ts
@@ -72,7 +72,7 @@ declare global {
          * This is an internal class that backs the mw.config and mw.messages APIs.
          *
          * It allows reading and writing to the collection via public methods,
-         * and allows batch iteraction for all its methods.
+         * and allows batch interaction for all its methods.
          *
          * For {@link mw.config}, scripts sometimes choose to "import" a set of keys locally,
          * like so:

--- a/mw/Upload.d.ts
+++ b/mw/Upload.d.ts
@@ -92,6 +92,14 @@ declare global {
             getBasename(path: string): string;
 
             /**
+             * Get the chunk size used for chunked uploads, in bytes.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getChunkSize
+             */
+            getChunkSize(): boolean;
+
+            /**
              * Get the current value of the edit comment for the upload.
              *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getComment
@@ -119,6 +127,14 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getFilename
              */
             getFilename(): string;
+
+            /**
+             * Check if upload warnings will be ignored when publishing.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getIgnoreWarnings
+             */
+            getIgnoreWarnings(): boolean;
 
             /**
              * Get the imageinfo object for the finished upload.
@@ -183,6 +199,14 @@ declare global {
             setAutoText(autotext: boolean): void;
 
             /**
+             * Set the chunk size used for chunked uploads, in bytes.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setChunkSize
+             */
+            setChunkSize(chunkSize: number): void;
+
+            /**
              * Set the edit comment for the upload.
              *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setComment
@@ -224,6 +248,14 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setFilenameFromFile
              */
             setFilenameFromFile(): void;
+
+            /**
+             * Set whether to ignore upload warnings when publishing.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setIgnoreWarnings
+             */
+            setIgnoreWarnings(ignoreWarnings: boolean): void;
 
             /**
              * Set the license template for the upload.

--- a/mw/Upload.d.ts
+++ b/mw/Upload.d.ts
@@ -77,6 +77,14 @@ declare global {
             getApi(): JQuery.Promise<Api>;
 
             /**
+             * Get whether the file page wikitext should be generated server-side.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getAutoText
+             */
+            getAutoText(): boolean;
+
+            /**
              * Gets the base filename from a path name.
              *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getBasename
@@ -89,6 +97,14 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getComment
              */
             getComment(): string;
+
+            /**
+             * Get the copyright status for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getCopyStatus
+             */
+            getCopyStatus(): string;
 
             /**
              * Get the file being uploaded.
@@ -112,6 +128,22 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getImageInfo
              */
             getImageInfo(): ApiResponse | undefined;
+
+            /**
+             * Get the license for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getLicense
+             */
+            getLicense(): string;
+
+            /**
+             * Get the source for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#getSource
+             */
+            getSource(): string;
 
             /**
              * Gets the state of the upload.
@@ -142,11 +174,28 @@ declare global {
             getWatchlist(): boolean;
 
             /**
+             * Set whether the file page wikitext should be generated server-side from
+             * the comment, license, copyright status and source, overriding the text.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setAutoText
+             */
+            setAutoText(autotext: boolean): void;
+
+            /**
              * Set the edit comment for the upload.
              *
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setComment
              */
             setComment(comment: string): void;
+
+            /**
+             * Set the copyright status for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setCopyStatus
+             */
+            setCopyStatus(copyStatus: string): void;
 
             /**
              * Set the file to be uploaded.
@@ -175,6 +224,22 @@ declare global {
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setFilenameFromFile
              */
             setFilenameFromFile(): void;
+
+            /**
+             * Set the license template for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setLicense
+             */
+            setLicense(license: string): void;
+
+            /**
+             * Set the source for the upload.
+             *
+             * @since 1.47
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.Upload.html#setSource
+             */
+            setSource(source: string): void;
 
             /**
              * Sets the state and state details (if any) of the upload.

--- a/mw/cldr.d.ts
+++ b/mw/cldr.d.ts
@@ -2,7 +2,7 @@ declare global {
     namespace mw {
         /**
          * Namespace for CLDR-related utility methods.
-         * Provided by the `mediawiki.cdlr` ResourceLoader module.
+         * Provided by the `mediawiki.cldr` ResourceLoader module.
          *
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.cldr.html
          */

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -43,6 +43,14 @@ declare global {
             blockExpiryPreset?: string;
             blockHideUser?: true;
             blockId?: number | null;
+            /**
+             * @since 1.47
+             */
+            blockIndefiniteExpiry?: string;
+            /**
+             * @since 1.47
+             */
+            blockIndefiniteExpiryLabel?: string;
             blockNamespaceRestrictions?: string;
             blockPageRestrictions?: string;
             blockPreErrors?: string[];

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -101,6 +101,9 @@ declare global {
              * @since 1.46
              */
             SpecialWatchlistLabelsUrl?: string;
+            /**
+             * @deprecated Removed since 1.47.
+             */
             specUrl?: string | null;
             StructuredChangeFiltersDisplayConfig?: StructuredChangeFiltersDisplayConfig;
             /**
@@ -182,9 +185,18 @@ declare global {
             wgContentNamespaces: number[];
             wgCreateAccountDirty?: true;
             /**
+             * @since 1.47
+             */
+            wgCreateAccountUsernamePolicyBulletsHtml?: string[];
+            /**
              * @since 1.46
+             * @deprecated Removed since 1.47.
              */
             wgCreateAccountUsernamePolicyPopoverMsgs?: PopoverMessages;
+            /**
+             * @since 1.47
+             */
+            wgCreateAccountUsernamePolicyUrl?: string;
             /**
              * The top revision ID of the currently viewed page at the time the page was served. Also set on diff and history pages; zero for special pages.
              *

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -232,6 +232,10 @@ declare global {
             wgEditRecoveryWasPosted?: boolean;
             wgEditSubmitButtonLabelPublish?: boolean;
             /**
+             * @since 1.47
+             */
+            wgEnableChunkedUploads?: boolean;
+            /**
              * @since 1.46
              */
             wgErrorPageMessageKey?: string;
@@ -281,7 +285,15 @@ declare global {
              */
             wgIsRedirect: boolean;
             wgLegalTitleChars: string;
+            /**
+             * @since 1.47
+             */
+            wgMaxPhpUploadSize?: number;
             wgMaxUploadSize?: MaxUploadSize;
+            /**
+             * @since 1.47
+             */
+            wgMinUploadChunkSize?: number;
             wgMonthNames: [
                 string,
                 string,

--- a/mw/config.d.ts
+++ b/mw/config.d.ts
@@ -435,6 +435,10 @@ declare global {
             wgStructuredChangeFiltersDefaultSavedQueryExists?: true;
             wgStructuredChangeFiltersLimitPreferenceName?: string;
             wgStructuredChangeFiltersMessages?: Record<string, string>;
+            /**
+             * @since 1.47
+             */
+            wgStructuredChangeFiltersRestrictedTags?: StructuredChangeFiltersRestrictedTag[];
             wgStructuredChangeFiltersSavedQueriesPreferenceName?: string;
             wgTempUserName?: string | null;
             /**
@@ -684,6 +688,14 @@ interface StructuredChangeFilter {
 interface StructuredChangeFilterSubset {
     filter: string;
     group: string;
+}
+
+interface StructuredChangeFiltersRestrictedTag {
+    cssClass: string;
+    description: string;
+    helpLink: string | null;
+    label: string;
+    name: string;
 }
 
 interface StructuredChangeFiltersDisplayConfig {

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -1,6 +1,6 @@
 import { ApiBlockParams } from "types-mediawiki-api";
 import { User } from "./user";
-import { PortletOptions } from "./util";
+import { PortletLinkOptions } from "./util";
 
 /**
  * An instance of a hook, created via {@link mw.hook mw.hook method}.
@@ -261,7 +261,7 @@ declare global {
          */
         function hook(
             name: "util.addPortletLink"
-        ): Hook<[item: HTMLLIElement, options: PortletOptions]>;
+        ): Hook<[item: HTMLLIElement, options: PortletLinkOptions]>;
 
         /**
          * Create an instance of {@link Hook}, fired when categories are being added to the DOM.

--- a/mw/hook.d.ts
+++ b/mw/hook.d.ts
@@ -1,5 +1,6 @@
 import { ApiBlockParams } from "types-mediawiki-api";
 import { User } from "./user";
+import { PortletOptions } from "./util";
 
 /**
  * An instance of a hook, created via {@link mw.hook mw.hook method}.
@@ -248,17 +249,19 @@ declare global {
          *
          * @example
          * ```js
-         * mw.hook( 'util.addPortletLink' ).add( ( link ) => {
-         *     const span = $( '<span class="icon">' );
-         *     link.appendChild( span );
+         * mw.hook( 'util.addPortletLink' ).add( ( link, options ) => {
+         *     if ( options.id === 't-special-link' ) {
+         *         link.classList.add( 'my-special-class' );
+         *     }
          * } );
          * ```
+         * @since 1.47 - all portlet options are passed.
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/Hooks.html#~event:'util.addPortletLink'
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.html#.hook
          */
         function hook(
             name: "util.addPortletLink"
-        ): Hook<[item: HTMLLIElement, information: object]>;
+        ): Hook<[item: HTMLLIElement, options: PortletOptions]>;
 
         /**
          * Create an instance of {@link Hook}, fired when categories are being added to the DOM.

--- a/mw/message.d.ts
+++ b/mw/message.d.ts
@@ -19,7 +19,7 @@ declare global {
         const messages: Map<{ [key: string]: string }>;
 
         /**
-         * Describes a translateable text or HTML string. Similar to the Message class in MediaWiki PHP.
+         * Describes a translatable text or HTML string. Similar to the Message class in MediaWiki PHP.
          *
          * @example
          * ```js

--- a/mw/tempUserCreated.d.ts
+++ b/mw/tempUserCreated.d.ts
@@ -1,3 +1,12 @@
+interface UserCreatedPopoverProps {
+    classes?: string[];
+    content?: string[];
+    hideBackdrop?: boolean;
+    primaryActionLabel?: string | null;
+    primaryActionUrl?: string | null;
+    title?: string | null;
+}
+
 declare global {
     namespace mw {
         /**
@@ -7,6 +16,8 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.tempUserCreated.html
          */
         namespace tempUserCreated {
+            function showCondensedPopup(props: UserCreatedPopoverProps): void;
+
             /**
              * Show popup after creation of a temporary user.
              *

--- a/mw/tempUserCreated.d.ts
+++ b/mw/tempUserCreated.d.ts
@@ -16,6 +16,9 @@ declare global {
          * @see https://doc.wikimedia.org/mediawiki-core/master/js/mw.tempUserCreated.html
          */
         namespace tempUserCreated {
+            /**
+             * @since 1.47
+             */
             function showCondensedPopup(props: UserCreatedPopoverProps): void;
 
             /**

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -174,10 +174,14 @@ declare global {
              *
              * @example
              * ```js
-             * // Create a portlet with 2 menu items that is styled as a dropdown in certain skins.
-             * mw.util.addPortlet( 'p-myportlet', 'My label', '#p-cactions' );
-             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 1' );
-             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 2' );
+             * // Create a portlet with 2 menu items that uses a <div> label
+             * // and is styled as a dropdown in certain skins.
+             * mw.util.addPortlet( 'p-myportlet', {
+             *     label: 'My label',
+             *     selectorHint: '#p-cactions'
+             * } );
+             * mw.util.addPortletLink( 'p-myportlet', { href: '#', text: 'Link 1' } );
+             * mw.util.addPortletLink( 'p-myportlet', { href: '#', text: 'Link 2' } );
              * ```
              * @since 1.41
              * @since 1.47 - a {@link PortletOptions} object can passed as argument.
@@ -194,10 +198,14 @@ declare global {
              *
              * @example
              * ```js
-             * // Create a portlet with 2 menu items that is styled as a dropdown in certain skins.
-             * mw.util.addPortlet( 'p-myportlet', 'My label', '#p-cactions' );
-             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 1' );
-             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 2' );
+             * // Create a portlet with 2 menu items that uses a <div> label
+             * // and is styled as a dropdown in certain skins.
+             * mw.util.addPortlet( 'p-myportlet', {
+             *     label: 'My label',
+             *     selectorHint: '#p-cactions'
+             * } );
+             * mw.util.addPortletLink( 'p-myportlet', { href: '#', text: 'Link 1' } );
+             * mw.util.addPortletLink( 'p-myportlet', { href: '#', text: 'Link 2' } );
              * ```
              * @since 1.41
              * @deprecated since 1.47 - pass a {@link PortletOptions} object as argument.
@@ -244,16 +252,19 @@ declare global {
              * for that item, e.g. `'#foobar'` or `document.getElementById( 'foobar' )`.
              *
              * ```js
-             * mw.util.addPortletLink(
-             *     'p-tb', 'https://www.mediawiki.org/',
-             *     'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
-             * );
+             * mw.util.addPortletLink( 'p-tb', {
+             *     href: 'https://www.mediawiki.org/',
+             *     text: 'mediawiki.org',
+             *     id: 't-mworg',
+             *     tooltip: 'Go to mediawiki.org',
+             *     accesskey: 'm',
+             *     nextnode: '#t-print'
+             * } );
              *
-             * var node = mw.util.addPortletLink(
-             *     'p-tb',
-             *     mw.util.getUrl( 'Special:Example' ),
-             *     'Example'
-             * );
+             * var node = mw.util.addPortletLink( 'p-tb', {
+             *     href: mw.util.getUrl( 'Special:Example' ),
+             *     text: 'Example'
+             * } );
              * $( node ).on( 'click', function ( e ) {
              *     console.log( 'Example' );
              *     e.preventDefault();
@@ -265,7 +276,10 @@ declare global {
              *
              * ```js
              * $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
-             *     mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
+             *     mw.util.addPortletLink( 'p-tb', {
+             *         href: 'https://www.mediawiki.org/',
+             *         text: 'mediawiki.org'
+             *     } );
              * } );
              * ```
              *
@@ -308,16 +322,19 @@ declare global {
              * or `document.getElementById( 'foobar' )`.
              *
              * ```js
-             * mw.util.addPortletLink(
-             *     'p-tb', 'https://www.mediawiki.org/',
-             *     'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
-             * );
+             * mw.util.addPortletLink( 'p-tb', {
+             *     href: 'https://www.mediawiki.org/',
+             *     text: 'mediawiki.org',
+             *     id: 't-mworg',
+             *     tooltip: 'Go to mediawiki.org',
+             *     accesskey: 'm',
+             *     nextnode: '#t-print'
+             * } );
              *
-             * var node = mw.util.addPortletLink(
-             *     'p-tb',
-             *     mw.util.getUrl( 'Special:Example' ),
-             *     'Example'
-             * );
+             * var node = mw.util.addPortletLink( 'p-tb', {
+             *     href: mw.util.getUrl( 'Special:Example' ),
+             *     text: 'Example'
+             * } );
              * $( node ).on( 'click', function ( e ) {
              *     console.log( 'Example' );
              *     e.preventDefault();
@@ -329,7 +346,10 @@ declare global {
              *
              * ```js
              * $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
-             *     mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
+             *     mw.util.addPortletLink( 'p-tb', {
+             *         href: 'https://www.mediawiki.org/',
+             *         text: 'mediawiki.org'
+             *     } );
              * } );
              * ```
              *

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -12,10 +12,43 @@ type NoReturn<T extends (...args: any[]) => any> = T extends (
 /**
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#~PortletOptions
  */
-export interface PortletOptions {
+interface PortletOptions {
     /**
-     * Access key to activate this link. One character only, avoid conflicts with other links.
-     * Use `$( '[accesskey=x]' )` in the console to see if 'x' is already used.
+     * Label of the new portlet.
+     */
+    label?: string;
+    /**
+     * Selector of the element the new portlet would like to be
+     * inserted near. Typically the portlet will be inserted after this selector, but in some
+     * skins, the skin may relocate the element to another available space.
+     *
+     * When provided, skins can use the parameter to infer information about how the user intended
+     * the menu to be rendered. For example, in vector and vector-2022 targeting `#p-cactions` will
+     * result in the creation of a dropdown menu.
+     *
+     * If this argument is not passed, then the caller is responsible for appending the element to
+     * the DOM before using addPortletLink.
+     *
+     * To add a portlet in an exact position do not rely on this parameter, instead assign the
+     * returned element to a variable, and use `yourTarget.appendChild( portlet );`
+     */
+    selectorHint?: string;
+    /**
+     * Set to `true` to use a `<div>` for the portlet label instead of a `<label>` element.
+     * (Using a `<label>` is only valid within a `<form>`.)
+     *
+     * @since 1.47
+     */
+    useDivLabel?: boolean;
+}
+
+/**
+ * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#~PortletLinkOptions
+ */
+export interface PortletLinkOptions {
+    /**
+     * Access key to activate this link. One character only, avoid conflicts with other links. Use
+     * `$( '[accesskey=x]' )` in the console to see if 'x' is already used.
      */
     accesskey?: string;
     /**
@@ -32,9 +65,9 @@ export interface PortletOptions {
      */
     id?: string;
     /**
-     * Element that the new item should be added before.
-     * Must be another item in the same list, it will be ignored otherwise.
-     * Can be specified as DOM reference, as jQuery object, or as CSS selector string.
+     * Element that the new item should be added before. Must be another item in the same list, it
+     * will be ignored otherwise. Can be specified as DOM reference, as jQuery object, or as CSS
+     * selector string.
      */
     nextnode?: HTMLElement | JQuery | string;
     /**
@@ -145,24 +178,33 @@ declare global {
              * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 2' );
              * ```
              * @since 1.41
+             * @since 1.47 - a {@link PortletOptions} object can passed as argument.
              * @param id ID of the new portlet.
-             * @param label Label of the new portlet.
-             * @param selectorHint Selector of the element the new portlet would like to
-             *  be inserted near. Typically the portlet will be inserted after this selector, but in some
-             *  skins, the skin may relocate the element to another available space.
+             * @param options Options for the portlet.
+             * @returns will be null if it was not possible to create an portlet with the required
+             *  information e.g. the selector given in `selectorHint` parameter could not be
+             *  resolved to an existing element in the page.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortlet
+             */
+            function addPortlet(id: string, options?: PortletOptions): HTMLElement | null;
+            /**
+             * Creates a detached portlet Element in the skin with no elements.
              *
-             *  When provided, skins can use the parameter to infer information about how the user intended
-             *  the menu to be rendered. For example, in vector and vector-2022 targeting `#p-cactions` will
-             *  result in the creation of a dropdown menu.
-             *
-             *  If this argument is not passed, then the caller is responsible for appending the element
-             *  to the DOM before using addPortletLink.
-             *
-             *  To add a portlet in an exact position do not rely on this parameter, instead assign the returned
-             *  element to a variable, and use `yourTarget.appendChild( portlet );`
-             * @returns will be null if it was not possible to create an portlet with
-             *  the required information e.g. the selector given in `selectorHint` parameter could not be resolved
-             *  to an existing element in the page.
+             * @example
+             * ```js
+             * // Create a portlet with 2 menu items that is styled as a dropdown in certain skins.
+             * mw.util.addPortlet( 'p-myportlet', 'My label', '#p-cactions' );
+             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 1' );
+             * mw.util.addPortletLink( 'p-myportlet', '#', 'Link 2' );
+             * ```
+             * @since 1.41
+             * @deprecated since 1.47 - pass a {@link PortletOptions} object as argument.
+             * @param id ID of the new portlet.
+             * @param label See {@link PortletOptions.label}.
+             * @param selectorHint See {@link PortletOptions.selectorHint}.
+             * @returns will be null if it was not possible to create an portlet with the required
+             *  information e.g. the selector given in `selectorHint` parameter could not be
+             *  resolved to an existing element in the page.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortlet
              */
             function addPortlet(
@@ -225,24 +267,24 @@ declare global {
              * } );
              * ```
              *
-             * @since 1.47 - a {@link PortletOptions} object can passed as argument.
+             * @since 1.47 - a {@link PortletLinkOptions} object can passed as argument.
              * @param options Portlet options.
              * @returns The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortletLink
              */
-            function addPortletLink(options: PortletOptions): HTMLLIElement | null;
+            function addPortletLink(options: PortletLinkOptions): HTMLLIElement | null;
             /**
              * Add a link to a portlet menu on the page.
              *
              * The portlets that are supported include:
              *
-             * - p-cactions (Content actions)
-             * - p-personal (Personal tools)
-             * - p-navigation (Navigation)
-             * - p-tb (Toolbox)
-             * - p-associated-pages (For namespaces and special page tabs on supported skins)
-             * - p-dock-bottom (A sticky menu fixed to bottom of viewport on supported skins)
-             * - p-namespaces (For namespaces on legacy skins)
+             * - `p-cactions` (Content actions)
+             * - `p-personal` (Personal tools)
+             * - `p-navigation` (Navigation)
+             * - `p-tb` (Toolbox)
+             * - `p-associated-pages` (For namespaces and special page tabs on supported skins)
+             * - `p-dock-bottom` (A sticky menu fixed to bottom of viewport on supported skins)
+             * - `p-namespaces` (For namespaces on legacy skins)
              *
              * Additional menus can be discovered through the following code:
              *
@@ -252,12 +294,12 @@ declare global {
              *
              * Menu availability varies by skin, wiki, and current page.
              *
-             * The first three parameters are required, the others are optional and
-             * may be null. Though providing an id and tooltip is recommended.
+             * The first three parameters are required, the others are optional and may be null.
+             * Though providing an id and tooltip is recommended.
              *
-             * By default, the new link will be added to the end of the menu. To
-             * add the link before an existing item, pass the DOM node or a CSS selector
-             * for that item, e.g. `'#foobar'` or `document.getElementById( 'foobar' )`.
+             * By default, the new link will be added to the end of the menu. To add the link before
+             * an existing item, pass the DOM node or a CSS selector for that item, e.g. `'#foobar'`
+             * or `document.getElementById( 'foobar' )`.
              *
              * ```js
              * mw.util.addPortletLink(
@@ -285,19 +327,14 @@ declare global {
              * } );
              * ```
              *
-             * @deprecated since 1.47 - pass a {@link PortletOptions} object as argument.
+             * @deprecated since 1.47 - pass a {@link PortletLinkOptions} object as argument.
              * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal').
-             * @param href Link URL.
-             * @param text Link text.
-             * @param id ID of the list item, should be unique and preferably have
-             *  the appropriate prefix ('ca-', 'pt-', 'n-' or 't-').
-             * @param tooltip Text to show when hovering over the link, without accesskey suffix.
-             * @param accesskey Access key to activate this link. One character only,
-             *  avoid conflicts with other links. Use `$( '[accesskey=x]' )` in the console to
-             *  see if 'x' is already used.
-             * @param nextnode Element that the new item should be added before.
-             *  Must be another item in the same list, it will be ignored otherwise.
-             *  Can be specified as DOM reference, as jQuery object, or as CSS selector string.
+             * @param href See {@link PortletLinkOptions.href}.
+             * @param text See {@link PortletLinkOptions.text}.
+             * @param id See {@link PortletLinkOptions.id}.
+             * @param tooltip See {@link PortletLinkOptions.tooltip}.
+             * @param accesskey See {@link PortletLinkOptions.accesskey}.
+             * @param nextnode See {@link PortletLinkOptions.nextnode}.
              * @returns The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortletLink
              */

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -12,7 +12,7 @@ type NoReturn<T extends (...args: any[]) => any> = T extends (
 /**
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#~PortletOptions
  */
-interface PortletOptions {
+export interface PortletOptions {
     /**
      * Access key to activate this link. One character only, avoid conflicts with other links.
      * Use `$( '[accesskey=x]' )` in the console to see if 'x' is already used.
@@ -22,6 +22,10 @@ interface PortletOptions {
      * Link URL.
      */
     href: string;
+    /**
+     * Name of the Codex icon name this menu should use if skin supports this.
+     */
+    icon?: string;
     /**
      * ID of the list item, should be unique and preferably have the appropriate prefix
      * ('ca-', 'pt-', 'n-' or 't-').

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -10,6 +10,40 @@ type NoReturn<T extends (...args: any[]) => any> = T extends (
     : never;
 
 /**
+ * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#~PortletOptions
+ */
+interface PortletOptions {
+    /**
+     * Access key to activate this link. One character only, avoid conflicts with other links.
+     * Use `$( '[accesskey=x]' )` in the console to see if 'x' is already used.
+     */
+    accesskey?: string;
+    /**
+     * Link URL.
+     */
+    href: string;
+    /**
+     * ID of the list item, should be unique and preferably have the appropriate prefix
+     * ('ca-', 'pt-', 'n-' or 't-').
+     */
+    id?: string;
+    /**
+     * Element that the new item should be added before.
+     * Must be another item in the same list, it will be ignored otherwise.
+     * Can be specified as DOM reference, as jQuery object, or as CSS selector string.
+     */
+    nextnode?: HTMLElement | JQuery | string;
+    /**
+     * Link text.
+     */
+    text: string;
+    /**
+     * Text to show when hovering over the link, without accesskey suffix.
+     */
+    tooltip?: string;
+}
+
+/**
  * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#~ResizeableThumbnailUrl
  */
 interface ResizeableThumbnailUrl {
@@ -187,12 +221,73 @@ declare global {
              * } );
              * ```
              *
-             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal')
-             * @param href Link URL
-             * @param text Link text
+             * @since 1.47 - a {@link PortletOptions} object can passed as argument.
+             * @param options Portlet options.
+             * @returns The added list item, or null if no element was added.
+             * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortletLink
+             */
+            function addPortletLink(options: PortletOptions): HTMLLIElement | null;
+            /**
+             * Add a link to a portlet menu on the page.
+             *
+             * The portlets that are supported include:
+             *
+             * - p-cactions (Content actions)
+             * - p-personal (Personal tools)
+             * - p-navigation (Navigation)
+             * - p-tb (Toolbox)
+             * - p-associated-pages (For namespaces and special page tabs on supported skins)
+             * - p-dock-bottom (A sticky menu fixed to bottom of viewport on supported skins)
+             * - p-namespaces (For namespaces on legacy skins)
+             *
+             * Additional menus can be discovered through the following code:
+             *
+             * ```js
+             * $('.mw-portlet').toArray().map((el) => el.id);
+             * ```
+             *
+             * Menu availability varies by skin, wiki, and current page.
+             *
+             * The first three parameters are required, the others are optional and
+             * may be null. Though providing an id and tooltip is recommended.
+             *
+             * By default, the new link will be added to the end of the menu. To
+             * add the link before an existing item, pass the DOM node or a CSS selector
+             * for that item, e.g. `'#foobar'` or `document.getElementById( 'foobar' )`.
+             *
+             * ```js
+             * mw.util.addPortletLink(
+             *     'p-tb', 'https://www.mediawiki.org/',
+             *     'mediawiki.org', 't-mworg', 'Go to mediawiki.org', 'm', '#t-print'
+             * );
+             *
+             * var node = mw.util.addPortletLink(
+             *     'p-tb',
+             *     mw.util.getUrl( 'Special:Example' ),
+             *     'Example'
+             * );
+             * $( node ).on( 'click', function ( e ) {
+             *     console.log( 'Example' );
+             *     e.preventDefault();
+             * } );
+             * ```
+             *
+             * Remember that to call this inside a user script, you may have to ensure the
+             * `mediawiki.util` is loaded first:
+             *
+             * ```js
+             * $.when( mw.loader.using( [ 'mediawiki.util' ] ), $.ready ).then( function () {
+             *     mw.util.addPortletLink( 'p-tb', 'https://www.mediawiki.org/', 'mediawiki.org' );
+             * } );
+             * ```
+             *
+             * @deprecated since 1.47 - pass a {@link PortletOptions} object as argument.
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal').
+             * @param href Link URL.
+             * @param text Link text.
              * @param id ID of the list item, should be unique and preferably have
-             *  the appropriate prefix ('ca-', 'pt-', 'n-' or 't-')
-             * @param tooltip Text to show when hovering over the link, without accesskey suffix
+             *  the appropriate prefix ('ca-', 'pt-', 'n-' or 't-').
+             * @param tooltip Text to show when hovering over the link, without accesskey suffix.
              * @param accesskey Access key to activate this link. One character only,
              *  avoid conflicts with other links. Use `$( '[accesskey=x]' )` in the console to
              *  see if 'x' is already used.
@@ -224,8 +319,7 @@ declare global {
 
             /**
              * Adjust the thumbnail size to fit the width steps defined in config via
-             * config.ThumbnailSteps, according to whether config.ThumbnailStepsRatio
-             * is set.
+             * config.ThumbnailSteps.
              *
              * This logic is duplicated server-side in `File::adjustThumbWidthForSteps`.
              *

--- a/mw/util.d.ts
+++ b/mw/util.d.ts
@@ -57,6 +57,8 @@ export interface PortletLinkOptions {
     href: string;
     /**
      * Name of the Codex icon name this menu should use if skin supports this.
+     *
+     * @since 1.47
      */
     icon?: string;
     /**
@@ -268,11 +270,15 @@ declare global {
              * ```
              *
              * @since 1.47 - a {@link PortletLinkOptions} object can passed as argument.
+             * @param portletId ID of the target portlet (e.g. 'p-cactions' or 'p-personal').
              * @param options Portlet options.
              * @returns The added list item, or null if no element was added.
              * @see https://doc.wikimedia.org/mediawiki-core/master/js/module-mediawiki.util.html#.addPortletLink
              */
-            function addPortletLink(options: PortletLinkOptions): HTMLLIElement | null;
+            function addPortletLink(
+                portletId: string,
+                options: PortletLinkOptions
+            ): HTMLLIElement | null;
             /**
              * Add a link to a portlet menu on the page.
              *


### PR DESCRIPTION
This PR contains JSdoc and type changes from *MediaWiki* 1.46 to 1.47.

Currently up-to-date with [1.47.0-wmf.16](https://www.mediawiki.org/wiki/Special:MyLanguage/MediaWiki_1.47/wmf.16).

All (non-JSdoc) changes are listed below, breaking changes are annotated with ⚠.

## Changes
- Added:
  - `blockIndefiniteExpiry`, `blockIndefiniteExpiryLabel`, `wgCreateAccountUsernamePolicyBulletsHtml`, `wgCreateAccountUsernamePolicyUrl`, `wgEnableChunkedUploads`, `wgMaxPhpUploadSize`, `wgMinUploadChunkSize`, and `wgStructuredChangeFiltersRestrictedTags` configuration values (see `mw.config`).
  - `mw.tempUserCreated.showCondensedPopup()` function.
  - `get`/`setAutoText()`, `get`/`setChunkSize()`, `get`/`setCopyStatus()`, `get`/`setIgnoreWarnings()`, `get`/`setLicense()`, and `get`/`setSource()` methods to `new mw.Upload()`.
  - `useDivLabel` optional property to `mw.util.addPortlet()` options.
  - `icon` optional property to `mw.util.addPortletLink()` options.
- Changed:
  - ⚠ `mw.util.addPortlet()` alternatively accepts a portlet ID and options object as arguments. The legacy signature is deprecated.
  - ⚠ `mw.util.addPortletLink()` alternatively accepts a portlet link options object as single argument. The legacy signature is deprecated.
  - ⚠ removed `labels` (3rd) optional parameter from `new mw.Api().watch()`.
  - ⚠ removed `specUrl` and `wgCreateAccountUsernamePolicyPopoverMsgs` configuration values (see `mw.config`).